### PR TITLE
adding *.app and **/launch.json files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,7 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+# AL extension
+**/launch.json
+*.app


### PR DESCRIPTION
We shouldn't include build files (*.app) in the repo as they change with every build and add unnecessary files to the repo. 
The launch.json files are specific to environment and also not needed in repo.