### PR TITLE
Create Extension Table 5062 – Attachment

### DIFF
--- a/Extension Table 5062 – Attachment
+++ b/Extension Table 5062 – Attachment
@@ -1,0 +1,2 @@
+The"RunAttachment" feature requires a publisher (OnforeRunAttachment). This must have the variables involved in the process (segment line, etc.) as well as an IsHandled parameter.
+ 


### PR DESCRIPTION
The"RunAttachment" feature requires a publisher (OnforeRunAttachment). This must have the variables involved in the process (segment line, etc.) as well as an IsHandled parameter.
![Table 5062 Attachment](https://user-images.githubusercontent.com/26924867/59485525-6a2b0480-8e76-11e9-80e2-0fff19f338f7.png)
