### PR TITLE
Control add in workaround

### DIFF
--- a/Modules/DevTools/TestFramework/Any/app/app.json
+++ b/Modules/DevTools/TestFramework/Any/app/app.json
@@ -1,0 +1,23 @@
+{
+  "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
+  "name": "Any",
+  "publisher": "Microsoft",
+  "brief": "Library used to generate any values.",
+  "description": "In test code, Any should be used to generate any values.",
+  "version": "1.0.0.0",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "14.0.0.0",
+  "idRanges": [
+    {
+      "from": 130500,
+      "to": 130500
+    }
+  ],
+  "target": "Cloud"
+}

--- a/Modules/DevTools/TestFramework/Any/app/src/Any.Codeunit.al
+++ b/Modules/DevTools/TestFramework/Any/app/src/Any.Codeunit.al
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+/// <summary>
+///
+/// </summary>
+codeunit 130500 "Any"
+{
+
+    SingleInstance = true;
+
+    // <summary>.
+    // Generates a random integer between [1, Max]. 0 Returns 1 and negative numbers are treated as positive.
+    // </summary>
+    // <param name="Max">Max range of the number.</param>
+    // <return>Generated int value</return>
+    [Scope('OnPrem')]
+    procedure RandInt("Max": Integer): Integer
+    begin
+        EXIT(RANDOM(Max));
+    end;
+}
+

--- a/Modules/DevTools/TestFramework/Assert/app/app.json
+++ b/Modules/DevTools/TestFramework/Assert/app/app.json
@@ -1,0 +1,21 @@
+{
+  "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
+  "name": "Library Assert",
+  "publisher": "Microsoft",
+  "brief": "Library used in tests to verify if the values are as expected. ",
+  "description": "In test code Library Assert should be used to compare the values and throw errors. TESTFIELD and ERROR must not be used in test code.",
+  "version": "1.0.0.0",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "15.0.0.0",
+  "idRanges": [{
+    "from": 130002,
+    "to": 130002
+  }],
+  "target": "Cloud"
+}

--- a/Modules/DevTools/TestFramework/Assert/app/src/LibraryAssert.Codeunit.al
+++ b/Modules/DevTools/TestFramework/Assert/app/src/LibraryAssert.Codeunit.al
@@ -1,0 +1,371 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+/// <summary>
+///
+/// </summary>
+codeunit 130002 "Library Assert"
+{
+
+    trigger OnRun()
+    begin
+    end;
+
+    var
+        IsTrueFailedErr: Label 'Assert.IsTrue failed. %1';
+        IsFalseFailedErr: Label 'Assert.IsFalse failed. %1';
+        AreEqualFailedErr: Label 'Assert.AreEqual failed. Expected:<%1> (%2). Actual:<%3> (%4). %5.', Locked = true;
+        AreNotEqualFailedErr: Label 'Assert.AreNotEqual failed. Expected any value except:<%1> (%2). Actual:<%3> (%4). %5.', Locked = true;
+        AreNearlyEqualFailedErr: Label 'Assert.AreNearlyEqual failed. Expected a difference no greater than <%1> between expected value <%2> and actual value <%3>. %4';
+        AreNotNearlyEqualFailedErr: Label 'Assert.AreNotNearlyEqual failed. Expected a difference greater than <%1> between expected value <%2> and actual value <%3>. %4';
+        FailFailedErr: Label 'Assert.Fail failed. %1';
+        TableIsEmptyErr: Label 'Assert.TableIsEmpty failed. Table <%1> with filter <%2> must not contain records.', Locked = true;
+        TableIsNotEmptyErr: Label 'Assert.TableIsNotEmpty failed. Table <%1> with filter <%2> must contain records.', Locked = true;
+        KnownFailureErr: Label 'Known failure: see VSTF Bug #%1.';
+        ExpectedErrorFailedErr: Label 'Assert.ExpectedError failed. Expected: %1. Actual: %2.';
+        ExpectedErrorCodeFailedErr: Label 'Assert.ExpectedErrorCode failed. Expected: %1. Actual: %2. Actual error message: %3.';
+        ExpectedMessageFailedErr: Label 'Assert.ExpectedMessage failed. Expected: %1. Actual: %2.';
+        RecordCountErr: Label 'Assert.RecordCount failed. Expected number of %1 entries: %2. Actual: %3.', Locked = true;
+        UnsupportedTypeErr: Label 'Equality assertions only support Boolean, Option, Integer, BigInteger, Decimal, Code, Text, Date, DateFormula, Time, Duration, and DateTime values. Current value:%1.';
+        RecordNotFoundTok: Label 'DB:RecordNotFound';
+        RecordAlreadyExistsTok: Label 'DB:RecordExists';
+        RecordNothingInsideFilterTok: Label 'DB:NothingInsideFilter';
+        AssertErr: Label 'Expected error %1 actual %2';
+        PrimRecordNotFoundTok: Label 'DB:PrimRecordNotFound';
+        NoFilterTok: Label 'DB:NoFilter';
+        ErrorHasNotBeenThrownErr: Label 'The error has not been thrown.';
+
+        /// <summary>
+        /// Tests whether the specified condition is true and throws an exception if the condition is false.
+        /// </summary>
+        /// <param name="Condition">The condition the test expects to be true.</param>
+        /// <param name="Msg">The message to include in the exception when condition is false. The message is shown in test results.</param>
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error(IsTrueFailedErr, Msg)
+    end;
+
+    /// <summary>
+    /// Tests whether the specified condition is false and throws an exception if the condition is true.
+    /// </summary>
+    /// <param name="Condition">The condition the test expects to be false.</param>
+    /// <param name="Msg">The message to include in the exception when condition is true. The message is shown in test results.</param>
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+        if Condition then
+            Error(IsFalseFailedErr, Msg)
+    end;
+
+    /// <summary>
+    /// Tests whether the specified values are equal and throws an exception if the two values are not equal.
+    /// </summary>
+    /// <param name="Expected">The first value to compare. This is the value the tests expects.</param>
+    /// <param name="Actual">The second value to compare. This is the value produced by the code under test.</param>
+    /// <param name="Msg">The message to include in the exception when actual is not equal to expected. The message is shown in test results.</param>
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if not Equal(Expected, Actual) then
+            Error(AreEqualFailedErr, Expected, TypeNameOf(Expected), Actual, TypeNameOf(Actual), Msg)
+    end;
+
+    /// <summary>
+    /// Tests whether the specified values are unequal and throws an exception if they are equal.
+    /// </summary>
+    /// <param name="Expected">The first value to compare. This is the value the test expects not to match actual.</param>
+    /// <param name="Actual">The second value to compare. This is the value produced by the code under test.</param>
+    /// <param name="Msg">The message to include in the exception when actual is not equal to expected. The message is shown in test results.</param>
+    procedure AreNotEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Equal(Expected, Actual) then
+            Error(AreNotEqualFailedErr, Expected, TypeNameOf(Expected), Actual, TypeNameOf(Actual), Msg)
+    end;
+
+    /// <summary>
+    /// Tests whether the specified decimals are equal and throws an exception if the they are not equal.
+    /// </summary>
+    /// <param name="Expected">The first value to compare. This is the value the tests expects.</param>
+    /// <param name="Actual">The second value to compare. This is the value produced by the code under test.</param>
+    /// <param name="Delta">The required accuracy. An exception will be thrown only if actual is different than expected by more than delta.</param>
+    /// <param name="Msg">The message to include in the exception when actual is different than expected by more than delta. The message is shown in test results.</param>
+    procedure AreNearlyEqual(Expected: Decimal; Actual: Decimal; Delta: Decimal; Msg: Text)
+    begin
+        if Abs(Expected - Actual) > Abs(Delta) then
+            Error(AreNearlyEqualFailedErr, Delta, Expected, Actual, Msg)
+    end;
+
+    /// <summary>
+    /// Tests whether the specified decimals are unequal and throws an exception if the they are equal.
+    /// </summary>
+    /// <param name="Expected">The first value to compare. This is the value the tests expects not to match actual.</param>
+    /// <param name="Actual">The second value to compare. This is the value produced by the code under test.</param>
+    /// <param name="Delta">The required accuracy. An exception will be thrown only if actual is different than Expected by at most delta.</param>
+    /// <param name="Msg">The message to include in the exception when actual is equal to Expected or different by less than delta. The message is shown in test results.</param>
+    procedure AreNotNearlyEqual(Expected: Decimal; Actual: Decimal; Delta: Decimal; Msg: Text)
+    begin
+        if Abs(Expected - Actual) <= Abs(Delta) then
+            Error(AreNotNearlyEqualFailedErr, Delta, Expected, Actual, Msg)
+    end;
+
+    /// <summary>
+    /// Throws an exception.
+    /// </summary>
+    /// <param name="Msg">The message to include in the exception. The message is shown in test results.</param>
+    procedure Fail(Msg: Text)
+    begin
+        Error(FailFailedErr, Msg)
+    end;
+
+    /// <summary>
+    /// Tests whether the specified record is non-empty and throws an exception if it is.
+    /// </summary>
+    /// <param name="RecVariant">The record to be checked</param>
+    procedure RecordIsEmpty(RecVariant: Variant)
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.GetTable(RecVariant);
+        RecRefIsEmpty(RecRef);
+    end;
+
+    /// <summary>
+    /// Tests whether the specified record is empty and throws an exception if it is.
+    /// </summary>
+    /// <param name="RecVariant">The record to be checked</param>
+    procedure RecordIsNotEmpty(RecVariant: Variant)
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.GetTable(RecVariant);
+        RecRefIsNotEmpty(RecRef);
+    end;
+
+    /// <summary>
+    /// Tests whether the specified table is non-empty and throws an exception if it is.
+    /// </summary>
+    /// <param name="TableNo">The id of table the test expects to be empty</param>
+    procedure TableIsEmpty(TableNo: Integer)
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.Open(TableNo);
+        RecRefIsEmpty(RecRef);
+        RecRef.Close();
+    end;
+
+    /// <summary>
+    /// Tests whether the specified table is empty and throws an exception if it is.
+    /// </summary>
+    /// <param name="TableNo">The id of table the test expects not to be empty</param>
+    procedure TableIsNotEmpty(TableNo: Integer)
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.Open(TableNo);
+        RecRefIsNotEmpty(RecRef);
+        RecRef.Close();
+    end;
+
+    local procedure RecRefIsEmpty(var RecRef: RecordRef)
+    begin
+        if not RecRef.IsEmpty() then
+            Error(TableIsEmptyErr, RecRef.Caption(), RecRef.GetFilters());
+    end;
+
+    local procedure RecRefIsNotEmpty(var RecRef: RecordRef)
+    begin
+        if RecRef.IsEmpty() then
+            Error(TableIsNotEmptyErr, RecRef.Caption(), RecRef.GetFilters());
+    end;
+
+    /// <summary>
+    /// Tests whether the Table holds the expected number of Records and throws an exception when the count is different.
+    /// </summary>
+    /// <param name="RecVariant">The table whos records will be counter</param>
+    /// <param name="ExpectedCount">The expected number of records in the table</param>
+    procedure RecordCount(RecVariant: Variant; ExpectedCount: Integer)
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.GetTable(RecVariant);
+        if ExpectedCount <> RecRef.Count() then
+            Error(RecordCountErr, RecRef.Caption(), ExpectedCount, RecRef.Count());
+        RecRef.Close();
+    end;
+
+    /// <summary>
+    /// This function is used to indicate the test is known to fail with a certain error. If the last error thrown is the expected one, a known failure error is thrown. If the last error was a different error than an exception is thrown.
+    /// </summary>
+    /// <param name="Expected">The expected error</param>
+    /// <param name="WorkItemNo">The Id of the workitem to fix the know test defect</param>
+    procedure KnownFailure(Expected: Text; WorkItemNo: Integer)
+    begin
+        ExpectedError(Expected);
+        Error(KnownFailureErr, WorkItemNo)
+    end;
+
+    /// <summary>
+    /// Verifies that the last error thrown is the expected error. If a different error was thrown, an exception is thrown.
+    /// </summary>
+    /// <param name="Expected">The expected error</param>
+    procedure ExpectedError(Expected: Text)
+    begin
+        if (GetLastErrorText() = '') and (Expected = '') then begin
+            if GetLastErrorCallstack() = '' then
+                Error(ErrorHasNotBeenThrownErr);
+        end else
+            if StrPos(GetLastErrorText(), Expected) = 0 then
+                Error(ExpectedErrorFailedErr, Expected, GetLastErrorText());
+    end;
+
+    /// <summary>
+    /// Verifies that the last error code thrown is the expected error code. If a different error code was thrown, an exception is thrown.
+    /// </summary>
+    /// <param name="Expected">The expected error code</param>
+    procedure ExpectedErrorCode(Expected: Text)
+    begin
+        if StrPos(GetLastErrorCode(), Expected) = 0 then
+            Error(ExpectedErrorCodeFailedErr, Expected, GetLastErrorCode(), GetLastErrorText());
+    end;
+
+    /// <summary>
+    /// Tests that the Expected message matches the Actual message
+    /// </summary>
+    /// <param name="Expected">The first value to compare. This is the value the tests expects not to match actual.</param>
+    /// <param name="Actual">The second value to compare. This is the value produced by the code under test.</param>
+    procedure ExpectedMessage(Expected: Text; Actual: Text)
+    begin
+        if StrPos(Actual, Expected) = 0 then
+            Error(ExpectedMessageFailedErr, Expected, Actual);
+    end;
+
+    /// <summary>
+    /// Verifies that the last error code thrown was the Record Not Found error code.
+    /// </summary>
+    procedure AssertRecordNotFound()
+    begin
+        VerifyFailure(RecordNotFoundTok, StrSubstNo(AssertErr, RecordNotFoundTok, GetLastErrorCode()));
+    end;
+
+    /// <summary>
+    /// Verifies that the last error code thrown was the Record Already Exists error code.
+    /// </summary>
+    procedure AssertRecordAlreadyExists()
+    begin
+        VerifyFailure(RecordAlreadyExistsTok, StrSubstNo(AssertErr, RecordAlreadyExistsTok, GetLastErrorCode()));
+    end;
+
+    /// <summary>
+    /// Verifies that the last error code thrown was the Nothing Inside Filter error code.
+    /// </summary>
+    procedure AssertNothingInsideFilter()
+    begin
+        VerifyFailure(RecordNothingInsideFilterTok, StrSubstNo(AssertErr, RecordNothingInsideFilterTok, GetLastErrorCode()));
+    end;
+
+    /// <summary>
+    /// Verifies that the last error code thrown was the No Filter error code.
+    /// </summary>
+    procedure AssertNoFilter()
+    begin
+        VerifyFailure(NoFilterTok, StrSubstNo(AssertErr, NoFilterTok, GetLastErrorCode()));
+    end;
+
+    /// <summary>
+    /// Verifies that the last error code thrown was the Primary Record Not Found error code.
+    /// </summary>
+    procedure AssertPrimRecordNotFound()
+    begin
+        VerifyFailure(PrimRecordNotFoundTok, StrSubstNo(AssertErr, PrimRecordNotFoundTok, GetLastErrorCode()));
+    end;
+
+    local procedure TypeOf(Value: Variant): Integer
+    var
+        "Field": Record "Field";
+    begin
+        case true of
+            Value.IsBoolean():
+                exit(Field.Type::Boolean);
+            Value.IsOption() or Value.IsInteger() or Value.IsByte():
+                exit(Field.Type::Integer);
+            Value.IsBigInteger():
+                exit(Field.Type::BigInteger);
+            Value.IsDecimal():
+                exit(Field.Type::Decimal);
+            Value.IsText() or Value.IsCode() or Value.IsChar() or Value.IsTextConstant():
+                exit(Field.Type::Text);
+            Value.IsDate():
+                exit(Field.Type::Date);
+            Value.IsTime():
+                exit(Field.Type::Time);
+            Value.IsDuration():
+                exit(Field.Type::Duration);
+            Value.IsDateTime():
+                exit(Field.Type::DateTime);
+            Value.IsDateFormula():
+                exit(Field.Type::DateFormula);
+            Value.IsGuid():
+                exit(Field.Type::GUID);
+            Value.IsRecordId():
+                exit(Field.Type::RecordID);
+            else
+                Error(UnsupportedTypeErr, UnsupportedTypeName(Value))
+        end
+    end;
+
+    local procedure TypeNameOf(Value: Variant): Text
+    var
+        "Field": Record "Field";
+    begin
+        Field.Type := TypeOf(Value);
+        exit(Format(Field.Type));
+    end;
+
+    local procedure UnsupportedTypeName(Value: Variant): Text
+    begin
+        case true of
+            Value.IsRecord():
+                exit('Record');
+            Value.IsRecordRef():
+                exit('RecordRef');
+            Value.IsFieldRef():
+                exit('FieldRef');
+            Value.IsCodeunit():
+                exit('Codeunit');
+            Value.IsFile():
+                exit('File');
+        end;
+        exit('Unsupported Type');
+    end;
+
+    local procedure Equal(Left: Variant; Right: Variant): Boolean
+    begin
+        if IsNumber(Left) and IsNumber(Right) then
+            exit(EqualNumbers(Left, Right));
+
+        exit((TypeOf(Left) = TypeOf(Right)) and (Format(Left, 0, 2) = Format(Right, 0, 2)))
+    end;
+
+    local procedure IsNumber(Value: Variant): Boolean
+    begin
+        exit(Value.IsDecimal() or Value.IsInteger() or Value.IsChar())
+    end;
+
+    local procedure EqualNumbers(Left: Decimal; Right: Decimal): Boolean
+    begin
+        exit(Left = Right)
+    end;
+
+    local procedure VerifyFailure(expectedErrorCode: Text; failureText: Text)
+    var
+        errorCode: Text;
+    begin
+        errorCode := GetLastErrorCode();
+
+        IsTrue(errorCode = expectedErrorCode, failureText);
+        ClearLastError();
+    end;
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/app.json
+++ b/Modules/DevTools/TestTools/TestRunner/app/app.json
@@ -1,0 +1,21 @@
+{
+  "id": "23de40a6-dfe8-4f80-80db-d70f83ce8caf",
+  "name": "Test Runner",
+  "publisher": "Microsoft",
+  "brief": "Executes one or more tests and gathers the results.",
+  "description": "Provides options for running manual tests in the UI or automated tests in the console. Manual tests are run from the Test Tool page, and automated tests are run from the Command Line Test Tool page. For each group of tests, you can define the test isolation by using the Test Runner Codeunit. The Test Runner - Isol. Codeunit codeunit reverts changes to the database after tests are complete. The Test Runner Isol. Disabled codeunit prevents changes from being reverted. This is useful when testing requires multiple sessions, such as when invoking web services, job queues, background threads, and so on.",
+  "version": "1.0.0.0",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "13.0.0.0",
+  "idRanges": [{
+    "from": 130450,
+    "to": 130480
+  }],
+  "target": "OnPrem"
+}

--- a/Modules/DevTools/TestTools/TestRunner/app/src/ALTestSuite.Table.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/ALTestSuite.Table.al
@@ -1,0 +1,85 @@
+table 130451 "AL Test Suite"
+{
+    DataCaptionFields = Name,Description;
+    LookupPageID = "AL Test Suites";
+    ReplicateData = false;
+
+    fields
+    {
+        field(1;Name;Code[10])
+        {
+            NotBlank = true;
+        }
+        field(2;Description;Text[30])
+        {
+        }
+        field(3;"Tests to Execute";Integer)
+        {
+            CalcFormula = Count("Test Method Line" WHERE ("Test Suite"=FIELD(Name),
+                                                          "Line Type"=CONST(Function),
+                                                          Run=CONST(true)));
+            Editable = false;
+            FieldClass = FlowField;
+        }
+        field(4;"Tests not Executed";Integer)
+        {
+            CalcFormula = Count("Test Method Line" WHERE ("Test Suite"=FIELD(Name),
+                                                          "Line Type"=CONST(Function),
+                                                          Run=CONST(true),
+                                                          Result=CONST(" ")));
+            Editable = false;
+            FieldClass = FlowField;
+        }
+        field(5;Failures;Integer)
+        {
+            CalcFormula = Count("Test Method Line" WHERE ("Test Suite"=FIELD(Name),
+                                                          "Line Type"=CONST(Function),
+                                                          Run=CONST(true),
+                                                          Result=CONST(Failure)));
+            Editable = false;
+            FieldClass = FlowField;
+        }
+        field(6;"Last Run";DateTime)
+        {
+            Editable = false;
+        }
+        field(7;"Run Type";Option)
+        {
+            DataClassification = ToBeClassified;
+            OptionMembers = " ",All,"Active Codeunit","Active Test";
+        }
+        field(8;"Test Runner Id";Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(Key1;Name)
+        {
+            Clustered = true;
+        }
+    }
+
+    fieldgroups
+    {
+    }
+
+    trigger OnDelete()
+    var
+        TestMethodLine: Record "Test Method Line";
+    begin
+        TestMethodLine.SetRange("Test Suite",Name);
+        TestMethodLine.DeleteAll(true);
+    end;
+
+    trigger OnInsert()
+    var
+        TestRunnerMgt: Codeunit "Test Runner - Mgt";
+    begin
+        if "Test Runner Id" = 0 then
+          "Test Runner Id" := TestRunnerMgt.GetDefautlTestRunner();
+    end;
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/src/ALTestSuites.Page.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/ALTestSuites.Page.al
@@ -1,0 +1,43 @@
+page 130450 "AL Test Suites"
+{
+    PageType = List;
+    SaveValues = true;
+    SourceTable = "AL Test Suite";
+
+    layout
+    {
+        area(content)
+        {
+            repeater(Control1)
+            {
+                ShowCaption = false;
+                field(Name;Name)
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the name of the test suite.';
+                }
+                field(Description;Description)
+                {
+                    ApplicationArea = All;
+                }
+                field("Tests to Execute";"Tests to Execute")
+                {
+                    ApplicationArea = All;
+                }
+                field(Failures;Failures)
+                {
+                    ApplicationArea = All;
+                }
+                field("Tests not Executed";"Tests not Executed")
+                {
+                    ApplicationArea = All;
+                }
+            }
+        }
+    }
+
+    actions
+    {
+    }
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/src/ALTestTool.Page.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/ALTestTool.Page.al
@@ -1,0 +1,403 @@
+page 130451 "AL Test Tool"
+{
+    AccessByPermission = TableData "Test Method Line"=RIMD;
+    ApplicationArea = All;
+    AutoSplitKey = true;
+    Caption = 'AL Test Tool';
+    DataCaptionExpression = CurrentSuiteName;
+    DelayedInsert = true;
+    DeleteAllowed = true;
+    ModifyAllowed = true;
+    PageType = Worksheet;
+    SaveValues = true;
+    SourceTable = "Test Method Line";
+    UsageCategory = Administration;
+
+    layout
+    {
+        area(content)
+        {
+            field(CurrentSuiteName;CurrentSuiteName)
+            {
+                ApplicationArea = All;
+                Caption = 'Suite Name';
+                ToolTip = 'Specifies the currently selected Test Suite';
+
+                trigger OnLookup(var Text: Text): Boolean
+                var
+                    ALTestSuite: Record "AL Test Suite";
+                begin
+                    ALTestSuite.Name := CurrentSuiteName;
+                    if PAGE.RunModal(0,ALTestSuite) <> ACTION::LookupOK then
+                      exit(false);
+
+                    Text := ALTestSuite.Name;
+                    CurrPage.Update(false);
+                    exit(true);
+                end;
+
+                trigger OnValidate()
+                begin
+                    ChangeTestSuite();
+                end;
+            }
+            repeater(Control1)
+            {
+                IndentationColumn = NameIndent;
+                IndentationControls = Name;
+                ShowAsTree = true;
+                ShowCaption = false;
+                field(LineType;"Line Type")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Line Type';
+                    Editable = false;
+                    Style = Strong;
+                    StyleExpr = LineTypeEmphasize;
+                }
+                field(TestCodeunit;"Test Codeunit")
+                {
+                    ApplicationArea = All;
+                    BlankZero = true;
+                    Caption = 'Codeunit ID';
+                    Editable = false;
+                    Style = Strong;
+                    StyleExpr = TestCodeunitEmphasize;
+                }
+                field(Name;Name)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Name';
+                    Editable = false;
+                    Style = Strong;
+                    StyleExpr = NameEmphasize;
+                    ToolTip = 'Specifies the name of the test tool.';
+                }
+                field(Run;Run)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Run';
+
+                    trigger OnValidate()
+                    begin
+                        CurrPage.Update(true);
+                    end;
+                }
+                field(Result;Result)
+                {
+                    ApplicationArea = All;
+                    BlankZero = true;
+                    Caption = 'Result';
+                    Editable = false;
+                    Style = Favorable;
+                    StyleExpr = ResultEmphasize;
+                }
+                field("Error Message";ErrorMessageWithStackTraceTxt)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Error Message';
+                    DrillDown = true;
+                    Editable = false;
+                    Style = Unfavorable;
+                    StyleExpr = TRUE;
+                    ToolTip = 'Specifies full error message with stack trace';
+
+                    trigger OnDrillDown()
+                    begin
+                        Message(ErrorMessageWithStackTraceTxt);
+                    end;
+                }
+                field(Duration;RunDuration)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Duration';
+                    ToolTip = 'Specifies the duration of the test run';
+                }
+            }
+            group(Control14)
+            {
+                ShowCaption = false;
+                field(SuccessfulTests;Success)
+                {
+                    ApplicationArea = All;
+                    AutoFormatType = 1;
+                    Caption = 'Successful Tests';
+                    Editable = false;
+                    ToolTip = 'Specifies the number of Successful Tests';
+                }
+                field(FailedTests;Failure)
+                {
+                    ApplicationArea = All;
+                    AutoFormatType = 1;
+                    Caption = 'Failed Tests';
+                    Editable = false;
+                    ToolTip = 'Specifies the number of Failed Tests';
+                }
+                field(SkippedTests;Skipped)
+                {
+                    ApplicationArea = All;
+                    AutoFormatType = 1;
+                    Caption = 'Skipped Tests';
+                    Editable = false;
+                    ToolTip = 'Specifies the number of Skipped Tests';
+                }
+                field(NotExecutedTests;NotExecuted)
+                {
+                    ApplicationArea = All;
+                    AutoFormatType = 1;
+                    Caption = 'Tests not Executed';
+                    Editable = false;
+                    ToolTip = 'Specifies the number of Tests Not Executed';
+                }
+            }
+            group(Control13)
+            {
+                ShowCaption = false;
+                field(TestRunner;TestRunnerDisplayName)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Test Runner Codeunit';
+                    Editable = false;
+                    Enabled = false;
+                    ToolTip = 'Specifies currently selected test runner';
+
+                    trigger OnDrillDown()
+                    begin
+                        // Used to fix the rendering - don't show as a box
+                        Error('');
+                    end;
+                }
+            }
+        }
+    }
+
+    actions
+    {
+        area(processing)
+        {
+            group("Manage Tests")
+            {
+                Caption = 'Manage Tests';
+                action(DeleteLines)
+                {
+                    ApplicationArea = All;
+                    Caption = '&Delete Lines';
+                    Image = Delete;
+                    Promoted = true;
+                    PromotedCategory = Process;
+                    PromotedIsBig = true;
+                    PromotedOnly = true;
+                    ToolTip = 'Delete the selected lines.';
+
+                    trigger OnAction()
+                    var
+                        TestMethodLine: Record "Test Method Line";
+                        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+                    begin
+                        CurrPage.SetSelectionFilter(TestMethodLine);
+                        TestMethodLine.DeleteAll(true);
+                        TestSuiteMgt.CalcTestResults(Rec,Success,Failure,Skipped,NotExecuted);
+                    end;
+                }
+                action(GetTestCodeunits)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Get &Test Codeunits';
+                    Image = ChangeToLines;
+                    Promoted = true;
+                    PromotedCategory = Process;
+                    PromotedIsBig = true;
+                    PromotedOnly = true;
+                    ToolTip = 'Prompts a dialog to add test codeunits.';
+
+                    trigger OnAction()
+                    var
+                        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+                    begin
+                        TestSuiteMgt.SelectTestMethods(GlobalALTestSuite);
+                        CurrPage.Update(false);
+                    end;
+                }
+                action(GetTestsByRange)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Get Test Codeunits by Ra&nge';
+                    Image = GetLines;
+                    Promoted = true;
+                    PromotedCategory = Process;
+                    PromotedIsBig = true;
+                    PromotedOnly = true;
+                    ToolTip = 'Add test codeunits by using a range string.';
+
+                    trigger OnAction()
+                    var
+                        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+                    begin
+                        TestSuiteMgt.SelectTestMethods(GlobalALTestSuite);
+                        CurrPage.Update(false);
+                    end;
+                }
+            }
+            group("Run Tests")
+            {
+                Caption = 'Run Tests';
+                action(RunTests)
+                {
+                    ApplicationArea = All;
+                    Caption = '&Run Tests';
+                    Image = Start;
+                    Promoted = true;
+                    PromotedCategory = Process;
+                    PromotedIsBig = true;
+                    PromotedOnly = true;
+                    ToolTip = 'Runs selected tests.';
+
+                    trigger OnAction()
+                    var
+                        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+                        TestRunnerProgessDialog: Codeunit "Test Runner - Progess Dialog";
+                    begin
+                        BindSubscription(TestRunnerProgessDialog);
+                        TestSuiteMgt.RunTestSuiteSelection(Rec);
+                        CurrPage.Update(true);
+                    end;
+                }
+                action(RunSelectedTests)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Run Se&lected Tests';
+                    Image = TestFile;
+                    Promoted = true;
+                    PromotedCategory = Process;
+                    PromotedIsBig = true;
+                    PromotedOnly = true;
+
+                    trigger OnAction()
+                    var
+                        TestMethodLine: Record "Test Method Line";
+                        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+                    begin
+                        TestMethodLine.Copy(Rec);
+                        CurrPage.SetSelectionFilter(TestMethodLine);
+                        TestSuiteMgt.RunSelectedTests(TestMethodLine);
+                        CurrPage.Update(true);
+                    end;
+                }
+            }
+            group("Test Suite")
+            {
+                Caption = 'Test Suite';
+                action(SelectTestRunner)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Select Test R&unner';
+                    Image = SetupList;
+                    Promoted = true;
+                    PromotedCategory = "Report";
+                    PromotedIsBig = true;
+                    PromotedOnly = true;
+                    ToolTip = 'Specifies the action to select a test runner';
+
+                    trigger OnAction()
+                    var
+                        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+                    begin
+                        TestSuiteMgt.LookupTestRunner(GlobalALTestSuite);
+                    end;
+                }
+            }
+        }
+    }
+
+    trigger OnAfterGetRecord()
+    var
+        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+    begin
+        TestSuiteMgt.CalcTestResults(Rec,Success,Failure,Skipped,NotExecuted);
+        UpdateDisplayPropertiesForLine();
+        UpdateCalculatedFields();
+    end;
+
+    trigger OnOpenPage()
+    begin
+        SetCurrentTestSuite();
+    end;
+
+    var
+        GlobalALTestSuite: Record "AL Test Suite";
+        CurrentSuiteName: Code[10];
+        Skipped: Integer;
+        Success: Integer;
+        Failure: Integer;
+        NotExecuted: Integer;
+        [InDataSet]
+        NameIndent: Integer;
+        [InDataSet]
+        LineTypeEmphasize: Boolean;
+        NameEmphasize: Boolean;
+        [InDataSet]
+        TestCodeunitEmphasize: Boolean;
+        [InDataSet]
+        ResultEmphasize: Boolean;
+        RunDuration: Duration;
+        TestRunnerDisplayName: Text;
+        ErrorMessageWithStackTraceTxt: Text;
+
+    local procedure ChangeTestSuite()
+    var
+        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+    begin
+        GlobalALTestSuite.Get(CurrentSuiteName);
+        GlobalALTestSuite.CalcFields("Tests to Execute");
+
+        CurrPage.SaveRecord();
+
+        FilterGroup(2);
+        SetRange("Test Suite",CurrentSuiteName);
+        FilterGroup(0);
+
+        CurrPage.Update(false);
+
+        TestRunnerDisplayName := TestSuiteMgt.GetTestRunnerDisplayName(GlobalALTestSuite);
+    end;
+
+    local procedure SetCurrentTestSuite()
+    var
+        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+    begin
+        GlobalALTestSuite.SetAutoCalcFields("Tests to Execute");
+
+        if not GlobalALTestSuite.Get(CurrentSuiteName) then
+          if (CurrentSuiteName = '') and GlobalALTestSuite.FindFirst() then
+            CurrentSuiteName := GlobalALTestSuite.Name
+          else begin
+            TestSuiteMgt.CreateTestSuite(CurrentSuiteName);
+            Commit();
+            GlobalALTestSuite.Get(CurrentSuiteName);
+          end;
+
+        FilterGroup(2);
+        SetRange("Test Suite",CurrentSuiteName);
+        FilterGroup(0);
+
+        if Find('-') then;
+
+        TestRunnerDisplayName := TestSuiteMgt.GetTestRunnerDisplayName(GlobalALTestSuite);
+    end;
+
+    local procedure UpdateDisplayPropertiesForLine()
+    begin
+        NameIndent := "Line Type";
+        LineTypeEmphasize := "Line Type" = "Line Type"::Codeunit;
+        TestCodeunitEmphasize := "Line Type" = "Line Type"::Codeunit;
+        ResultEmphasize := Result = Result::Success;
+    end;
+
+    local procedure UpdateCalculatedFields()
+    var
+        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+    begin
+        RunDuration := "Finish Time" - "Start Time";
+        ErrorMessageWithStackTraceTxt := TestSuiteMgt.GetErrorMessageWithStackTrace(Rec);
+    end;
+}

--- a/Modules/DevTools/TestTools/TestRunner/app/src/CommandLineTestTool.Page.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/CommandLineTestTool.Page.al
@@ -1,0 +1,318 @@
+page 130455 "Command Line Test Tool"
+{
+    AccessByPermission = TableData "Test Method Line" = RIMD;
+    ApplicationArea = All;
+    AutoSplitKey = true;
+    Caption = 'Command Line Test Tool';
+    DataCaptionExpression = CurrentSuiteName;
+    DelayedInsert = true;
+    DeleteAllowed = true;
+    ModifyAllowed = true;
+    PageType = Worksheet;
+    SourceTable = "Test Method Line";
+    UsageCategory = Administration;
+
+    layout
+    {
+        area(content)
+        {
+            field(CurrentSuiteName; CurrentSuiteName)
+            {
+                ApplicationArea = All;
+                Caption = 'Suite Name';
+                ToolTip = 'Specifies the current Suite Name';
+
+                trigger OnValidate()
+                begin
+                    ChangeTestSuite();
+                end;
+            }
+            field(TestCodeunitRangeFilter; TestCodeunitRangeFilter)
+            {
+                ApplicationArea = All;
+                Caption = 'Test Codeunit Range';
+                ToolTip = 'Specifies the values that will update the current suite selection';
+
+                trigger OnValidate()
+                var
+                    TestSuiteMgt: Codeunit "Test Suite Mgt.";
+                begin
+                    TestSuiteMgt.DeleteAllMethods(GlobalALTestSuite);
+                    TestSuiteMgt.SelectTestMethodsByRange(GlobalALTestSuite, TestCodeunitRangeFilter);
+                    IF FindFirst() THEN;
+                end;
+            }
+            field(TestRunnerCodeunitId; TestRunnerCodeunitId)
+            {
+                ApplicationArea = All;
+                Caption = 'Test Runnter Codeunit ID';
+                ToolTip = 'Specifies the currently selected test runner ID';
+
+                trigger OnValidate()
+                var
+                    TestSuiteMgt: Codeunit "Test Suite Mgt.";
+                begin
+                    TestSuiteMgt.ChangeTestRunner(GlobalALTestSuite, TestRunnerCodeunitId);
+                end;
+            }
+            field(ExtensionId; ExtensionId)
+            {
+                ApplicationArea = All;
+                Caption = 'Extension ID';
+                ToolTip = 'Specifies the values if set will update the current suite selection';
+
+                trigger OnValidate()
+                var
+                    TestSuiteMgt: Codeunit "Test Suite Mgt.";
+                begin
+                    TestSuiteMgt.DeleteAllMethods(GlobalALTestSuite);
+                    TestSuiteMgt.SelectTestMethodsByExtension(GlobalALTestSuite, ExtensionId);
+                    IF FindFirst() THEN;
+                end;
+            }
+            field(DisableTestMethod; RemoveTestMethod)
+            {
+                ApplicationArea = All;
+                Caption = 'DisableTestMethod';
+                ToolTip = 'Specifies the values that will update enabled property on the test method';
+
+                trigger OnValidate()
+                begin
+                    FindAndDisableTestMethod();
+                end;
+            }
+            repeater(Control1)
+            {
+                IndentationControls = Name;
+                ShowCaption = false;
+                field(LineType; LineTypeCode)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Line Type';
+                    Editable = false;
+                    ToolTip = 'Specifies a Non-Translatable value for console test runner.';
+                }
+                field(TestCodeunit; "Test Codeunit")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Codeunit ID';
+                    Editable = false;
+                }
+                field(Name; Name)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Name';
+                    Editable = false;
+                    ToolTip = 'Specifies the name of the test tool.';
+                }
+                field(Run; Run)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Run';
+
+                    trigger OnValidate()
+                    begin
+                        CurrPage.Update(true);
+                    end;
+                }
+                field(Result; ResultCode)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Result';
+                    Editable = false;
+                    ToolTip = 'Specifies a Non-Translatable value for console test runner.';
+                }
+                field(ErrorMessage; FullErrorMessage)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Error Message';
+                    DrillDown = true;
+                    Editable = false;
+                    ToolTip = 'Specifies full error message with stack trace';
+                }
+                field(StackTrace; StackTrace)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Stack Trace';
+                    ToolTip = 'Specifies stack trace';
+                }
+                field(FinishTime; "Finish Time")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Finish Time';
+                    ToolTip = 'Specifies the duration of the test run';
+                }
+                field(StartTime; "Start Time")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Start Time';
+                }
+            }
+        }
+    }
+
+    actions
+    {
+        area(processing)
+        {
+            action(RunSelectedTests)
+            {
+                ApplicationArea = All;
+                Caption = 'Run Se&lected Tests';
+                Image = TestFile;
+                Promoted = true;
+                PromotedCategory = Process;
+                PromotedIsBig = true;
+
+                trigger OnAction()
+                var
+                    TestMethodLine: Record "Test Method Line";
+                    TestSuiteMgt: Codeunit "Test Suite Mgt.";
+                begin
+                    TestMethodLine.Copy(Rec);
+                    CurrPage.SetSelectionFilter(TestMethodLine);
+                    TestSuiteMgt.RunSelectedTests(TestMethodLine);
+                    Find();
+                    CurrPage.Update(true);
+                end;
+            }
+        }
+    }
+
+    trigger OnAfterGetCurrRecord()
+    var
+        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+    begin
+        TestSuiteMgt.CalcTestResults(Rec, Success, Failure, Skipped, NotExecuted);
+        UpdateLine();
+    end;
+
+    trigger OnAfterGetRecord()
+    var
+        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+    begin
+        TestSuiteMgt.CalcTestResults(Rec, Success, Failure, Skipped, NotExecuted);
+        UpdateLine();
+    end;
+
+    trigger OnOpenPage()
+    begin
+        SetCurrentTestSuite();
+    end;
+
+    var
+        GlobalALTestSuite: Record "AL Test Suite";
+        CurrentSuiteName: Code[10];
+        TestCodeunitRangeFilter: Text;
+        TestRunnerCodeunitId: Integer;
+        Skipped: Integer;
+        Success: Integer;
+        Failure: Integer;
+        NotExecuted: Integer;
+        ResultCode: Text;
+        LineTypeCode: Text;
+        FullErrorMessage: Text;
+        StackTrace: Text;
+        ExtensionId: Text;
+        RemoveTestMethod: Text;
+
+    local procedure ChangeTestSuite()
+    var
+        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+    begin
+        if not GlobalALTestSuite.Get(CurrentSuiteName) then begin
+            TestSuiteMgt.CreateTestSuite(CurrentSuiteName);
+            Commit();
+        end;
+
+        GlobalALTestSuite.CalcFields("Tests to Execute");
+
+        CurrPage.SaveRecord();
+
+        FilterGroup(2);
+        SetRange("Test Suite", CurrentSuiteName);
+        FilterGroup(0);
+
+        CurrPage.Update(false);
+    end;
+
+    local procedure SetCurrentTestSuite()
+    var
+        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+    begin
+        if not GlobalALTestSuite.Get(CurrentSuiteName) then
+            if GlobalALTestSuite.FindFirst() then
+                CurrentSuiteName := GlobalALTestSuite.Name
+            else begin
+                TestSuiteMgt.CreateTestSuite(CurrentSuiteName);
+                Commit();
+            end;
+
+        FilterGroup(2);
+        SetRange("Test Suite", CurrentSuiteName);
+        FilterGroup(0);
+
+        if Find('-') then;
+
+        GlobalALTestSuite.Get(CurrentSuiteName);
+        GlobalALTestSuite.CalcFields("Tests to Execute");
+    end;
+
+    local procedure UpdateLine()
+    var
+        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+        ConvertToInteger: Integer;
+    begin
+        ConvertToInteger := Result;
+        ResultCode := Format(ConvertToInteger);
+
+        ConvertToInteger := "Line Type";
+        LineTypeCode := Format(ConvertToInteger);
+
+        StackTrace := TestSuiteMgt.GetErrorCallStack(Rec);
+        FullErrorMessage := TestSuiteMgt.GetFullErrorMessage(Rec);
+    end;
+
+    local procedure FindAndDisableTestMethod()
+    var
+        TestMethodLine: Record "Test Method Line";
+        CodeunitTestMethodLine: Record "Test Method Line";
+        CodeunitName: Text;
+        TestMethodName: Text;
+    begin
+        if StrPos(RemoveTestMethod, ',') <= 0 then
+            exit;
+
+        CodeunitName := CopyStr(SelectStr(1, RemoveTestMethod), 1, MaxStrLen(CodeunitTestMethodLine.Name));
+        TestMethodName := CopyStr(SelectStr(2, RemoveTestMethod), 1, MaxStrLen(CodeunitTestMethodLine.Name));
+
+        if CodeunitName = '' then
+            exit;
+
+        if TestMethodName = '' then
+            exit;
+
+        CodeunitTestMethodLine.SetRange("Test Suite", GlobalALTestSuite.Name);
+        CodeunitTestMethodLine.SetRange("Line Type", CodeunitTestMethodLine."Line Type"::Codeunit);
+        CodeunitTestMethodLine.SetRange(Name, CodeunitName);
+        if not CodeunitTestMethodLine.FindFirst() then
+            exit;
+
+        TestMethodLine.SetRange("Test Suite", GlobalALTestSuite.Name);
+        TestMethodLine.SetRange("Line Type", "Line Type"::"Function");
+        TestMethodLine.SetRange("Test Codeunit", CodeunitTestMethodLine."Test Codeunit");
+        TestMethodLine.SetFilter(Name, TestMethodName);
+        TestMethodLine.ModifyAll(Run, false);
+
+
+        TestMethodLine.SETRANGE(Name);
+        TestMethodLine.SETRANGE(Run, TRUE);
+        if not TestMethodLine.FindFirst() then begin
+            CodeunitTestMethodLine.VALIDATE(Run, FALSE);
+            CodeunitTestMethodLine.Modify(TRUE);
+        end;
+
+        CurrPage.Update();
+    end;
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/src/SelectTestRunner.Page.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/SelectTestRunner.Page.al
@@ -1,0 +1,32 @@
+page 130454 "Select TestRunner"
+{
+    Editable = false;
+    PageType = List;
+    SourceTable = AllObjWithCaption;
+    SourceTableView = WHERE("Object Type"=CONST(Codeunit),
+                            "Object Subtype"=CONST('TestRunner'));
+
+    layout
+    {
+        area(content)
+        {
+            repeater(Control1)
+            {
+                ShowCaption = false;
+                field("Object ID";"Object ID")
+                {
+                    ApplicationArea = All;
+                }
+                field("Object Name";"Object Name")
+                {
+                    ApplicationArea = All;
+                }
+            }
+        }
+    }
+
+    actions
+    {
+    }
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/src/SelectTests.Page.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/SelectTests.Page.al
@@ -1,0 +1,32 @@
+page 130453 "Select Tests"
+{
+    Editable = false;
+    PageType = List;
+    SourceTable = AllObjWithCaption;
+    SourceTableView = WHERE("Object Type"=CONST(Codeunit),
+                            "Object Subtype"=CONST('Test'));
+
+    layout
+    {
+        area(content)
+        {
+            repeater(Control1)
+            {
+                ShowCaption = false;
+                field("Object ID";"Object ID")
+                {
+                    ApplicationArea = All;
+                }
+                field("Object Name";"Object Name")
+                {
+                    ApplicationArea = All;
+                }
+            }
+        }
+    }
+
+    actions
+    {
+    }
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/src/SelectTestsByRange.Page.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/SelectTestsByRange.Page.al
@@ -1,0 +1,34 @@
+page 130452 "Select Tests By Range"
+{
+    PageType = StandardDialog;
+
+    layout
+    {
+        area(content)
+        {
+            group(Control1)
+            {
+                ShowCaption = false;
+                field("Selection Filter";SelectionFilter)
+                {
+                    ApplicationArea = All;
+                    Caption = 'Selection Filter';
+                }
+            }
+        }
+    }
+
+    actions
+    {
+    }
+
+    var
+        SelectionFilter: Text;
+
+    [Scope('OnPrem')]
+    procedure GetRange(): Text
+    begin
+        exit(SelectionFilter);
+    end;
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/src/TestMethodLine.Table.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/TestMethodLine.Table.al
@@ -1,0 +1,138 @@
+table 130450 "Test Method Line"
+{
+    ReplicateData = false;
+
+    fields
+    {
+        field(1; "Test Suite"; Code[10])
+        {
+            TableRelation = "AL Test Suite".Name;
+        }
+        field(2; "Line No."; Integer)
+        {
+            AutoIncrement = true;
+        }
+        field(3; "Line Type"; Option)
+        {
+            Editable = false;
+            InitValue = "Codeunit";
+            OptionMembers = "Codeunit","Function";
+
+            trigger OnValidate()
+            var
+                TestSuiteMgt: Codeunit "Test Suite Mgt.";
+            begin
+                TestSuiteMgt.ValidateTestMethodLineType(Rec);
+            end;
+        }
+        field(4; "Test Codeunit"; Integer)
+        {
+            Editable = false;
+            TableRelation = IF ("Line Type" = CONST(Codeunit)) AllObjWithCaption."Object ID" WHERE("Object Type" = CONST(Codeunit),
+                                                                                                  "Object Subtype" = CONST('Test'));
+
+            trigger OnValidate()
+            var
+                TestSuiteMgt: Codeunit "Test Suite Mgt.";
+            begin
+                TestSuiteMgt.ValidateTestMethodTestCodeunit(Rec);
+            end;
+        }
+        field(5; Name; Text[128])
+        {
+            Editable = false;
+
+            trigger OnValidate()
+            var
+                TestSuiteMgt: Codeunit "Test Suite Mgt.";
+            begin
+                TestSuiteMgt.ValidateTestMethodName(Rec);
+            end;
+        }
+        field(6; "Function"; Text[128])
+        {
+            Editable = false;
+
+            trigger OnValidate()
+            var
+                TestSuiteMgt: Codeunit "Test Suite Mgt.";
+            begin
+                TestSuiteMgt.ValidateTestMethodFunction(Rec);
+            end;
+        }
+        field(7; Run; Boolean)
+        {
+            InitValue = true;
+
+            trigger OnValidate()
+            var
+                TestSuiteMgt: Codeunit "Test Suite Mgt.";
+            begin
+                TestSuiteMgt.ValidateTestMethodRun(Rec);
+            end;
+        }
+        field(8; Result; Option)
+        {
+            Editable = false;
+            OptionMembers = " ",Failure,Success,Skipped;
+
+            trigger OnValidate()
+            var
+                TestSuiteMgt: Codeunit "Test Suite Mgt.";
+            begin
+                TestSuiteMgt.ClearErrorOnLine(Rec);
+            end;
+        }
+        field(10; "Start Time"; DateTime)
+        {
+            Editable = false;
+        }
+        field(11; "Finish Time"; DateTime)
+        {
+            Editable = false;
+        }
+        field(12; Level; Integer)
+        {
+            Editable = false;
+        }
+        field(50; "Error Message Preview"; Text[2048])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(51; "Error Code"; Text[30])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(52; "Error Message"; BLOB)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(53; "Error Call Stack"; BLOB)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(Key1; "Test Suite", "Line No.")
+        {
+            Clustered = true;
+        }
+        key(Key2; "Test Suite", Result, "Line Type", Run)
+        {
+        }
+    }
+
+    fieldgroups
+    {
+    }
+
+    trigger OnDelete()
+    var
+        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+    begin
+        TestSuiteMgt.DeleteChildren(Rec);
+    end;
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/src/TestProfileManagement.Codeunit.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/TestProfileManagement.Codeunit.al
@@ -1,0 +1,25 @@
+codeunit 130457 "Test Profile Management"
+{
+    // Used to insert a profile into blank database
+    // Web Client cannot load a blank company with no profiles
+
+
+    trigger OnRun()
+    begin
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, 2000000003, 'OnCompanyOpen', '', false, false)]
+    local procedure TestProfileFunctions()
+    var
+        "Profile": Record "Profile";
+    begin
+        if Profile.FindFirst() then
+          exit;
+
+        Profile."Default Role Center" := true;
+        Profile."Profile ID" := 'TEST ROLE CENTER';
+        Profile."Role Center ID" := PAGE::"Test Role Center";
+        Profile.Insert(true);
+    end;
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/src/TestRoleCenter.Page.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/TestRoleCenter.Page.al
@@ -1,0 +1,26 @@
+page 130456 "Test Role Center"
+{
+    PageType = RoleCenter;
+
+    layout
+    {
+        area(rolecenter)
+        {
+        }
+    }
+
+    actions
+    {
+        area(creation)
+        {
+            action(TestRunner)
+            {
+                ApplicationArea = All;
+                Caption = 'Test Runner';
+                RunObject = Page "AL Test Tool";
+                ToolTip = 'Specifies the action for invoking Test Runner page';
+            }
+        }
+    }
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/src/TestRunnerGetMethods.Codeunit.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/TestRunnerGetMethods.Codeunit.al
@@ -1,0 +1,58 @@
+codeunit 130452 "Test Runner - Get Methods"
+{
+    Subtype = TestRunner;
+    TableNo = "Test Method Line";
+
+    trigger OnRun()
+    var
+        ALTestSuite: Record "AL Test Suite";
+        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+    begin
+        CurrentTestMethodLine.Copy(Rec);
+        ALTestSuite.Get("Test Suite");
+        MaxLineNo := TestSuiteMgt.GetLastTestLineNo(ALTestSuite);
+        CODEUNIT.Run(CurrentTestMethodLine."Test Codeunit");
+    end;
+
+    var
+        CurrentTestMethodLine: Record "Test Method Line";
+        MaxLineNo: Integer;
+
+    trigger OnBeforeTestRun(CodeunitID: Integer;CodeunitName: Text;FunctionName: Text;FunctionTestPermissions: TestPermissions): Boolean
+    begin
+        if (FunctionName = 'OnRun') or (FunctionName = '') then
+          exit(true);
+
+        OnGetTestMethods(CodeunitID,CodeunitName,FunctionName,FunctionTestPermissions);
+        AddTestMethod(CodeunitID,FunctionName);
+
+        // Do not run the tests
+        exit(false);
+    end;
+
+    trigger OnAfterTestRun(CodeunitID: Integer;CodeunitName: Text;FunctionName: Text;FunctionTestPermissions: TestPermissions;IsSuccess: Boolean)
+    begin
+        // This method is invoked by platform
+        // It is not used to discover individual test methods
+    end;
+
+    local procedure AddTestMethod(CodeunitID: Integer;FunctionName: Text[128])
+    var
+        TestMethodLine: Record "Test Method Line";
+    begin
+        MaxLineNo += 10000;
+        TestMethodLine."Line No." := MaxLineNo;
+        TestMethodLine.Validate("Test Codeunit",CodeunitID);
+        TestMethodLine.Validate("Test Suite",CurrentTestMethodLine."Test Suite");
+        TestMethodLine.Validate("Line Type",TestMethodLine."Line Type"::"Function");
+        TestMethodLine.Validate("Function",FunctionName);
+        TestMethodLine.Validate(Run,CurrentTestMethodLine.Run);
+        TestMethodLine.Insert(true);
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnGetTestMethods(CodeunitID: Integer;CodeunitName: Text[30];FunctionName: Text[128];FunctionTestPermissions: TestPermissions)
+    begin
+    end;
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/src/TestRunnerIsolCodeunit.Codeunit.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/TestRunnerIsolCodeunit.Codeunit.al
@@ -1,0 +1,33 @@
+codeunit 130450 "Test Runner - Isol. Codeunit"
+{
+    Subtype = TestRunner;
+    TableNo = "Test Method Line";
+    TestIsolation = Codeunit;
+
+    trigger OnRun()
+    begin
+        ALTestSuite.Get("Test Suite");
+        CurrentTestMethodLine.Copy(Rec);
+        TestRunnerMgt.RunTests(Rec);
+    end;
+
+    var
+        ALTestSuite: Record "AL Test Suite";
+        CurrentTestMethodLine: Record "Test Method Line";
+        TestRunnerMgt: Codeunit "Test Runner - Mgt";
+
+    trigger OnBeforeTestRun(CodeunitID: Integer;CodeunitName: Text;FunctionName: Text;FunctionTestPermissions: TestPermissions): Boolean
+    begin
+        exit(
+          TestRunnerMgt.PlatformBeforeTestRun(
+            CodeunitID,CodeunitName,FunctionName,FunctionTestPermissions,ALTestSuite.Name,CurrentTestMethodLine.GetFilter("Line No.")));
+    end;
+
+    trigger OnAfterTestRun(CodeunitID: Integer;CodeunitName: Text;FunctionName: Text;FunctionTestPermissions: TestPermissions;IsSuccess: Boolean)
+    begin
+        TestRunnerMgt.PlatformAfterTestRun(
+          CodeunitID,CodeunitName,FunctionName,FunctionTestPermissions,IsSuccess,ALTestSuite.Name,
+          CurrentTestMethodLine.GetFilter("Line No."));
+    end;
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/src/TestRunnerIsolDisabled.Codeunit.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/TestRunnerIsolDisabled.Codeunit.al
@@ -1,0 +1,33 @@
+codeunit 130451 "Test Runner - Isol. Disabled"
+{
+    Subtype = TestRunner;
+    TableNo = "Test Method Line";
+    TestIsolation = Disabled;
+
+    trigger OnRun()
+    begin
+        ALTestSuite.Get("Test Suite");
+        CurrentTestMethodLine.Copy(Rec);
+        TestRunnerMgt.RunTests(Rec);
+    end;
+
+    var
+        ALTestSuite: Record "AL Test Suite";
+        CurrentTestMethodLine: Record "Test Method Line";
+        TestRunnerMgt: Codeunit "Test Runner - Mgt";
+
+    trigger OnBeforeTestRun(CodeunitID: Integer;CodeunitName: Text;FunctionName: Text;FunctionTestPermissions: TestPermissions): Boolean
+    begin
+        exit(
+          TestRunnerMgt.PlatformBeforeTestRun(
+            CodeunitID,CodeunitName,FunctionName,FunctionTestPermissions,ALTestSuite.Name,CurrentTestMethodLine.GetFilter("Line No.")));
+    end;
+
+    trigger OnAfterTestRun(CodeunitID: Integer;CodeunitName: Text;FunctionName: Text;FunctionTestPermissions: TestPermissions;IsSuccess: Boolean)
+    begin
+        TestRunnerMgt.PlatformAfterTestRun(
+          CodeunitID,CodeunitName,FunctionName,FunctionTestPermissions,IsSuccess,ALTestSuite.Name,
+          CurrentTestMethodLine.GetFilter("Line No."));
+    end;
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/src/TestRunnerMgt.Codeunit.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/TestRunnerMgt.Codeunit.al
@@ -1,0 +1,201 @@
+codeunit 130454 "Test Runner - Mgt"
+{
+
+    trigger OnRun()
+    begin
+    end;
+
+    [Scope('OnPrem')]
+    procedure RunTests(var NewTestMethodLine: Record "Test Method Line")
+    var
+        TestMethodLine: Record "Test Method Line";
+    begin
+        TestMethodLine.Copy(NewTestMethodLine);
+        TestMethodLine.SetRange("Test Suite", TestMethodLine."Test Suite");
+        TestMethodLine.ModifyAll(Result, TestMethodLine.Result::" ");
+        TestMethodLine.ModifyAll("Error Message Preview", '');
+
+        Commit();
+
+        TestMethodLine.SetRange("Line Type", TestMethodLine."Line Type"::Codeunit);
+
+        OnRunTestSuite(TestMethodLine);
+
+        if TestMethodLine.FindSet() then
+            repeat
+                OnBeforeCodeunitRun(TestMethodLine);
+                CODEUNIT.Run(TestMethodLine."Test Codeunit");
+                TestMethodLine.Find();
+                OnAfterCodeunitRun(TestMethodLine);
+            until TestMethodLine.Next() = 0;
+
+        OnAfterRunTestSuite(TestMethodLine);
+    end;
+
+    [Scope('OnPrem')]
+    procedure GetDefautlTestRunner(): Integer
+    begin
+        exit(GetCodeIsolationTestRunner());
+    end;
+
+    [Scope('OnPrem')]
+    procedure GetIsolationDisabledTestRunner(): Integer
+    begin
+        exit(CODEUNIT::"Test Runner - Isol. Disabled");
+    end;
+
+    [Scope('OnPrem')]
+    procedure GetCodeIsolationTestRunner(): Integer
+    begin
+        exit(CODEUNIT::"Test Runner - Isol. Codeunit");
+    end;
+
+    [Scope('OnPrem')]
+    procedure PlatformBeforeTestRun(CodeunitID: Integer; CodeunitName: Text[30]; FunctionName: Text[128]; FunctionTestPermissions: TestPermissions; TestSuite: Code[10]; LineNoTestFilter: Text): Boolean
+    var
+        TestMethodLineFunction: Record "Test Method Line";
+    begin
+        // Invoked by the platform before any codeunit is run
+        if (FunctionName = '') or (FunctionName = 'OnRun') then
+            exit(true);
+
+        if not GetTestFunction(TestMethodLineFunction, FunctionName, TestSuite, CodeunitID, LineNoTestFilter) then
+            exit(false);
+
+        if not TestMethodLineFunction.Run then
+            exit(false);
+
+        OnBeforeTestMethodRun(TestMethodLineFunction, CodeunitID, CodeunitName, FunctionName, FunctionTestPermissions);
+
+        exit(true);
+    end;
+
+    [Scope('OnPrem')]
+    procedure PlatformAfterTestRun(CodeunitID: Integer; CodeunitName: Text[30]; FunctionName: Text[128]; FunctionTestPermissions: TestPermissions; IsSuccess: Boolean; TestSuite: Code[10]; LineNoTestFilter: Text)
+    var
+        TestMethodLine: Record "Test Method Line";
+        CodeunitTestMethodLine: Record "Test Method Line";
+    begin
+        // Invoked by platform after every test method is run
+        if (FunctionName = '') or (FunctionName = 'OnRun') then
+            exit;
+
+        GetTestFunction(TestMethodLine, FunctionName, TestSuite, CodeunitID, LineNoTestFilter);
+        UpdateTestFunctionLine(TestMethodLine, IsSuccess);
+
+        if GetTestCodeunit(CodeunitTestMethodLine, TestMethodLine) then
+            UpdateCodeunitLine(CodeunitTestMethodLine, TestMethodLine, IsSuccess);
+
+        Commit();
+        ClearLastError();
+
+        OnAfterTestMethodRun(TestMethodLine, CodeunitID, CodeunitName, FunctionName, FunctionTestPermissions, IsSuccess);
+    end;
+
+    local procedure UpdateCodeunitLine(var CodeunitTestMethodLine: Record "Test Method Line"; TestMethodLine: Record "Test Method Line"; IsSuccess: Boolean)
+    var
+        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+        FunctionTestMethodLine: Record "Test Method Line";
+        DummyBlankDateTime: DateTime;
+    begin
+        if IsSuccess then begin
+            FunctionTestMethodLine.SETRANGE("Test Suite", CodeunitTestMethodLine."Test Suite");
+            FunctionTestMethodLine.SETRANGE("Test Codeunit", CodeunitTestMethodLine."Test Codeunit");
+            FunctionTestMethodLine.SETRANGE("Line Type", FunctionTestMethodLine."Line Type"::"Function");
+            FunctionTestMethodLine.SETRANGE(Result, FunctionTestMethodLine.Result::Failure);
+            if not FunctionTestMethodLine.FindFirst() then begin
+                CodeunitTestMethodLine.Result := CodeunitTestMethodLine.Result::Success;
+                TestSuiteMgt.ClearErrorOnLine(CodeunitTestMethodLine);
+            end;
+        end else begin
+            CodeunitTestMethodLine.Result := CodeunitTestMethodLine.Result::Failure;
+            TestSuiteMgt.SetLastErrorOnLine(CodeunitTestMethodLine);
+        end;
+
+        if (TestMethodLine."Start Time" < CodeunitTestMethodLine."Start Time") or
+           (CodeunitTestMethodLine."Start Time" = DummyBlankDateTime)
+        then
+            CodeunitTestMethodLine."Start Time" := TestMethodLine."Start Time";
+
+        CodeunitTestMethodLine."Finish Time" := CurrentDateTime();
+        CodeunitTestMethodLine.Modify();
+    end;
+
+    local procedure UpdateTestFunctionLine(var TestMethodLineFunction: Record "Test Method Line"; IsSuccess: Boolean)
+    var
+        TestSuiteMgt: Codeunit "Test Suite Mgt.";
+    begin
+        TestSuiteMgt.ClearErrorOnLine(TestMethodLineFunction);
+
+        if IsSuccess then
+            TestMethodLineFunction.Result := TestMethodLineFunction.Result::Success
+        else begin
+            TestMethodLineFunction.Result := TestMethodLineFunction.Result::Failure;
+            TestSuiteMgt.SetLastErrorOnLine(TestMethodLineFunction);
+        end;
+
+        TestMethodLineFunction."Finish Time" := CurrentDateTime();
+        TestMethodLineFunction.Modify();
+    end;
+
+    local procedure GetTestFunction(var TestMethodLineFunction: Record "Test Method Line"; FunctionName: Text[128]; TestSuite: Code[10]; TestCodeunit: Integer; LineNoTestFilter: Text): Boolean
+    begin
+        TestMethodLineFunction.Reset();
+        TestMethodLineFunction.SetRange("Test Suite", TestSuite);
+        TestMethodLineFunction.SetRange("Test Codeunit", TestCodeunit);
+        TestMethodLineFunction.SetRange("Function", FunctionName);
+
+        if LineNoTestFilter <> '' then
+            TestMethodLineFunction.SetFilter("Line No.", LineNoTestFilter);
+
+        if not TestMethodLineFunction.FindFirst() then
+            exit(false);
+
+        TestMethodLineFunction."Start Time" := CurrentDateTime();
+        TestMethodLineFunction."Finish Time" := TestMethodLineFunction."Start Time";
+        TestMethodLineFunction.Result := TestMethodLineFunction.Result::Skipped;
+        TestMethodLineFunction.Modify();
+
+        exit(true);
+    end;
+
+    local procedure GetTestCodeunit(var CodeunitTestMethodLineFunction: Record "Test Method Line"; var TestMethodLineFunction: Record "Test Method Line"): Boolean
+    begin
+        CodeunitTestMethodLineFunction.SetRange("Test Suite", TestMethodLineFunction."Test Suite");
+        CodeunitTestMethodLineFunction.SetRange("Test Codeunit", TestMethodLineFunction."Test Codeunit");
+        CodeunitTestMethodLineFunction.SetRange("Line Type", CodeunitTestMethodLineFunction."Line Type"::Codeunit);
+
+        exit(CodeunitTestMethodLineFunction.FindFirst());
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnRunTestSuite(var TestMethodLine: Record "Test Method Line")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterRunTestSuite(var TestMethodLine: Record "Test Method Line")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCodeunitRun(var TestMethodLine: Record "Test Method Line")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterCodeunitRun(var TestMethodLine: Record "Test Method Line")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeTestMethodRun(var CurrentTestMethodLine: Record "Test Method Line"; CodeunitID: Integer; CodeunitName: Text[30]; FunctionName: Text[128]; FunctionTestPermissions: TestPermissions)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterTestMethodRun(var CurrentTestMethodLine: Record "Test Method Line"; CodeunitID: Integer; CodeunitName: Text[30]; FunctionName: Text[128]; FunctionTestPermissions: TestPermissions; IsSuccess: Boolean)
+    begin
+    end;
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/src/TestRunnerProgessDialog.Codeunit.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/TestRunnerProgessDialog.Codeunit.al
@@ -1,0 +1,114 @@
+codeunit 130455 "Test Runner - Progess Dialog"
+{
+    EventSubscriberInstance = Manual;
+
+    trigger OnRun()
+    begin
+    end;
+
+    var
+        Window: Dialog;
+        ExecutingTestsMsg: Label 'Executing Tests...\', Locked=true;
+        TestSuiteMsg: Label 'Test Suite    #1###################\', Locked=true;
+        TestCodeunitMsg: Label 'Test Codeunit #2################### @3@@@@@@@@@@@@@\', Locked=true;
+        TestFunctionMsg: Label 'Test Function #4################### @5@@@@@@@@@@@@@\', Locked=true;
+        NoOfResultsMsg: Label 'No. of Results with:\', Locked=true;
+        WindowUpdateDateTime: DateTime;
+        WindowTestSuccess: Integer;
+        WindowTestFailure: Integer;
+        WindowTestSkip: Integer;
+        SuccessMsg: Label '    Success   #6######\', Locked=true;
+        FailureMsg: Label '    Failure   #7######\', Locked=true;
+        SkipMsg: Label '    Skip      #8######\', Locked=true;
+        WindowNoOfTestCodeunitTotal: Integer;
+        WindowNoOfFunctionTotal: Integer;
+        WindowNoOfTestCodeunit: Integer;
+        WindowNoOfFunction: Integer;
+        CurrentCodeunitNumber: Integer;
+
+    [EventSubscriber(ObjectType::Codeunit, 130454, 'OnRunTestSuite', '', false, false)]
+    local procedure OpenWindow(var TestMethodLine: Record "Test Method Line")
+    var
+        CopyTestMethodLine: Record "Test Method Line";
+    begin
+        if not GuiAllowed() then
+          exit;
+
+        CopyTestMethodLine.Copy(TestMethodLine);
+        WindowNoOfTestCodeunitTotal := CopyTestMethodLine.Count();
+        CopyTestMethodLine.Reset();
+        CopyTestMethodLine.SetRange("Test Suite",TestMethodLine."Test Suite");
+        CopyTestMethodLine.SetRange("Line Type",TestMethodLine."Line Type"::"Function");
+
+        WindowNoOfFunctionTotal := CopyTestMethodLine.Count();
+
+        Window.HideSubsequentDialogs(true);
+        Window.Open(
+          ExecutingTestsMsg +
+          TestSuiteMsg +
+          TestCodeunitMsg +
+          TestFunctionMsg +
+          NoOfResultsMsg +
+          SuccessMsg +
+          FailureMsg +
+          SkipMsg);
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, 130454, 'OnAfterRunTestSuite', '', false, false)]
+    local procedure CloseWindow(var TestMethodLine: Record "Test Method Line")
+    begin
+        if not GuiAllowed() then
+          exit;
+
+        Window.Close();
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, 130454, 'OnAfterTestMethodRun', '', false, false)]
+    local procedure UpDateWindow(var CurrentTestMethodLine: Record "Test Method Line";CodeunitID: Integer;CodeunitName: Text[30];FunctionName: Text[128];FunctionTestPermissions: TestPermissions;IsSuccess: Boolean)
+    begin
+        if not GuiAllowed() then
+          exit;
+
+        case CurrentTestMethodLine.Result of
+          CurrentTestMethodLine.Result::Failure:
+            WindowTestFailure += 1;
+          CurrentTestMethodLine.Result::Success:
+            WindowTestSuccess += 1;
+          else
+            WindowTestSkip += 1;
+        end;
+
+        WindowNoOfFunction += 1;
+
+        if CurrentCodeunitNumber <> CurrentTestMethodLine."Test Codeunit" then begin
+          if CurrentCodeunitNumber <> 0 then
+            WindowNoOfTestCodeunit += 1;
+          CurrentCodeunitNumber := CurrentTestMethodLine."Test Codeunit";
+        end;
+
+        if IsTimeForUpdate() then begin
+          Window.Update(1,CurrentTestMethodLine."Test Suite");
+          Window.Update(2,CurrentTestMethodLine."Test Codeunit");
+          Window.Update(4,FunctionName);
+          Window.Update(6,WindowTestSuccess);
+          Window.Update(7,WindowTestFailure);
+          Window.Update(8,WindowTestSkip);
+
+          if WindowNoOfTestCodeunitTotal <> 0 then
+            Window.Update(3,Round(WindowNoOfTestCodeunit / WindowNoOfTestCodeunitTotal * 10000,1));
+          if WindowNoOfFunctionTotal <> 0 then
+            Window.Update(5,Round(WindowNoOfFunction / WindowNoOfFunctionTotal * 10000,1));
+        end;
+    end;
+
+    local procedure IsTimeForUpdate(): Boolean
+    begin
+        if true in [WindowUpdateDateTime = 0DT,CurrentDateTime() - WindowUpdateDateTime >= 1000] then begin
+          WindowUpdateDateTime := CurrentDateTime();
+          exit(true);
+        end;
+
+        exit(false);
+    end;
+}
+

--- a/Modules/DevTools/TestTools/TestRunner/app/src/TestSuiteMgt.Codeunit.al
+++ b/Modules/DevTools/TestTools/TestRunner/app/src/TestSuiteMgt.Codeunit.al
@@ -1,0 +1,525 @@
+codeunit 130456 "Test Suite Mgt."
+{
+
+    trigger OnRun()
+    begin
+    end;
+
+    var
+        NoTestRunnerSelectedTxt: Label 'No test runner is selected.';
+        CannotChangeValueErr: Label 'You cannot change the value of the OnRun.', Locked=true;
+        SelectTestsToRunQst: Label '&All,Active &Codeunit,Active &Line', Locked=true;
+        SelectCodeunitsToRunQst: Label '&All,Active &Codeunit', Locked=true;
+        DefaultTestSuiteNameTxt: Label 'DEFAULT', Locked=true;
+
+    [Scope('OnPrem')]
+    procedure RunTestSuiteSelection(var TestMethodLine: Record "Test Method Line")
+    var
+        ALTestSuite: Record "AL Test Suite";
+        CurrentTestMethodLine: Record "Test Method Line";
+        Selection: Integer;
+        LineNoFilter: Text;
+    begin
+        CurrentTestMethodLine.Copy(TestMethodLine);
+        ALTestSuite.Get(TestMethodLine."Test Suite");
+
+        if GuiAllowed() then
+          Selection := PromptUserToSelectTestsToRun(CurrentTestMethodLine)
+        else
+          Selection := ALTestSuite."Run Type"::All;
+
+        if Selection <= 0 then
+          exit;
+
+        LineNoFilter := GetLineNoFilter(CurrentTestMethodLine,Selection);
+
+        if LineNoFilter <> '' then
+          CurrentTestMethodLine.SetFilter("Line No.",LineNoFilter);
+
+        RunTests(CurrentTestMethodLine,ALTestSuite);
+    end;
+
+    [Scope('OnPrem')]
+    procedure RunAllTests(var TestMethodLine: Record "Test Method Line")
+    var
+        ALTestSuite: Record "AL Test Suite";
+    begin
+        ALTestSuite.Get(TestMethodLine."Test Suite");
+
+        TestMethodLine.Reset();
+        TestMethodLine.SetRange("Test Suite",ALTestSuite.Name);
+
+        RunTests(TestMethodLine,ALTestSuite);
+    end;
+
+    [Scope('OnPrem')]
+    procedure RunSelectedTests(var TestMethodLine: Record "Test Method Line")
+    var
+        ALTestSuite: Record "AL Test Suite";
+        CurrentCodeunitNumber: Integer;
+        LineNoFilter: Text;
+    begin
+        TestMethodLine.SetCurrentKey("Line No.");
+        TestMethodLine.Ascending(true);
+        if not TestMethodLine.FindFirst() then
+          exit;
+
+        ALTestSuite.Get(TestMethodLine."Test Suite");
+        LineNoFilter := '';
+
+        repeat
+          if TestMethodLine."Test Codeunit" <> CurrentCodeunitNumber then begin
+            CurrentCodeunitNumber := TestMethodLine."Test Codeunit";
+            if LineNoFilter <> '' then
+              LineNoFilter += '|';
+
+            if TestMethodLine."Line Type" = TestMethodLine."Line Type"::Codeunit then
+              LineNoFilter += GetLineNoFilter(TestMethodLine,ALTestSuite."Run Type"::"Active Codeunit");
+
+            if TestMethodLine."Line Type" = TestMethodLine."Line Type"::"Function" then
+              LineNoFilter += GetLineNoFilter(TestMethodLine,ALTestSuite."Run Type"::"Active Test");
+          end else
+            if TestMethodLine."Line Type" = TestMethodLine."Line Type"::"Function" then
+              LineNoFilter += '|' + Format(TestMethodLine."Line No.");
+        until TestMethodLine.Next() = 0;
+
+        TestMethodLine.Reset();
+        TestMethodLine.SetRange("Test Suite",ALTestSuite.Name);
+        TestMethodLine.SetFilter("Line No.",LineNoFilter);
+        TestMethodLine.FindFirst();
+        RunTests(TestMethodLine,ALTestSuite);
+    end;
+
+    [Scope('OnPrem')]
+    procedure SelectTestMethods(var ALTestSuite: Record "AL Test Suite")
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+        SelectTests: Page "Select Tests";
+    begin
+        SelectTests.LookupMode := true;
+        if SelectTests.RunModal() = ACTION::LookupOK then begin
+          SelectTests.SetSelectionFilter(AllObjWithCaption);
+          GetTestMethods(ALTestSuite,AllObjWithCaption);
+        end;
+    end;
+
+    [Scope('OnPrem')]
+    procedure LookupTestMethodsByRange(var ALTestSuite: Record "AL Test Suite")
+    var
+        SelectTestsByRange: Page "Select Tests By Range";
+    begin
+        ALTestSuite.Find();
+        SelectTestsByRange.LookupMode := true;
+        if SelectTestsByRange.RunModal() = ACTION::LookupOK then
+          SelectTestMethodsByRange(ALTestSuite,SelectTestsByRange.GetRange());
+    end;
+
+    [Scope('OnPrem')]
+    procedure SelectTestMethodsByRange(var ALTestSuite: Record "AL Test Suite";TestCodeunitFilter: Text)
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+    begin
+        AllObjWithCaption.SetFilter("Object ID",TestCodeunitFilter);
+        AllObjWithCaption.SetRange("Object Type",AllObjWithCaption."Object Type"::Codeunit);
+        AllObjWithCaption.SetRange("Object Subtype",GetTestObjectSubtype());
+        GetTestMethods(ALTestSuite,AllObjWithCaption);
+    end;
+
+    [Scope('OnPrem')]
+    procedure SelectTestMethodsByExtension(var ALTestSuite: Record "AL Test Suite";ExtensionID: Text)
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+        NAVApp: Record "NAV App";
+        AppExtensionId: Guid;
+    begin
+        Evaluate(AppExtensionId,ExtensionID);
+        NAVApp.SetRange(ID,AppExtensionId);
+        NAVApp.FindFirst();
+        AllObjWithCaption.SetRange("App Package ID",NAVApp."Package ID");
+        AllObjWithCaption.SetRange("Object Type",AllObjWithCaption."Object Type"::Codeunit);
+        AllObjWithCaption.SetRange("Object Subtype",GetTestObjectSubtype());
+        GetTestMethods(ALTestSuite,AllObjWithCaption);
+    end;
+
+    [Scope('OnPrem')]
+    procedure LookupTestRunner(var ALTestSuite: Record "AL Test Suite")
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+        SelectTestRunner: Page "Select TestRunner";
+    begin
+        SelectTestRunner.LookupMode := true;
+        if SelectTestRunner.RunModal() = ACTION::LookupOK then begin
+          SelectTestRunner.GetRecord(AllObjWithCaption);
+          ChangeTestRunner(ALTestSuite,AllObjWithCaption."Object ID");
+        end;
+    end;
+
+    [Scope('OnPrem')]
+    procedure ChangeTestRunner(var ALTestSuite: Record "AL Test Suite";NewTestRunnerId: Integer)
+    begin
+        ALTestSuite.Validate("Test Runner Id",NewTestRunnerId);
+        ALTestSuite.Modify(true);
+    end;
+
+    [Scope('OnPrem')]
+    procedure CreateTestSuite(var TestSuiteName: Code[10])
+    var
+        ALTestSuite: Record "AL Test Suite";
+    begin
+        if TestSuiteName = '' then
+          TestSuiteName := DefaultTestSuiteNameTxt;
+
+        ALTestSuite.Name := CopyStr(TestSuiteName,1,MaxStrLen(ALTestSuite.Name));
+        ALTestSuite.Insert(true);
+    end;
+
+    [Scope('OnPrem')]
+    procedure GetTestMethods(var ALTestSuite: Record "AL Test Suite";var AllObjWithCaption: Record AllObjWithCaption)
+    var
+        TestLineNo: Integer;
+    begin
+        if not AllObjWithCaption.FindSet() then
+          exit;
+
+        repeat
+          // Must be inside of loop. Test Runner used for discovering tests is adding methods
+          TestLineNo := GetLastTestLineNo(ALTestSuite) + 10000;
+          AddTestMethod(AllObjWithCaption,ALTestSuite,TestLineNo);
+        until AllObjWithCaption.Next() = 0;
+    end;
+
+    local procedure PromptUserToSelectTestsToRun(TestMethodLine: Record "Test Method Line"): Integer
+    var
+        Selection: Integer;
+    begin
+        if TestMethodLine."Line Type" = TestMethodLine."Line Type"::Codeunit then
+          Selection := StrMenu(SelectCodeunitsToRunQst,1)
+        else
+          Selection := StrMenu(SelectTestsToRunQst,3);
+
+        exit(Selection);
+    end;
+
+    local procedure GetLineNoFilter(TestMethodLine: Record "Test Method Line";Selection: Option) LineNoFilter: Text
+    var
+        DummyALTestSuite: Record "AL Test Suite";
+        CodeunitTestMethodLine: Record "Test Method Line";
+        MinNumber: Integer;
+    begin
+        LineNoFilter := '';
+        case Selection of
+          DummyALTestSuite."Run Type"::"Active Test":
+            begin
+              TestMethodLine.TestField("Line Type",TestMethodLine."Line Type"::"Function");
+              LineNoFilter := Format(TestMethodLine."Line No.");
+              CodeunitTestMethodLine.SetRange("Test Suite",TestMethodLine."Test Suite");
+              CodeunitTestMethodLine.SetRange("Test Codeunit",TestMethodLine."Test Codeunit");
+              CodeunitTestMethodLine.FindFirst();
+              LineNoFilter := StrSubstNo('%1|%2',CodeunitTestMethodLine."Line No.",TestMethodLine."Line No.");
+            end;
+          DummyALTestSuite."Run Type"::"Active Codeunit":
+            begin
+              CodeunitTestMethodLine.SetRange("Test Suite",TestMethodLine."Test Suite");
+              CodeunitTestMethodLine.SetRange("Test Codeunit",TestMethodLine."Test Codeunit");
+              CodeunitTestMethodLine.SetAscending("Line No.",true);
+              CodeunitTestMethodLine.FindFirst();
+              MinNumber := CodeunitTestMethodLine."Line No.";
+              CodeunitTestMethodLine.FindLast();
+              LineNoFilter :=
+                StrSubstNo('%1..%2',MinNumber,CodeunitTestMethodLine."Line No.");
+            end;
+        end;
+    end;
+
+    [Scope('OnPrem')]
+    procedure GetLastTestLineNo(ALTestSuite: Record "AL Test Suite"): Integer
+    var
+        TestMethodLine: Record "Test Method Line";
+        LineNo: Integer;
+    begin
+        LineNo := 0;
+
+        TestMethodLine.SetRange("Test Suite",ALTestSuite.Name);
+        if TestMethodLine.FindLast() then
+          LineNo := TestMethodLine."Line No.";
+
+        exit(LineNo);
+    end;
+
+    local procedure AddTestMethod(AllObjWithCaption: Record AllObjWithCaption;ALTestSuite: Record "AL Test Suite";NextLineNo: Integer)
+    var
+        TestMethodLine: Record "Test Method Line";
+    begin
+        TestMethodLine."Test Suite" := ALTestSuite.Name;
+        TestMethodLine."Line No." := NextLineNo;
+        TestMethodLine."Test Codeunit" := AllObjWithCaption."Object ID";
+        TestMethodLine.Validate("Line Type",TestMethodLine."Line Type"::Codeunit);
+        TestMethodLine.Name := AllObjWithCaption."Object Name";
+        TestMethodLine.Insert(true);
+
+        CODEUNIT.Run(CODEUNIT::"Test Runner - Get Methods",TestMethodLine);
+    end;
+
+    local procedure GetTestObjectSubtype(): Text
+    begin
+        exit('Test');
+    end;
+
+    [Scope('OnPrem')]
+    procedure DeleteAllMethods(var ALTestSuite: Record "AL Test Suite")
+    var
+        TestMethodLine: Record "Test Method Line";
+    begin
+        TestMethodLine.SetRange("Test Suite",ALTestSuite.Name);
+        TestMethodLine.DeleteAll(true);
+    end;
+
+    [Scope('OnPrem')]
+    procedure RunTests(var TestMethodLine: Record "Test Method Line";ALTestSuite: Record "AL Test Suite")
+    begin
+        CODEUNIT.Run(ALTestSuite."Test Runner Id",TestMethodLine);
+    end;
+
+    [Scope('OnPrem')]
+    procedure GetTestRunnerDisplayName(ALTestSuite: Record "AL Test Suite"): Text
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+    begin
+        if not AllObjWithCaption.Get(AllObjWithCaption."Object Type"::Codeunit,ALTestSuite."Test Runner Id") then
+          exit(NoTestRunnerSelectedTxt);
+
+        exit(StrSubstNo('%1 - %2',ALTestSuite."Test Runner Id",AllObjWithCaption."Object Name"));
+    end;
+
+    [Scope('OnPrem')]
+    procedure UpdateRunValueOnChildren(var TestMethodLine: Record "Test Method Line")
+    var
+        BackupTestMethodLine: Record "Test Method Line";
+    begin
+        if TestMethodLine."Line Type" = TestMethodLine."Line Type"::"Function" then
+          exit;
+
+        BackupTestMethodLine.Copy(TestMethodLine);
+
+        TestMethodLine.Reset();
+        TestMethodLine.SetRange("Test Suite", BackupTestMethodLine."Test Suite");
+
+        TestMethodLine.SETRANGE("Line Type",TestMethodLine."Line Type"::"Function");
+        TestMethodLine.SETRANGE("Test Codeunit",BackupTestMethodLine."Test Codeunit");
+        TestMethodLine.MODIFYALL(Run,BackupTestMethodLine.Run, TRUE);
+
+        TestMethodLine.Copy(BackupTestMethodLine);
+    end;
+
+    [Scope('OnPrem')]
+    procedure DeleteChildren(var TestMethodLine: Record "Test Method Line")
+    var
+        BackupTestMethodLine: Record "Test Method Line";
+    begin
+        BackupTestMethodLine.Copy(TestMethodLine);
+
+        TestMethodLine.Reset();
+        TestMethodLine.SetRange("Test Suite",TestMethodLine."Test Suite");
+        TestMethodLine.SetRange("Test Codeunit",BackupTestMethodLine."Test Codeunit");
+        TestMethodLine.SetFilter(Level,'>%1',BackupTestMethodLine.Level);
+
+        if TestMethodLine.IsEmpty() then begin
+          TestMethodLine.Copy(BackupTestMethodLine);
+          exit;
+        end;
+
+        TestMethodLine.DeleteAll();
+
+        TestMethodLine.Copy(BackupTestMethodLine);
+    end;
+
+    [Scope('OnPrem')]
+    procedure CalcTestResults(CurrentTestMethodLine: Record "Test Method Line";var Success: Integer;var Fail: Integer;var Skipped: Integer;var NotExecuted: Integer)
+    var
+        TestMethodLine: Record "Test Method Line";
+    begin
+        TestMethodLine.SetRange("Test Suite",CurrentTestMethodLine."Test Suite");
+        TestMethodLine.SetFilter("Function",'<>%1','OnRun');
+        TestMethodLine.SetRange("Line Type",TestMethodLine."Line Type"::"Function");
+
+        TestMethodLine.SetRange(Result,TestMethodLine.Result::Success);
+        Success := TestMethodLine.Count();
+
+        TestMethodLine.SetRange(Result,TestMethodLine.Result::Failure);
+        Fail := TestMethodLine.Count();
+
+        TestMethodLine.SetRange(Result,TestMethodLine.Result::Skipped);
+        Skipped := TestMethodLine.Count();
+
+        TestMethodLine.SetRange(Result,TestMethodLine.Result::" ");
+        NotExecuted := TestMethodLine.Count();
+    end;
+
+    local procedure GetLineLevel(var TestMethodLine: Record "Test Method Line"): Integer
+    begin
+        case TestMethodLine."Line Type" of
+            TestMethodLine."Line Type"::Codeunit:
+                exit(0);
+            else
+                exit(1);
+        end;
+    end;
+
+    [Scope('OnPrem')]
+    procedure SetLastErrorOnLine(var TestMethodLine: Record "Test Method Line")
+    begin
+        TestMethodLine."Error Code" := CopyStr(GetLastErrorCode(),1,MaxStrLen(TestMethodLine."Error Code"));
+        TestMethodLine."Error Message Preview" := CopyStr(GetLastErrorCode(),1,MaxStrLen(TestMethodLine."Error Message Preview"));
+        SetFullErrorMessage(TestMethodLine,GetLastErrorText());
+        SetErrorCallStack(TestMethodLine,GetLastErrorCallstack());
+    end;
+
+    [Scope('OnPrem')]
+    procedure ClearErrorOnLine(var TestMethodLine: Record "Test Method Line")
+    begin
+        Clear(TestMethodLine."Error Call Stack");
+        Clear(TestMethodLine."Error Code");
+        Clear(TestMethodLine."Error Message");
+        Clear(TestMethodLine."Error Message Preview");
+    end;
+
+    [Scope('OnPrem')]
+    procedure GetFullErrorMessage(var TestMethodLine: Record "Test Method Line"): Text
+    var
+        ErrorMessageInStream: InStream;
+        ErrorMessage: Text;
+    begin
+        TestMethodLine.CalcFields("Error Message");
+        if not TestMethodLine."Error Message".HasValue() then
+          exit('');
+
+        TestMethodLine."Error Message".CreateInStream(ErrorMessageInStream,GetDefaultTextEncoding());
+        ErrorMessageInStream.ReadText(ErrorMessage);
+        exit(ErrorMessage);
+    end;
+
+    local procedure SetFullErrorMessage(var TestMethodLine: Record "Test Method Line";ErrorMessage: Text)
+    var
+        ErrorMessageOutStream: OutStream;
+    begin
+        TestMethodLine."Error Message".CreateOutStream(ErrorMessageOutStream,GetDefaultTextEncoding());
+        ErrorMessageOutStream.WriteText(ErrorMessage);
+        TestMethodLine.Modify(true);
+    end;
+
+    [Scope('OnPrem')]
+    procedure GetErrorCallStack(var TestMethodLine: Record "Test Method Line"): Text
+    var
+        ErrorCallStackInStream: InStream;
+        ErrorCallStack: Text;
+    begin
+        TestMethodLine.CalcFields("Error Call Stack");
+        if not TestMethodLine."Error Call Stack".HasValue() then
+          exit('');
+
+        TestMethodLine."Error Call Stack".CreateInStream(ErrorCallStackInStream,GetDefaultTextEncoding());
+        ErrorCallStackInStream.ReadText(ErrorCallStack);
+        exit(ErrorCallStack);
+    end;
+
+    local procedure SetErrorCallStack(var TestMethodLine: Record "Test Method Line";ErrorCallStack: Text)
+    var
+        ErrorCallStackOutStream: OutStream;
+    begin
+        TestMethodLine."Error Call Stack".CreateOutStream(ErrorCallStackOutStream,GetDefaultTextEncoding());
+        ErrorCallStackOutStream.WriteText(ErrorCallStack);
+        TestMethodLine.Modify(true);
+    end;
+
+    local procedure GetDefaultTextEncoding(): TextEncoding
+    begin
+        exit(TEXTENCODING::UTF16);
+    end;
+
+    [Scope('OnPrem')]
+    procedure GetErrorMessageWithStackTrace(var TestMethodLine: Record "Test Method Line"): Text
+    var
+        FullErrorMessage: Text;
+        NewLine: Text;
+    begin
+        FullErrorMessage := GetFullErrorMessage(TestMethodLine);
+
+        if FullErrorMessage = '' then
+          exit('');
+
+        NewLine[1] := 10;
+        FullErrorMessage := StrSubstNo('Error Message: %1 - Error Call Stack: ',FullErrorMessage);
+        FullErrorMessage += NewLine + NewLine + GetErrorCallStack(TestMethodLine);
+        exit(FullErrorMessage);
+    end;
+
+    [Scope('OnPrem')]
+    procedure ValidateTestMethodLineType(var TestMethodLine: Record "Test Method Line")
+    begin
+        case TestMethodLine."Line Type" of
+            TestMethodLine."Line Type"::Codeunit:
+                begin
+                    TestMethodLine.TestField("Function", '');
+                    TestMethodLine.Name := '';
+                end;
+        end;
+
+        TestMethodLine.Level := GetLineLevel(TestMethodLine);
+    end;
+
+    [Scope('OnPrem')]
+    procedure ValidateTestMethodTestCodeunit(var TestMethodLine: Record "Test Method Line")
+    var
+        AllObjWithCaption: Record AllObjWithCaption;
+    begin
+        if TestMethodLine."Test Codeunit" = 0 then
+          exit;
+
+        if AllObjWithCaption.Get(AllObjWithCaption."Object Type"::Codeunit,TestMethodLine."Test Codeunit") then
+          TestMethodLine.Name := AllObjWithCaption."Object Name";
+
+        TestMethodLine.Level := GetLineLevel(TestMethodLine);
+    end;
+
+    [Scope('OnPrem')]
+    procedure ValidateTestMethodName(var TestMethodLine: Record "Test Method Line")
+    var
+        TestUnitNo: Integer;
+    begin
+        case TestMethodLine."Line Type" of
+          TestMethodLine."Line Type"::"Function":
+            TestMethodLine.TestField(Name,TestMethodLine."Function");
+          TestMethodLine."Line Type"::Codeunit:
+            begin
+              TestMethodLine.TestField(Name);
+              Evaluate(TestUnitNo,TestMethodLine.Name);
+              TestMethodLine.Validate("Test Codeunit",TestUnitNo);
+            end;
+        end;
+    end;
+
+    [Scope('OnPrem')]
+    procedure ValidateTestMethodFunction(var TestMethodLine: Record "Test Method Line")
+    begin
+        if TestMethodLine."Line Type" <> TestMethodLine."Line Type"::"Function" then begin
+          TestMethodLine.TestField("Function",'');
+          exit;
+        end;
+
+        TestMethodLine.Level := GetLineLevel(TestMethodLine);
+        TestMethodLine.Name := TestMethodLine."Function";
+    end;
+
+    [Scope('OnPrem')]
+    procedure ValidateTestMethodRun(var CurrentTestMethodLine: Record "Test Method Line")
+    var
+        TestMethodLine: Record "Test Method Line";
+    begin
+        if CurrentTestMethodLine."Function" = 'OnRun' then
+          Error(CannotChangeValueErr);
+
+        TestMethodLine.Copy(CurrentTestMethodLine);
+
+        UpdateRunValueOnChildren(TestMethodLine);
+    end;
+}

--- a/Modules/System/Satisfaction Survey/src/SatisfactionSurveyAsync.ControlAddIn.al
+++ b/Modules/System/Satisfaction Survey/src/SatisfactionSurveyAsync.ControlAddIn.al
@@ -1,6 +1,6 @@
 controladdin SatisfactionSurveyAsync
 {
-    Scripts = '.\Satisfaction Survey\js\SATAsync.js';
+    Scripts = 'js\SATAsync.js';
     RequestedWidth = 0;
     RequestedHeight = 0;
     HorizontalStretch = false;

--- a/Modules/System/js/SATAsync.js
+++ b/Modules/System/js/SATAsync.js
@@ -1,0 +1,25 @@
+function SendRequest(Url, Timeout) {
+    var request = new XMLHttpRequest();
+    try {
+        validateParams(Url, Timeout);
+        request.timeout = Timeout;
+        request.onreadystatechange = responseHandler;
+        request.open("GET", Url, true);
+        request.send(null);
+    }
+    catch (ex) {
+        Microsoft.Dynamics.NAV.InvokeExtensibilityMethod('ResponseReceived', [0, ex.message]);
+    }
+
+    function responseHandler() {
+        if (request.readyState == 4) {
+            Microsoft.Dynamics.NAV.InvokeExtensibilityMethod('ResponseReceived', [request.status, request.responseText.substring(0, 250)]);
+        }
+    }
+
+    function validateParams(Url, Timeout) {
+        if (!Url || !Url.startsWith('https://') || Timeout <= 0 || Timeout > 60000) {
+            throw 'Unexpected parameter';
+        }
+    }
+}


### PR DESCRIPTION
From developer: The js file need to be duplicated in the modules root because of the problem with a relative path to js files in controladdins (bug logged). It is a workaround to be able to compile both the big system application module and SAT module.