### PR TITLE
Update breaking change

### DIFF
--- a/BREAKINGCHANGES.md
+++ b/BREAKINGCHANGES.md
@@ -150,6 +150,10 @@ We’re working hard to make this a comprehensive list, but there’s always a c
 
 **Solution**: Function has been moved to `codeunit 457 "Environment Information"`, function `IsInvoicing`.
 
+**Error**: _'Codeunit "Tenant Information"' does not contain a definition for 'GetPlatformVerion'_
+
+**Solution**: The function a very technical term about the platform build number used internally by MS. Please use the alternate methods available in either `codeunit 417 "Tenant Information"` or `codeunit 457 "Environment Information"`.
+
 ---
 
 ## Extension Management Module


### PR DESCRIPTION
Inform users why they should not be using the old GetPlatformVersion function anymore.