### PR TITLE
Added Reset function to the assisted setup

### DIFF
--- a/Modules/System/Assisted Setup/src/AssistedSetup.Codeunit.al
+++ b/Modules/System/Assisted Setup/src/AssistedSetup.Codeunit.al
@@ -93,9 +93,9 @@ codeunit 3725 "Assisted Setup"
     /// <param name="ExtensionID">The app ID of the extension to which the setup belongs.</param>
     /// <param name="PageID">The ID of the page to open when the user clicks the setup.</param>
     /// <returns>True if the assisted setup is uncomplete now.</returns>
-    procedure Reset(ExtensionID: Guid; PageID: Integer)
+    procedure Reset(PageID: Integer)
     begin
-        AssistedSetupImpl.Reset(ExtensionID, PageID);
+        AssistedSetupImpl.Reset(PageID);
     end;
 
     /// <summary>Issues the call to execute the setup.</summary>

--- a/Modules/System/Assisted Setup/src/AssistedSetup.Codeunit.al
+++ b/Modules/System/Assisted Setup/src/AssistedSetup.Codeunit.al
@@ -89,6 +89,15 @@ codeunit 3725 "Assisted Setup"
         AssistedSetupImpl.Complete(ExtensionID, PageID);
     end;
 
+    /// <summary>Sets the status of the assisted setup to uncomplete.</summary>
+    /// <param name="ExtensionID">The app ID of the extension to which the setup belongs.</param>
+    /// <param name="PageID">The ID of the page to open when the user clicks the setup.</param>
+    /// <returns>True if the assisted setup is uncomplete now.</returns>
+    procedure Reset(ExtensionID: Guid; PageID: Integer)
+    begin
+        AssistedSetupImpl.Reset(ExtensionID, PageID);
+    end;
+
     /// <summary>Issues the call to execute the setup.</summary>
     /// <param name="ExtensionID">The app ID of the extension to which the setup belongs.</param>
     /// <param name="PageID">The ID of the page to open when the user clicks the setup.</param>

--- a/Modules/System/Assisted Setup/src/AssistedSetup.Codeunit.al
+++ b/Modules/System/Assisted Setup/src/AssistedSetup.Codeunit.al
@@ -89,10 +89,8 @@ codeunit 3725 "Assisted Setup"
         AssistedSetupImpl.Complete(ExtensionID, PageID);
     end;
 
-    /// <summary>Sets the status of the assisted setup to uncomplete.</summary>
-    /// <param name="ExtensionID">The app ID of the extension to which the setup belongs.</param>
+    /// <summary>Sets the status of the assisted setup to incomplete.</summary>
     /// <param name="PageID">The ID of the page to open when the user clicks the setup.</param>
-    /// <returns>True if the assisted setup is uncomplete now.</returns>
     procedure Reset(PageID: Integer)
     begin
         AssistedSetupImpl.Reset(PageID);

--- a/Modules/System/Assisted Setup/src/AssistedSetupImpl.Codeunit.al
+++ b/Modules/System/Assisted Setup/src/AssistedSetupImpl.Codeunit.al
@@ -99,6 +99,18 @@ codeunit 1813 "Assisted Setup Impl."
         AssistedSetup.Modify(true);
     end;
 
+    procedure Reset(ExtensionID: Guid; PageID: Integer)
+    var
+        AssistedSetup: Record "Assisted Setup";
+    begin
+        if not AssistedSetup.WritePermission() then
+            exit;
+        if not AssistedSetup.Get(PageID) then
+            exit;
+        AssistedSetup.Validate(Completed, false);
+        AssistedSetup.Modify(true);
+    end;
+
     procedure ExistsAndIsNotComplete(ExtensionID: Guid; PageID: Integer): Boolean
     var
         AssistedSetup: Record "Assisted Setup";

--- a/Modules/System/Assisted Setup/src/AssistedSetupImpl.Codeunit.al
+++ b/Modules/System/Assisted Setup/src/AssistedSetupImpl.Codeunit.al
@@ -99,7 +99,7 @@ codeunit 1813 "Assisted Setup Impl."
         AssistedSetup.Modify(true);
     end;
 
-    procedure Reset(ExtensionID: Guid; PageID: Integer)
+    procedure Reset(PageID: Integer)
     var
         AssistedSetup: Record "Assisted Setup";
     begin


### PR DESCRIPTION
Discussed this feature in Yammer with Soumya Dutta:

https://www.yammer.com/dynamicsnavdev/#/Threads/show?threadId=314088954175488&search_origin=global&scoring=linear1Y-prankie-group-private-higher&match=any-exact&search_sort=relevance&page=1&search=assisted%20setup.

We need this function in test scenarios to make sure that the wizard's complete status is reseted before opening the assisted setup.
If the assisted setup is not reseted a confirm will appear. But if its not completed, the confirm will not appear.

Because there is no "optional confirmhandler" the reset function is the easiest way to solve this behavior.