### PR TITLE
Added procedure to remove Assisted Setup

### DIFF
--- a/Modules/System/Assisted Setup/src/AssistedSetup.Codeunit.al
+++ b/Modules/System/Assisted Setup/src/AssistedSetup.Codeunit.al
@@ -112,9 +112,9 @@ codeunit 3725 "Assisted Setup"
     /// <summary>Removes an Assisted Setup from a given extension so it will no longer be shown in the list.</summary>
     /// <param name="ExtensionID">The app ID of the extension to which the setup belongs.</param>
     /// <param name="PageID">The ID of the page to be removed.</param>
-    procedure Remove(ExtensionID: Guid; PageID: Integer)
+    procedure Remove(PageID: Integer)
     begin
-        AssistedSetupImpl.Remove(ExtensionID, PageID);
+        AssistedSetupImpl.Remove(PageID);
     end;
 
 

--- a/Modules/System/Assisted Setup/src/AssistedSetup.Codeunit.al
+++ b/Modules/System/Assisted Setup/src/AssistedSetup.Codeunit.al
@@ -109,6 +109,15 @@ codeunit 3725 "Assisted Setup"
         AssistedSetupImpl.Open(AssistedSetupGroup);
     end;
 
+    /// <summary>Removes an Assisted Setup from a given extension so it will no longer be shown in the list.</summary>
+    /// <param name="ExtensionID">The app ID of the extension to which the setup belongs.</param>
+    /// <param name="PageID">The ID of the page to be removed.</param>
+    procedure Remove(ExtensionID: Guid; PageID: Integer)
+    begin
+        AssistedSetupImpl.Remove(ExtensionID, PageID);
+    end;
+
+
     /// <summary>Notifies the user that the list of assisted setup guides is being gathered, and that new guides might be added.</summary>
     [IntegrationEvent(false, false)]
     internal procedure OnRegister()

--- a/Modules/System/Assisted Setup/src/AssistedSetup.Codeunit.al
+++ b/Modules/System/Assisted Setup/src/AssistedSetup.Codeunit.al
@@ -110,7 +110,6 @@ codeunit 3725 "Assisted Setup"
     end;
 
     /// <summary>Removes an Assisted Setup from a given extension so it will no longer be shown in the list.</summary>
-    /// <param name="ExtensionID">The app ID of the extension to which the setup belongs.</param>
     /// <param name="PageID">The ID of the page to be removed.</param>
     procedure Remove(PageID: Integer)
     begin

--- a/Modules/System/Assisted Setup/src/AssistedSetupImpl.Codeunit.al
+++ b/Modules/System/Assisted Setup/src/AssistedSetupImpl.Codeunit.al
@@ -214,6 +214,17 @@ codeunit 1813 "Assisted Setup Impl."
         AssistedSetup.RunModal();
     end;
 
+    procedure Remove(ExtensionID: Guid; PageID: Integer)
+    var
+        AssistedSetup: Record "Assisted Setup";
+    begin
+        if not AssistedSetup.WritePermission() then
+            exit;
+        if not AssistedSetup.Get(PageID) then
+            exit;
+        AssistedSetup.Delete(true);
+    end;
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::Video, 'OnVideoPlayed', '', false, false)]
     local procedure OnVideoPlayed(TableNum: Integer; SystemID: Guid)
     var

--- a/Modules/System/Assisted Setup/src/AssistedSetupImpl.Codeunit.al
+++ b/Modules/System/Assisted Setup/src/AssistedSetupImpl.Codeunit.al
@@ -214,7 +214,7 @@ codeunit 1813 "Assisted Setup Impl."
         AssistedSetup.RunModal();
     end;
 
-    procedure Remove(ExtensionID: Guid; PageID: Integer)
+    procedure Remove(PageID: Integer)
     var
         AssistedSetup: Record "Assisted Setup";
     begin


### PR DESCRIPTION
Procedures to remove deprecated Assisted Setups. 

If the Pages the Assisted Setup record refers to are removed, running the assisted setup will result in a runtime error. 