### PR TITLE
ERiC version 31 is using UTF-8 formatted XML.

### DIFF
--- a/AddOns/Elster/app/src/Reports/REP11016.CreateXMLFileVATAdvNotif.al
+++ b/AddOns/Elster/app/src/Reports/REP11016.CreateXMLFileVATAdvNotif.al
@@ -143,7 +143,7 @@ report 11016 "Create XML-File VAT Adv.Notif."
     begin
         PrepareXmlDoc();
 
-        if not XmlDocument.ReadFrom('<?xml version="1.0" encoding="ISO-8859-15"?>' + '<Elster xmlns="' + XmlNameSpace + '"></Elster>', XmlSubDoc) then
+        if not XmlDocument.ReadFrom('<?xml version="1.0" encoding="UTF-8"?>' + '<Elster xmlns="' + XmlNameSpace + '"></Elster>', XmlSubDoc) then
             Error(XMLDocHasNotBeenCreatedErr);
         XmlSubDoc.GetRoot(XmlRootElem);
         AddTransferHeader(XmlRootElem);


### PR DESCRIPTION
The new version of ELSTER and ERiC (version 31.4.2.0) is only accepting UTF-8 formatted XML files for Sales Adv. VAT Notification. All other parts are absolutly the same, but ISO-xxx XML files are declined.

Just changed to notation in the XML header.