### PR TITLE
Update BREAKINGCHANGES.md

### DIFF
--- a/BREAKINGCHANGES.md
+++ b/BREAKINGCHANGES.md
@@ -119,7 +119,7 @@ SaaS: access the table using the `query 774 "Users in Plans"`.
 **Solution**: Function has been removed. Replacement:
 
 ```
-TempBlob.CreateOutStream(OutStream);
+TempBlob.CreateOutStream(OutStream[, TextEncoding]);
 OutStream.WriteText(Text);
 ```
 


### PR DESCRIPTION
WriteAsText had a TextEncoding overload. I think it's important to show how that can be accomplished as well.