### PR TITLE
Invalid enum for test marker and obsolete authentication switch

### DIFF
--- a/AddOns/Elster/app/src/Pages/PAG11016.SalesVATAdvNotifCard.al
+++ b/AddOns/Elster/app/src/Pages/PAG11016.SalesVATAdvNotifCard.al
@@ -116,11 +116,6 @@ page 11016 "Sales VAT Adv. Notif. Card"
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the VAT statement template name used to calculate the amounts and assign them to the key figures required by the tax authorities.';
                 }
-                field("Use Authentication"; "Use Authentication")
-                {
-                    ApplicationArea = Basic, Suite;
-                    ToolTip = 'Specifies whether to submit signed data to the tax authorities.';
-                }
             }
             group(Communication)
             {

--- a/AddOns/Elster/app/src/Reports/REP11016.CreateXMLFileVATAdvNotif.al
+++ b/AddOns/Elster/app/src/Reports/REP11016.CreateXMLFileVATAdvNotif.al
@@ -273,12 +273,8 @@ report 11016 "Create XML-File VAT Adv.Notif."
             exit;
         if not AddElement(XmlRootElem, XmlElemNew, 'DatenArt', 'UStVA', XmlNameSpace) then
             exit;
-        if UseAuthentication then begin
-            if not AddElement(XmlRootElem, XmlElemNew, 'Vorgang', 'send-Auth', XmlNameSpace) then
-                exit;
-        end else
-            if not AddElement(XmlRootElem, XmlElemNew, 'Vorgang', 'send-NoSig', XmlNameSpace) then
-                exit;
+        if not AddElement(XmlRootElem, XmlElemNew, 'Vorgang', 'send-Auth', XmlNameSpace) then
+            exit;
         if "Sales VAT Advance Notif.".Testversion then
             if not AddElement(XmlRootElem, XmlElemNew, 'Testmerker', '700000004', XmlNameSpace) then
                 exit;

--- a/AddOns/Elster/app/src/Reports/REP11016.CreateXMLFileVATAdvNotif.al
+++ b/AddOns/Elster/app/src/Reports/REP11016.CreateXMLFileVATAdvNotif.al
@@ -12,7 +12,7 @@ report 11016 "Create XML-File VAT Adv.Notif."
     {
         dataitem("Sales VAT Advance Notif."; "Sales VAT Advance Notif.")
         {
-            DataItemTableView = sorting ("No.")
+            DataItemTableView = sorting("No.")
                                 order(Ascending);
 
             trigger OnPreDataItem()
@@ -279,11 +279,8 @@ report 11016 "Create XML-File VAT Adv.Notif."
         end else
             if not AddElement(XmlRootElem, XmlElemNew, 'Vorgang', 'send-NoSig', XmlNameSpace) then
                 exit;
-        if "Sales VAT Advance Notif.".Testversion then begin
+        if "Sales VAT Advance Notif.".Testversion then
             if not AddElement(XmlRootElem, XmlElemNew, 'Testmerker', '700000004', XmlNameSpace) then
-                exit;
-        end else
-            if not AddElement(XmlRootElem, XmlElemNew, 'Testmerker', '000000000', XmlNameSpace) then
                 exit;
         if not AddElement(XmlRootElem, XmlElemNew, 'HerstellerID', ManufacturerID, XmlNameSpace) then
             exit;

--- a/AddOns/Elster/app/src/Tables/TAB11021.SalesVATAdvanceNotif.al
+++ b/AddOns/Elster/app/src/Tables/TAB11021.SalesVATAdvanceNotif.al
@@ -89,7 +89,7 @@ table 11021 "Sales VAT Advance Notif."
         {
             DataClassification = CustomerContent;
             Editable = false;
-            TableRelation = "VAT Statement Name".Name where ("Statement Template Name" = field ("Statement Template Name"));
+            TableRelation = "VAT Statement Name".Name where("Statement Template Name" = field("Statement Template Name"));
 
             trigger OnValidate()
             begin
@@ -209,6 +209,8 @@ table 11021 "Sales VAT Advance Notif."
         field(31; "Use Authentication"; Boolean)
         {
             DataClassification = CustomerContent;
+            ObsoleteState = Removed;
+            ObsoleteReason = 'Authentication is required for electronic transmission.';
 
             trigger OnValidate()
             begin


### PR DESCRIPTION
Implemented two changes in ELSTER / ERiC Add-On:

1. At least in the current version of ELSTER/ERiC it's necessary to send all data in USTVA format (Sales VAT Adv. Notifcation) authenticated. send-NoSig is deprecated and no longer supported for this data format.
2. For sending productive data the created XML is currently creating a XML Node called "Testmerker" with value 000000000. Referring to schema documentation for ELSTER version 11 (V11_V2.23) this is no valid enumeration. Based on the schema documentation this Node is optional and only for testing purpose.