### PR TITLE
Improving Page "Command Line Test Tool" for ALTestRunner.ps1

### DIFF
--- a/Modules/DevTools/TestFramework/TestRunner/src/CommandLineTestTool.Page.al
+++ b/Modules/DevTools/TestFramework/TestRunner/src/CommandLineTestTool.Page.al
@@ -281,6 +281,7 @@ page 130455 "Command Line Test Tool"
         if not GlobalALTestSuite.Get(CurrentSuiteName) then begin
             TestSuiteMgt.CreateTestSuite(CurrentSuiteName);
             Commit();
+            GlobalALTestSuite.Get(CurrentSuiteName);
         end;
 
         GlobalALTestSuite.CalcFields("Tests to Execute");

--- a/Modules/DevTools/TestFramework/TestRunner/src/CommandLineTestTool.Page.al
+++ b/Modules/DevTools/TestFramework/TestRunner/src/CommandLineTestTool.Page.al
@@ -253,6 +253,7 @@ page 130455 "Command Line Test Tool"
     trigger OnOpenPage()
     begin
         SetCurrentTestSuite();
+        ClearAllGlobalVars();
     end;
 
     var
@@ -370,6 +371,15 @@ page 130455 "Command Line Test Tool"
         end;
 
         CurrPage.Update();
+    end;
+
+    local procedure ClearAllGlobalVars()
+    begin
+        Clear(TestCodeunitRangeFilter);
+        Clear(TestRunnerCodeunitId);
+        Clear(ExtensionId);
+        Clear(RemoveTestMethod);
+        Clear(TestResultsJSONText);
     end;
 }
 

--- a/Modules/DevTools/TestFramework/TestRunner/src/CommandLineTestTool.Page.al
+++ b/Modules/DevTools/TestFramework/TestRunner/src/CommandLineTestTool.Page.al
@@ -9,6 +9,7 @@ page 130455 "Command Line Test Tool"
     DeleteAllowed = true;
     ModifyAllowed = true;
     PageType = Worksheet;
+    SaveValues = true;
     SourceTable = "Test Method Line";
     UsageCategory = Administration;
 


### PR DESCRIPTION
**Running Tests using the ALTestRunner.ps1**
Currently it is not possible to run a specific test suite using the ALTestRunner PowerShell Script, if you have more than one test suite (and the test suite you want to run is not the first one).
The PowerShell script “ALTestRunnerInternal.ps1” opens the CommandLineTestTool.page, selects the test suite you have specified within the script and closes the page afterwards (function Setup-TestRun, line no 124). 
Later on the test page will be opened again to run the tests (function Run-NextTest, line no 163). 
The problem is, that the previously selected test suite never gets saved and so you won’t be able to run any tests within a different test suite than the first one. 

If the property “SaveValues = true” is added to the Page 130455 “Command Line Test Tool”, the selected test suite is saved and the correct test suite will be executed. 
