### PR TITLE
Set TestRunnerDisplayName after Lookup Test Runner

### DIFF
--- a/Modules/DevTools/TestFramework/TestRunner/src/ALTestTool.Page.al
+++ b/Modules/DevTools/TestFramework/TestRunner/src/ALTestTool.Page.al
@@ -304,6 +304,7 @@ page 130451 "AL Test Tool"
                         TestSuiteMgt: Codeunit "Test Suite Mgt.";
                     begin
                         TestSuiteMgt.LookupTestRunner(GlobalALTestSuite);
+                        TestRunnerDisplayName := TestSuiteMgt.GetTestRunnerDisplayName(GlobalALTestSuite);
                     end;
                 }
             }


### PR DESCRIPTION
After selecting a Test Runner in the AL Test Tool the displayed name is not updated.