### PR TITLE
Publisher OnBeforeGetCustomizedCueStyleOption in Codeunit 9702

### DIFF
--- a/Modules/System/Cues and KPIs/src/CuesAndKPIs.Codeunit.al
+++ b/Modules/System/Cues and KPIs/src/CuesAndKPIs.Codeunit.al
@@ -100,6 +100,7 @@ codeunit 9701 "Cues And KPIs"
     /// </summary>
     /// <param name="TableID">The ID of the table where the cue is defined.</param>
     /// <param name="FieldNo">The ID of the field which the cue is based on.</param>
+    /// <param name="CueValue">Cue value parameter that can be used to determine cue style.</param>
     /// <param name="CueStyle">Exit parameter that holds newly determined cue style based on custom prerequisites.</param>
     /// <param name="Resolved">A boolean value that describes whether or not the cue style has been determined.</param>
     [IntegrationEvent(false, false)]

--- a/Modules/System/Cues and KPIs/src/CuesAndKPIs.Codeunit.al
+++ b/Modules/System/Cues and KPIs/src/CuesAndKPIs.Codeunit.al
@@ -94,8 +94,16 @@ codeunit 9701 "Cues And KPIs"
     begin
     end;
 
+    /// <summary>
+    /// Event that allows definition of cue style for a cue using style enum without the usage of a cue setup table.
+    /// Subscribe to this event if you want to define a cue style for a cue using custom prerequisites.
+    /// </summary>
+    /// <param name="TableID">The ID of the table where the cue is defined.</param>
+    /// <param name="FieldNo">The ID of the field which the cue is based on.</param>
+    /// <param name="CueStyle">Exit parameter that holds newly determined cue style based on custom prerequisites.</param>
+    /// <param name="Resolved">A boolean value that describes whether or not the cue style has been determined.</param>
     [IntegrationEvent(false, false)]
-    procedure OnBeforeGetCustomizedCueStyleOption(TableId: Integer; FieldNo: Integer; CueValue: Decimal; var Style: Enum "Cues And KPIs Style"; var Handled: Boolean)
+    procedure OnBeforeGetCustomizedCueStyleOption(TableID: Integer; FieldNo: Integer; CueValue: Decimal; var CueStyle: Enum "Cues And KPIs Style"; var Resolved: Boolean)
     begin
     end;
 }

--- a/Modules/System/Cues and KPIs/src/CuesAndKPIs.Codeunit.al
+++ b/Modules/System/Cues and KPIs/src/CuesAndKPIs.Codeunit.al
@@ -93,4 +93,9 @@ codeunit 9701 "Cues And KPIs"
     internal procedure OnConvertStyleToStyleText(CueStyle: Enum "Cues And KPIs Style"; var Result: Text; var Resolved: Boolean)
     begin
     end;
+
+    [IntegrationEvent(false, false)]
+    procedure OnBeforeGetCustomizedCueStyleOption(TableId: Integer; FieldNo: Integer; CueValue: Decimal; var Style: Enum "Cues And KPIs Style"; var Handled: Boolean)
+    begin
+    end;
 }

--- a/Modules/System/Cues and KPIs/src/CuesAndKPIsImpl.Codeunit.al
+++ b/Modules/System/Cues and KPIs/src/CuesAndKPIsImpl.Codeunit.al
@@ -121,7 +121,12 @@ codeunit 9702 "Cues And KPIs Impl."
     local procedure GetCustomizedCueStyleOption(TableId: Integer; FieldNo: Integer; CueValue: Decimal): Integer
     var
         CueSetup: Record "Cue Setup";
+        Style: Enum "Cues And KPIs Style";
+        Handled: Boolean;
     begin
+        OnBeforeGetCustomizedCueStyleOption(TableId, FieldNo, CueValue, Style, Handled);
+        if Handled then
+            exit(Style);
         FindCueSetup(CueSetup, TableId, FieldNo);
         if CueValue < CueSetup."Threshold 1" then
             exit(CueSetup."Low Range Style");
@@ -258,5 +263,10 @@ codeunit 9702 "Cues And KPIs Impl."
               WrongThresholdsErr,
               CueSetup.FieldCaption("Threshold 2"),
               CueSetup.FieldCaption("Threshold 1"));
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeGetCustomizedCueStyleOption(TableId: Integer; FieldNo: Integer; CueValue: Decimal; var Style: Enum "Cues And KPIs Style"; var Handled: Boolean)
+    begin
     end;
 }

--- a/Modules/System/Cues and KPIs/src/CuesAndKPIsImpl.Codeunit.al
+++ b/Modules/System/Cues and KPIs/src/CuesAndKPIsImpl.Codeunit.al
@@ -121,11 +121,11 @@ codeunit 9702 "Cues And KPIs Impl."
     local procedure GetCustomizedCueStyleOption(TableId: Integer; FieldNo: Integer; CueValue: Decimal): Integer
     var
         CueSetup: Record "Cue Setup";
-        Style: Enum "Cues And KPIs Style";
-        Handled: Boolean;
+        CueStyle: Enum "Cues And KPIs Style";
+        Resolved: Boolean;
     begin
-        CuesAndKPIs.OnBeforeGetCustomizedCueStyleOption(TableId, FieldNo, CueValue, Style, Handled);
-        if Handled then
+        CuesAndKPIs.OnBeforeGetCustomizedCueStyleOption(TableID, FieldNo, CueValue, CueStyle, Resolved);
+        if Resolved then
             exit(Style);
         FindCueSetup(CueSetup, TableId, FieldNo);
         if CueValue < CueSetup."Threshold 1" then

--- a/Modules/System/Cues and KPIs/src/CuesAndKPIsImpl.Codeunit.al
+++ b/Modules/System/Cues and KPIs/src/CuesAndKPIsImpl.Codeunit.al
@@ -126,7 +126,7 @@ codeunit 9702 "Cues And KPIs Impl."
     begin
         CuesAndKPIs.OnBeforeGetCustomizedCueStyleOption(TableID, FieldNo, CueValue, CueStyle, Resolved);
         if Resolved then
-            exit(Style);
+            exit(CueStyle);
         FindCueSetup(CueSetup, TableId, FieldNo);
         if CueValue < CueSetup."Threshold 1" then
             exit(CueSetup."Low Range Style");

--- a/Modules/System/Cues and KPIs/src/CuesAndKPIsImpl.Codeunit.al
+++ b/Modules/System/Cues and KPIs/src/CuesAndKPIsImpl.Codeunit.al
@@ -124,7 +124,7 @@ codeunit 9702 "Cues And KPIs Impl."
         Style: Enum "Cues And KPIs Style";
         Handled: Boolean;
     begin
-        OnBeforeGetCustomizedCueStyleOption(TableId, FieldNo, CueValue, Style, Handled);
+        CuesAndKPIs.OnBeforeGetCustomizedCueStyleOption(TableId, FieldNo, CueValue, Style, Handled);
         if Handled then
             exit(Style);
         FindCueSetup(CueSetup, TableId, FieldNo);
@@ -263,10 +263,5 @@ codeunit 9702 "Cues And KPIs Impl."
               WrongThresholdsErr,
               CueSetup.FieldCaption("Threshold 2"),
               CueSetup.FieldCaption("Threshold 1"));
-    end;
-
-    [IntegrationEvent(false, false)]
-    local procedure OnBeforeGetCustomizedCueStyleOption(TableId: Integer; FieldNo: Integer; CueValue: Decimal; var Style: Enum "Cues And KPIs Style"; var Handled: Boolean)
-    begin
     end;
 }


### PR DESCRIPTION
With this change it is possible to dynamically decide on the Cue Style using enum "Cues And KPIs Style" but regardless of the the decimal Cue Value. 

Explanation: The Cue should be shown in red if there are some rejected entries behind the Document Count.

Example: The Cue shows Number 10 indicating that there are 10 Documents involved. Out of those 10 any or all of those 10 could be critical or marked as rejected and needs checking out first. So only in this case the Cue should have a Style 'Unfavorable'.
