### PR TITLE
Add logic to give better Error Message

### DIFF
--- a/Modules/System/XML Validation/src/dotnet.al
+++ b/Modules/System/XML Validation/src/dotnet.al
@@ -5,6 +5,8 @@ dotnet
         Culture = 'neutral';
         PublicKeyToken = 'b77a5c561934e089';
 
-        type("System.Xml.XmlValidatingReader"; "XmlValidatingReader") { }
+        type("System.Xml.Schema.ValidationEventHandler"; "ValidationEventHandler") { }
+        type("System.Xml.Schema.XmlSchemaSet"; "XmlSchemaSet") { }
+        type("System.Xml.Schema.XmlSchemaValidationException"; "XmlSchemaValidationException") { }
     }
 }

--- a/Modules/System/XML Validation/src/dotnet.al
+++ b/Modules/System/XML Validation/src/dotnet.al
@@ -1,0 +1,10 @@
+dotnet
+{
+    assembly("System.Xml")
+    {
+        Culture = 'neutral';
+        PublicKeyToken = 'b77a5c561934e089';
+
+        type("System.Xml.XmlValidatingReader"; "XmlValidatingReader") { }
+    }
+}


### PR DESCRIPTION
When the TryValidateAgainstSchema function was used in combination with the GetLastErrorText functionality, the error message was unclear. The actual validation error was not displayed. 

For example:

![image](https://user-images.githubusercontent.com/48217797/83132254-67560d80-a0e1-11ea-96ce-8a3d07d31fdd.png)

These code modifications ensure the actual validation error is shown:

![image](https://user-images.githubusercontent.com/48217797/83132489-c582f080-a0e1-11ea-8ea9-720ce916296c.png)


