### PR TITLE
Fixed Error: text overflow for Customer Party Name

### DIFF
--- a/AddOns/OIOUBL/app/src/Management/COD13648.CommonLogic.al
+++ b/AddOns/OIOUBL/app/src/Management/COD13648.CommonLogic.al
@@ -188,7 +188,7 @@ codeunit 13648 "OIOUBL-Common Logic"
         InvoiceElement.Add(AccountingSupplierPartyElement);
     end;
 
-    Local procedure InsertCustomerParty(var AccountingCustomerParty: XmlElement; GLN: Code[13]; VATRegNo: Text[20]; PartyName: Text[50]; PostalAddress: Record "Standard Address"; PartyContact: Record Contact);
+    Local procedure InsertCustomerParty(var AccountingCustomerParty: XmlElement; GLN: Code[13]; VATRegNo: Text[20]; PartyName: Text[100]; PostalAddress: Record "Standard Address"; PartyContact: Record Contact);
     var
         PartyElement: XmlElement;
     begin
@@ -211,7 +211,7 @@ codeunit 13648 "OIOUBL-Common Logic"
         AccountingCustomerParty.Add(PartyElement);
     end;
 
-    procedure InsertAccountingCustomerParty(var InvoiceElement: XmlElement; GLN: Code[13]; VATRegNo: Text[20]; PartyName: Text[50]; PostalAddress: Record "Standard Address"; PartyContact: Record Contact);
+    procedure InsertAccountingCustomerParty(var InvoiceElement: XmlElement; GLN: Code[13]; VATRegNo: Text[20]; PartyName: Text[100]; PostalAddress: Record "Standard Address"; PartyContact: Record Contact);
     var
         AccountingCustomerParty: XmlElement;
     begin


### PR DESCRIPTION
Hi Microsoft

I've found a possible text overflow for the customer party name and have had the error manifested at a customer - and because of that made a fix for it. 

Cheers, 
Rasmus Torpe