### PR TITLE
Any.DecimalInRange fixed

### DIFF
--- a/Modules/DevTools/TestFramework/TestLibraries/Any/src/Any.Codeunit.al
+++ b/Modules/DevTools/TestFramework/TestLibraries/Any/src/Any.Codeunit.al
@@ -44,8 +44,17 @@ codeunit 130500 "Any"
     /// <param name="DecimalPlaces">Number of decimal places</param>
     /// <returns>Pseudo-random decimal value</returns>
     procedure DecimalInRange(MaxValue: Integer; DecimalPlaces: Integer): Decimal
+    var
+        x: Integer;
+        Pow: Integer;
     begin
-        exit(IntegerInRange(MaxValue * Power(10, DecimalPlaces)) / Power(10, DecimalPlaces));
+        Pow := Power(10, DecimalPlaces);
+
+        x := IntegerInRange(MaxValue * Pow);
+        if x mod 10 = 0 then
+            x += IntegerInRange(1, 9);
+
+        exit(x / Pow);
     end;
 
     /// <summary>


### PR DESCRIPTION
Sometimes `Any.DecimalInRange` returned a decimal number, whose No. of decimal places did not equal the parameter.
This now has been fixed in accordance with @nikolakukrika. It should be ported afterwards to library random.

The variable name `pow` has been chosen in accordance to `procedure DecimalInRange(MinValue: Decimal; MaxValue: Decimal; DecimalPlaces: Integer): Decimal`.

I am unsure, but it looks like `procedure DecimalInRange(MinValue: Decimal; MaxValue: Decimal; DecimalPlaces: Integer): Decimal` might need a fix as well.

Please refer to https://www.yammer.com/dynamicsnavdev/threads/857565538000896 for further information.