### PR TITLE
Added the Salt parameter to EncryptStream + DecryptStream

### DIFF
--- a/Modules/System Tests/Cryptography Management/src/DESCryptoServiceProviderTest.Codeunit.al
+++ b/Modules/System Tests/Cryptography Management/src/DESCryptoServiceProviderTest.Codeunit.al
@@ -46,6 +46,7 @@ codeunit 132588 "DESCryptoServiceProvider Test"
         LibraryAssert.AreEqual(ExpectedDecryptedText, DecryptedText, 'Unexpected value when decrypting text using DESCryptoServiceProvider');
     end;
 
+    [Test]
     procedure TestEncryptStream()
     var
         DESCryptoServiceProvider: Codeunit "DESCryptoServiceProvider Impl.";
@@ -82,6 +83,7 @@ codeunit 132588 "DESCryptoServiceProvider Test"
         LibraryAssert.AreEqual(ExpectedEncryptedText, EncryptedStreamText, 'Unexpected value when decrypting stream using DESCryptoServiceProvider');
     end;
 
+    [Test]
     procedure TestDecryptStream()
     var
         DESCryptoServiceProvider: Codeunit "DESCryptoServiceProvider Impl.";

--- a/Modules/System Tests/Cryptography Management/src/DESCryptoServiceProviderTest.Codeunit.al
+++ b/Modules/System Tests/Cryptography Management/src/DESCryptoServiceProviderTest.Codeunit.al
@@ -73,7 +73,7 @@ codeunit 132588 "DESCryptoServiceProvider Test"
         TempBlob.Blob.CreateOutStream(OutputOutstream);
 
         // [WHEN] Encrypt Stream
-        DESCryptoServiceProvider.EncryptStreamWithDESCryptoServiceProvider(Password, InputInstream, OutputOutstream);
+        DESCryptoServiceProvider.EncryptStreamWithDESCryptoServiceProvider(Password, Salt, InputInstream, OutputOutstream);
 
         TempBlob.Blob.CreateInStream(OutputInstream);
         EncryptedStreamText := Base64Convert.ToBase64(OutputInstream);

--- a/Modules/System Tests/Cryptography Management/src/DESCryptoServiceProviderTest.Codeunit.al
+++ b/Modules/System Tests/Cryptography Management/src/DESCryptoServiceProviderTest.Codeunit.al
@@ -46,4 +46,77 @@ codeunit 132588 "DESCryptoServiceProvider Test"
         LibraryAssert.AreEqual(ExpectedDecryptedText, DecryptedText, 'Unexpected value when decrypting text using DESCryptoServiceProvider');
     end;
 
+    procedure TestEncryptStream()
+    var
+        DESCryptoServiceProvider: Codeunit "DESCryptoServiceProvider Impl.";
+        LibraryAssert: Codeunit "Library Assert";
+        InputInstream: InStream;
+        OutputOutstream: Outstream;
+        OutputInstream: InStream;
+        Base64Convert: Codeunit "Base64 Convert";
+        TempBlob: Record TempBlob temporary;
+        Pixel: Text;
+        ExpectedEncryptedText: Text;
+        EncryptedStreamText: Text;
+        Password: Text;
+        Salt: Text;
+    begin
+        // [GIVEN] With Encryption Key
+        ExpectedEncryptedText := 'xkSRTuW2xetrKER7vZiWFxrUU0I86+69aWshKgRxiLdGI8CvfreYzsBa+OIvneALcgJfZeGp5XTmJ4tFkUUXts5JuzoxFoVn';
+        Password := 'Test1234';
+        Salt := 'Test1234';
+        Pixel := 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+
+        TempBlob.Blob.CreateOutStream(OutputOutstream);
+        Base64Convert.FromBase64(Pixel, OutputOutstream);
+        TempBlob.Blob.CreateInStream(InputInstream);
+        TempBlob.Blob.CreateOutStream(OutputOutstream);
+
+        // [WHEN] Encrypt Stream
+        DESCryptoServiceProvider.EncryptStreamWithDESCryptoServiceProvider(Password, InputInstream, OutputOutstream);
+
+        TempBlob.Blob.CreateInStream(OutputInstream);
+        EncryptedStreamText := Base64Convert.ToBase64(OutputInstream);
+
+        // [THEN] Verify Result 
+        LibraryAssert.AreEqual(ExpectedEncryptedText, EncryptedStreamText, 'Unexpected value when decrypting stream using DESCryptoServiceProvider');
+    end;
+
+    procedure TestDecryptStream()
+    var
+        DESCryptoServiceProvider: Codeunit "DESCryptoServiceProvider Impl.";
+        Base64Convert: Codeunit "Base64 Convert";
+        LibraryAssert: Codeunit "Library Assert";
+        TempBlob: Record "Temp Blob" temporary;
+        OutputOutstream: Outstream;
+        OutputInstream: InStream;
+        EncryptedStreamText: Text;
+        DecryptedStreamText: Text;
+        ExpectedDecryptedStreamText: Text;
+        Password: Text;
+        Salt: Text;
+        DecryptedText: Text;
+        InputInstream: InStream;
+    begin
+        // [GIVEN] With Encryption Key
+        EncryptedStreamText := 'xkSRTuW2xetrKER7vZiWFxrUU0I86+69aWshKgRxiLdGI8CvfreYzsBa+OIvneALcgJfZeGp5XTmJ4tFkUUXts5JuzoxFoVn';
+        Password := 'Test1234';
+        Salt := 'Test1234';
+        ExpectedDecryptedStreamText := 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+
+        TempBlob.Blob.CreateOutStream(OutputOutstream);
+        Base64Convert.FromBase64(EncryptedStreamText, OutputOutstream);
+        TempBlob.Blob.CreateInStream(InputInstream);
+        TempBlob.Blob.CreateOutStream(OutputOutstream);
+
+        // [WHEN] Decrypt Stream
+        DESCryptoServiceProvider.DecryptStreamWithDESCryptoServiceProvider(Password, Salt, InputInstream, OutputOutstream);
+
+        // [THEN] Verify Result 
+        TempBlob.Blob.CreateInStream(OutputInstream);
+        DecryptedStreamText := Base64Convert.ToBase64(OutputInstream);
+
+        LibraryAssert.AreEqual(ExpectedDecryptedStreamText, DecryptedStreamText, 'Unexpected value when decrypting stream text using DESCryptoServiceProvider');
+    end;
+
 }

--- a/Modules/System/Cryptography Management/src/DESCryptoServiceProvider.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/DESCryptoServiceProvider.Codeunit.al
@@ -49,7 +49,7 @@ codeunit 1379 DESCryptoServiceProvider
     /// <param name="InputInstream">Represents the input instream data to encrypt</param>
     /// <param name="OutputOutstream">Represents the output instream encrypted data</param>
     [NonDebuggable]
-    [Obsolete('(<Removed>,<Add the salt parameter to continue using this function)>')]
+    [Obsolete('(Removed,Add the salt parameter to continue using this function)')]
     procedure EncryptStream(Password: Text; InputInstream: InStream; var OutputOutstream: Outstream)
     begin
         DESCryptoServiceProviderImpl.EncryptStream(Password, InputInstream, OutputOutstream);
@@ -62,7 +62,7 @@ codeunit 1379 DESCryptoServiceProvider
     /// <param name="InputInstream">Represents the input instream data to decrypt</param>
     /// <param name="OutputOutstream">Represents the output instream decrypted data</param>
     [NonDebuggable]
-    [Obsolete('(<Removed>,<Add the salt parameter to continue using this function)>')]
+    [Obsolete('(Removed,Add the salt parameter to continue using this function)')]
     procedure DecryptStream(Password: Text; InputInstream: InStream; var OutputOutstream: Outstream)
     begin
         DESCryptoServiceProviderImpl.DecryptStream(Password, InputInstream, OutputOutstream);

--- a/Modules/System/Cryptography Management/src/DESCryptoServiceProvider.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/DESCryptoServiceProvider.Codeunit.al
@@ -47,23 +47,25 @@ codeunit 1379 DESCryptoServiceProvider
     /// Encrypts data in stream with DotNet Cryptography.DESCryptoServiceProvider
     /// </summary>
     /// <param name="Password">Represents the password to be used to initialize a new instance of Rfc2898DeriveBytes</param>
+    /// <param name="Salt">Represents the salt to be used to initialize a new instance of System.Security.Cryptography.Rfc2898DeriveBytes</param>
     /// <param name="InputInstream">Represents the input instream data to encrypt</param>
     /// <param name="OutputOutstream">Represents the output instream encrypted data</param>
     [NonDebuggable]
-    procedure EncryptStream(Password: Text; InputInstream: InStream; var OutputOutstream: Outstream)
+    procedure EncryptStream(Password: Text; Salt: Text; InputInstream: InStream; var OutputOutstream: Outstream)
     begin
-        DESCryptoServiceProviderImpl.EncryptStream(Password, InputInstream, OutputOutstream);
+        DESCryptoServiceProviderImpl.EncryptStream(Password, Salt, InputInstream, OutputOutstream);
     end;
 
     /// <summary>
     /// Decrypts data in stream with DotNet Cryptography.DESCryptoServiceProvider
     /// </summary>
     /// <param name="Password">Represents the password to be used to initialize a new instance of Rfc2898DeriveBytes</param>
+    /// <param name="Salt">Represents the salt to be used to initialize a new instance of System.Security.Cryptography.Rfc2898DeriveBytes</param>
     /// <param name="InputInstream">Represents the input instream data to decrypt</param>
     /// <param name="OutputOutstream">Represents the output instream decrypted data</param>
     [NonDebuggable]
-    procedure DecryptStream(Password: Text; InputInstream: InStream; var OutputOutstream: Outstream)
+    procedure DecryptStream(Password: Text; Salt: Text; InputInstream: InStream; var OutputOutstream: Outstream)
     begin
-        DESCryptoServiceProviderImpl.DecryptStream(Password, InputInstream, OutputOutstream);
+        DESCryptoServiceProviderImpl.DecryptStream(Password, Salt, InputInstream, OutputOutstream);
     end;
 }

--- a/Modules/System/Cryptography Management/src/DESCryptoServiceProvider.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/DESCryptoServiceProvider.Codeunit.al
@@ -42,6 +42,31 @@ codeunit 1379 DESCryptoServiceProvider
         DecryptedText := DESCryptoServiceProviderImpl.DecryptText(EncryptedText, Password, Salt);
     end;
 
+    /// <summary>
+    /// Encrypts data in stream with DotNet Cryptography.DESCryptoServiceProvider
+    /// </summary>
+    /// <param name="Password">Represents the password to be used to initialize a new instance of Rfc2898DeriveBytes</param>
+    /// <param name="InputInstream">Represents the input instream data to encrypt</param>
+    /// <param name="OutputOutstream">Represents the output instream encrypted data</param>
+    [NonDebuggable]
+    [Obsolete('(<Removed>,<Add the salt parameter to continue using this function)>')]
+    procedure EncryptStream(Password: Text; InputInstream: InStream; var OutputOutstream: Outstream)
+    begin
+        DESCryptoServiceProviderImpl.EncryptStream(Password, InputInstream, OutputOutstream);
+    end;
+
+    /// <summary>
+    /// Decrypts data in stream with DotNet Cryptography.DESCryptoServiceProvider
+    /// </summary>
+    /// <param name="Password">Represents the password to be used to initialize a new instance of Rfc2898DeriveBytes</param>
+    /// <param name="InputInstream">Represents the input instream data to decrypt</param>
+    /// <param name="OutputOutstream">Represents the output instream decrypted data</param>
+    [NonDebuggable]
+    [Obsolete('(<Removed>,<Add the salt parameter to continue using this function)>')]
+    procedure DecryptStream(Password: Text; InputInstream: InStream; var OutputOutstream: Outstream)
+    begin
+        DESCryptoServiceProviderImpl.DecryptStream(Password, InputInstream, OutputOutstream);
+    end;
 
     /// <summary>
     /// Encrypts data in stream with DotNet Cryptography.DESCryptoServiceProvider

--- a/Modules/System/Cryptography Management/src/DESCryptoServiceProvider.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/DESCryptoServiceProvider.Codeunit.al
@@ -52,7 +52,7 @@ codeunit 1379 DESCryptoServiceProvider
     [Obsolete('(Removed,Add the salt parameter to continue using this function)')]
     procedure EncryptStream(Password: Text; InputInstream: InStream; var OutputOutstream: Outstream)
     begin
-        DESCryptoServiceProviderImpl.EncryptStream(Password, InputInstream, OutputOutstream);
+        DESCryptoServiceProviderImpl.EncryptStream(Password, Password, InputInstream, OutputOutstream);
     end;
 
     /// <summary>
@@ -65,7 +65,7 @@ codeunit 1379 DESCryptoServiceProvider
     [Obsolete('(Removed,Add the salt parameter to continue using this function)')]
     procedure DecryptStream(Password: Text; InputInstream: InStream; var OutputOutstream: Outstream)
     begin
-        DESCryptoServiceProviderImpl.DecryptStream(Password, InputInstream, OutputOutstream);
+        DESCryptoServiceProviderImpl.DecryptStream(Password, Password, InputInstream, OutputOutstream);
     end;
 
     /// <summary>

--- a/Modules/System/Cryptography Management/src/DESCryptoServiceProviderImpl.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/DESCryptoServiceProviderImpl.Codeunit.al
@@ -40,7 +40,7 @@ codeunit 1382 "DESCryptoServiceProvider Impl."
     end;
 
     [NonDebuggable]
-    procedure EncryptStream(Password: Text; InputInstream: InStream; VAR OutputOutstream: Outstream)
+    procedure EncryptStream(Password: Text; Salt: Text; InputInstream: InStream; VAR OutputOutstream: Outstream)
     var
         MemoryStream: DotNet MemoryStream;
         ByteArray: DotNet Array;
@@ -48,7 +48,7 @@ codeunit 1382 "DESCryptoServiceProvider Impl."
     begin
         InStreamToArray(InputInstream, ByteArray);
 
-        ConstructDESCryptoServiceProvider(SymmetricAlgorithm, Password, Password);
+        ConstructDESCryptoServiceProvider(SymmetricAlgorithm, Password, Salt);
         TransformToArray(SymmetricAlgorithm.CreateEncryptor(), ByteArray);
 
         MemoryStream := MemoryStream.MemoryStream(ByteArray);
@@ -56,14 +56,14 @@ codeunit 1382 "DESCryptoServiceProvider Impl."
     end;
 
     [NonDebuggable]
-    procedure DecryptStream(Password: Text; InputInstream: InStream; var OutputOutstream: Outstream)
+    procedure DecryptStream(Password: Text; Salt: Text; InputInstream: InStream; var OutputOutstream: Outstream)
     var
         MemoryStream: DotNet MemoryStream;
         ByteArray: DotNet Array;
         SymmetricAlgorithm: DotNet "Cryptography.SymmetricAlgorithm";
     begin
         InStreamToArray(InputInstream, ByteArray);
-        ConstructDESCryptoServiceProvider(SymmetricAlgorithm, Password, Password);
+        ConstructDESCryptoServiceProvider(SymmetricAlgorithm, Password, Salt);
         TransformToArray(SymmetricAlgorithm.CreateDecryptor(), ByteArray);
 
         MemoryStream := MemoryStream.MemoryStream(ByteArray);


### PR DESCRIPTION
Hi @PredragMaricic and @JesperSchulz,

I added the Salt to the EncryptStream + DecryptStream. Can you please review these and merge the changes to both BC15 and BC16?

I saw the test functions for these two were also missing here in Github, but I did provide them earlier to @PredragMaricic by e-mail, so they should be in your own repository. I did add the salt in the test functions as well. 