### PR TITLE
Issue #9905 - ERiC 33.2.x Support (2021 Sales VAT Adv. Notifications)

### DIFF
--- a/Apps/DE/Elster/app/src/Reports/CreateXMLFileVATAdvNotif.Report.al
+++ b/Apps/DE/Elster/app/src/Reports/CreateXMLFileVATAdvNotif.Report.al
@@ -127,6 +127,7 @@ report 11016 "Create XML-File VAT Adv.Notif."
         ElsterTok: Label 'ElsterTelemetryCategoryTok', Locked = true;
         CreateXMLFileMsg: Label 'Creating XML file', Locked = true;
         CreateXMLFileSuccessMsg: Label 'XML file created successfully', Locked = true;
+        AnmeldungssteuernXmlNameSpaceTxt: Label 'http://finkonsens.de/elster/elsteranmeldung/ustva/v%1', Locked = true;
         Window: Dialog;
         SubsequentAction: Option "Only create","Create and export";
         TaxAmount: array[100] of Decimal;
@@ -373,37 +374,65 @@ report 11016 "Create XML-File VAT Adv.Notif."
         if not AddElement(XmlRootElem, XmlElemNew, 'Nutzdaten', '', XmlNameSpace) then
             exit;
         XmlRootElem := XmlElemNew;
-        if not AddElement(XmlRootElem, XmlElemNew, 'Anmeldungssteuern', '', XmlNameSpace) then
-            exit;
-        XmlRootElem := XmlElemNew;
-        if not XmlRootElem.Add(XmlAttribute.Create('art', 'UStVA')) then
-            exit;
-        if ("Sales VAT Advance Notif."."Starting Date" >= DMY2Date(1, 7, 2011)) and
-           ("Sales VAT Advance Notif."."Starting Date" <= DMY2Date(31, 12, 2011))
-        then
-            NotificationVersion := '02'
-        else
-            NotificationVersion := '01';
-        if not XmlRootElem.Add(XmlAttribute.Create('version', Format(Date2DMY("Sales VAT Advance Notif."."Starting Date", 3)) + NotificationVersion)) then
-            exit;
-        if not AddElement(XmlRootElem, XmlElemNew, 'DatenLieferant', '', XmlNameSpace) then
-            exit;
-        XmlRootElem := XmlElemNew;
-        if not AddElement(XmlRootElem, XmlElemNew, 'Name', ContactForTaxOffice, XmlNameSpace) then
-            exit;
-        if CompanyInfo.Address <> '' then begin
-            if not AddElement(XmlRootElem, XmlElemNew, 'Strasse', CompanyInfo.Address, XmlNameSpace) then
+        if ("Sales VAT Advance Notif."."Starting Date" <= DMY2Date(31, 12, 2020)) then begin
+            if not AddElement(XmlRootElem, XmlElemNew, 'Anmeldungssteuern', '', XmlNameSpace) then
                 exit;
-        end else
-            if not AddElement(XmlRootElem, XmlElemNew, 'Strasse', CompanyInfo."Address 2", XmlNameSpace) then
+            XmlRootElem := XmlElemNew;
+            if not XmlRootElem.Add(XmlAttribute.Create('art', 'UStVA')) then
                 exit;
-        if not AddElement(XmlRootElem, XmlElemNew, 'PLZ', CompanyInfo."Post Code", XmlNameSpace) then
-            exit;
-        if not AddElement(XmlRootElem, XmlElemNew, 'Ort', CompanyInfo.City, XmlNameSpace) then
-            exit;
-        XmlRootElem.GetParent(XmlRootElem);
-        if not AddElement(XmlRootElem, XmlElemNew, 'Erstellungsdatum', Format(Today(), 0, '<year4><month,2><day,2>'), XmlNameSpace) then
-            exit;
+            if ("Sales VAT Advance Notif."."Starting Date" >= DMY2Date(1, 7, 2011)) and
+               ("Sales VAT Advance Notif."."Starting Date" <= DMY2Date(31, 12, 2011))
+            then
+                NotificationVersion := '02'
+            else
+                NotificationVersion := '01';
+            if not XmlRootElem.Add(XmlAttribute.Create('version', Format(Date2DMY("Sales VAT Advance Notif."."Starting Date", 3)) + NotificationVersion)) then
+                exit;
+            if not AddElement(XmlRootElem, XmlElemNew, 'DatenLieferant', '', XmlNameSpace) then
+                exit;
+            XmlRootElem := XmlElemNew;
+            if not AddElement(XmlRootElem, XmlElemNew, 'Name', ContactForTaxOffice, XmlNameSpace) then
+                exit;
+            if CompanyInfo.Address <> '' then begin
+                if not AddElement(XmlRootElem, XmlElemNew, 'Strasse', CompanyInfo.Address, XmlNameSpace) then
+                    exit;
+            end else
+                if not AddElement(XmlRootElem, XmlElemNew, 'Strasse', CompanyInfo."Address 2", XmlNameSpace) then
+                    exit;
+            if not AddElement(XmlRootElem, XmlElemNew, 'PLZ', CompanyInfo."Post Code", XmlNameSpace) then
+                exit;
+            if not AddElement(XmlRootElem, XmlElemNew, 'Ort', CompanyInfo.City, XmlNameSpace) then
+                exit;
+            XmlRootElem.GetParent(XmlRootElem);
+            if not AddElement(XmlRootElem, XmlElemNew, 'Erstellungsdatum', Format(Today(), 0, '<year4><month,2><day,2>'), XmlNameSpace) then
+                exit;
+        end else begin
+            if not AddElement(XmlRootElem, XmlElemNew, 'Anmeldungssteuern', '', XmlNameSpace) then
+                exit;
+            XmlRootElem := XmlElemNew;
+            if not XmlRootElem.Add(XmlAttribute.Create('xmlns', StrSubstNo(AnmeldungssteuernXmlNameSpaceTxt, Date2DMY("Sales VAT Advance Notif."."Starting Date", 3)))) then
+                exit;
+            if not XmlRootElem.Add(XmlAttribute.Create('version', Format(Date2DMY("Sales VAT Advance Notif."."Starting Date", 3)))) then
+                exit;
+            if not AddElement(XmlRootElem, XmlElemNew, 'Erstellungsdatum', Format(Today(), 0, '<year4><month,2><day,2>'), XmlNameSpace) then
+                exit;
+            if not AddElement(XmlRootElem, XmlElemNew, 'DatenLieferant', '', XmlNameSpace) then
+                exit;
+            XmlRootElem := XmlElemNew;
+            if not AddElement(XmlRootElem, XmlElemNew, 'Name', ContactForTaxOffice, XmlNameSpace) then
+                exit;
+            if CompanyInfo.Address <> '' then begin
+                if not AddElement(XmlRootElem, XmlElemNew, 'Strasse', CompanyInfo.Address, XmlNameSpace) then
+                    exit;
+            end else
+                if not AddElement(XmlRootElem, XmlElemNew, 'Strasse', CompanyInfo."Address 2", XmlNameSpace) then
+                    exit;
+            if not AddElement(XmlRootElem, XmlElemNew, 'PLZ', CompanyInfo."Post Code", XmlNameSpace) then
+                exit;
+            if not AddElement(XmlRootElem, XmlElemNew, 'Ort', CompanyInfo.City, XmlNameSpace) then
+                exit;
+            XmlRootElem.GetParent(XmlRootElem);
+        end;
         if not AddElement(XmlRootElem, XmlElemNew, 'Steuerfall', '', XmlNameSpace) then
             exit;
         XmlRootElem := XmlElemNew;

--- a/Apps/DE/Elster/app/src/Reports/CreateXMLFileVATAdvNotif.Report.al
+++ b/Apps/DE/Elster/app/src/Reports/CreateXMLFileVATAdvNotif.Report.al
@@ -127,12 +127,12 @@ report 11016 "Create XML-File VAT Adv.Notif."
         ElsterTok: Label 'ElsterTelemetryCategoryTok', Locked = true;
         CreateXMLFileMsg: Label 'Creating XML file', Locked = true;
         CreateXMLFileSuccessMsg: Label 'XML file created successfully', Locked = true;
-        AnmeldungssteuernXmlNameSpaceTxt: Label 'http://finkonsens.de/elster/elsteranmeldung/ustva/v%1', Locked = true;
         Window: Dialog;
         SubsequentAction: Option "Only create","Create and export";
         TaxAmount: array[100] of Decimal;
         TaxBase: array[100] of Decimal;
-        XmlNameSpace: Text[250];
+        ElsterXmlNameSpace: Text[250];
+        UseDataXmlNameSpace: Text[250];
         DatenLieferantTransferHeader: Text[256];
         DatenLieferantNutzdatenHeader: Text[256];
         Version: Text[250];
@@ -147,16 +147,17 @@ report 11016 "Create XML-File VAT Adv.Notif."
     var
         XmlSubDoc: XmlDocument;
         XmlRootElem: XmlElement;
+        XmlNameSpace: Text;
         t: Text;
     begin
         PrepareXmlDoc();
 
-        if not XmlDocument.ReadFrom('<?xml version="1.0" encoding="UTF-8"?>' + '<Elster xmlns="' + XmlNameSpace + '"></Elster>', XmlSubDoc) then
+        if not XmlDocument.ReadFrom('<?xml version="1.0" encoding="UTF-8"?>' + '<Elster xmlns="' + ElsterXmlNameSpace + '"></Elster>', XmlSubDoc) then
             LogInternalError(XMLDocHasNotBeenCreatedErr, DataClassification::SystemMetadata, Verbosity::Error);
         XmlSubDoc.GetRoot(XmlRootElem);
         AddTransferHeader(XmlRootElem);
-        AddUseDataHeader(XmlRootElem);
-        AddUseData(XmlRootElem);
+        AddUseDataHeader(XmlRootElem, XmlNameSpace);
+        AddUseData(XmlRootElem, XmlNameSpace);
         XmlSubDoc.WriteTo(t);
 
         UpdateSalesVATAdvNotif(XmlSubDoc);
@@ -249,7 +250,8 @@ report 11016 "Create XML-File VAT Adv.Notif."
         AddAddressText(2, "Sales VAT Advance Notif."."Contact Phone No." + '; ');
         AddAddressText(2, "Sales VAT Advance Notif."."Contact E-Mail");
 
-        XmlNameSpace := 'http://www.elster.de/elsterxml/schema/v11';
+        ElsterXmlNameSpace := 'http://www.elster.de/elsterxml/schema/v11';
+        UseDataXmlNameSpace := 'http://finkonsens.de/elster/elsteranmeldung/ustva/v2021';
 
         Version :=
           CopyStr(
@@ -272,98 +274,108 @@ report 11016 "Create XML-File VAT Adv.Notif."
     var
         XmlElemNew: XmlElement;
     begin
-        if not AddElement(XmlRootElem, XmlElemNew, 'TransferHeader', '', XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'TransferHeader', '', ElsterXmlNameSpace) then
             exit;
         XmlRootElem := XmlElemNew;
         if not XmlRootElem.Add(XmlAttribute.Create('version', '11')) then
             exit;
-        if not AddElement(XmlRootElem, XmlElemNew, 'Verfahren', 'ElsterAnmeldung', XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'Verfahren', 'ElsterAnmeldung', ElsterXmlNameSpace) then
             exit;
-        if not AddElement(XmlRootElem, XmlElemNew, 'DatenArt', 'UStVA', XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'DatenArt', 'UStVA', ElsterXmlNameSpace) then
             exit;
         if UseAuthentication then begin
-            if not AddElement(XmlRootElem, XmlElemNew, 'Vorgang', 'send-Auth', XmlNameSpace) then
+            if not AddElement(XmlRootElem, XmlElemNew, 'Vorgang', 'send-Auth', ElsterXmlNameSpace) then
                 exit;
         end else
-            if not AddElement(XmlRootElem, XmlElemNew, 'Vorgang', 'send-NoSig', XmlNameSpace) then
+            if not AddElement(XmlRootElem, XmlElemNew, 'Vorgang', 'send-NoSig', ElsterXmlNameSpace) then
                 exit;
         if "Sales VAT Advance Notif.".Testversion then begin
-            if not AddElement(XmlRootElem, XmlElemNew, 'Testmerker', '700000004', XmlNameSpace) then
+            if not AddElement(XmlRootElem, XmlElemNew, 'Testmerker', '700000004', ElsterXmlNameSpace) then
                 exit;
         end else
-            if not AddElement(XmlRootElem, XmlElemNew, 'Testmerker', '000000000', XmlNameSpace) then
+            if not AddElement(XmlRootElem, XmlElemNew, 'Testmerker', '000000000', ElsterXmlNameSpace) then
                 exit;
-        if not AddElement(XmlRootElem, XmlElemNew, 'HerstellerID', ManufacturerID, XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'HerstellerID', ManufacturerID, ElsterXmlNameSpace) then
             exit;
-        if not AddElement(XmlRootElem, XmlElemNew, 'DatenLieferant', DatenLieferantTransferHeader, XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'DatenLieferant', DatenLieferantTransferHeader, ElsterXmlNameSpace) then
             exit;
-        if not AddElement(XmlRootElem, XmlElemNew, 'Datei', '', XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'Datei', '', ElsterXmlNameSpace) then
             exit;
         XmlRootElem := XmlElemNew;
-        if not AddElement(XmlRootElem, XmlElemNew, 'Verschluesselung', 'CMSEncryptedData', XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'Verschluesselung', 'CMSEncryptedData', ElsterXmlNameSpace) then
             exit;
-        if not AddElement(XmlRootElem, XmlElemNew, 'Kompression', 'GZIP', XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'Kompression', 'GZIP', ElsterXmlNameSpace) then
             exit;
-        if not AddElement(XmlRootElem, XmlElemNew, 'TransportSchluessel', '', XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'TransportSchluessel', '', ElsterXmlNameSpace) then
             exit;
 
         XmlRootElem.GetParent(XmlRootElem);
 
         if StrLen(Version) > 42 then
             Version := CopyStr(Version, 1, 42);
-        if not AddElement(XmlRootElem, XmlElemNew, 'VersionClient', Version, XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'VersionClient', Version, ElsterXmlNameSpace) then
             exit;
 
         if "Sales VAT Advance Notif."."Additional Information" <> '' then begin
-            if not AddElement(XmlRootElem, XmlElemNew, 'Zusatz', '', XmlNameSpace) then
+            if not AddElement(XmlRootElem, XmlElemNew, 'Zusatz', '', ElsterXmlNameSpace) then
                 exit;
-            if AddElement(XmlRootElem, XmlElemNew, 'Info', AdditionalInformation, XmlNameSpace) then
+            if AddElement(XmlRootElem, XmlElemNew, 'Info', AdditionalInformation, ElsterXmlNameSpace) then
                 exit;
         END;
         XmlRootElem.GetParent(XmlRootElem);
     end;
 
-    local procedure AddUseDataHeader(var XmlRootElem: XmlElement)
+    local procedure AddUseDataHeader(var XmlRootElem: XmlElement; var XmlNameSpace: Text)
     var
         XmlElemNew: XmlElement;
     begin
-        if not AddElement(XmlRootElem, XmlElemNew, 'DatenTeil', '', XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'DatenTeil', '', ElsterXmlNameSpace) then
             exit;
         XmlRootElem := XmlElemNew;
-        if not AddElement(XmlRootElem, XmlElemNew, 'Nutzdatenblock', '', XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'Nutzdatenblock', '', ElsterXmlNameSpace) then
             exit;
         XmlRootElem := XmlElemNew;
-        if not AddElement(XmlRootElem, XmlElemNew, 'NutzdatenHeader', '', XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'NutzdatenHeader', '', ElsterXmlNameSpace) then
             exit;
         XmlRootElem := XmlElemNew;
         if not XmlRootElem.Add(XmlAttribute.Create('version', '11')) then
             exit;
-        if not AddElement(XmlRootElem, XmlElemNew, 'NutzdatenTicket', "Sales VAT Advance Notif."."No.", XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'NutzdatenTicket', "Sales VAT Advance Notif."."No.", ElsterXmlNameSpace) then
             exit;
-        if not AddElement(XmlRootElem, XmlElemNew, 'Empfaenger', CompanyInfo."Tax Office Number", XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'Empfaenger', CompanyInfo."Tax Office Number", ElsterXmlNameSpace) then
             exit;
         if not XmlElemNew.Add(XmlAttribute.Create('id', 'F')) then
             exit;
-        if not AddElement(XmlRootElem, XmlElemNew, 'Hersteller', '', XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'Hersteller', '', ElsterXmlNameSpace) then
             exit;
         XmlRootElem := XmlElemNew;
-        if not AddElement(XmlRootElem, XmlElemNew, 'ProduktName', 'Microsoft Business Solutions-Navision', XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'ProduktName', 'Microsoft Business Solutions-Navision', ElsterXmlNameSpace) then
             exit;
-        if not AddElement(XmlRootElem, XmlElemNew, 'ProduktVersion', GetProductVersion(), XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'ProduktVersion', GetProductVersion(), ElsterXmlNameSpace) then
             exit;
         XmlRootElem.GetParent(XmlRootElem);
-        if not AddElement(XmlRootElem, XmlElemNew, 'DatenLieferant', DatenLieferantNutzdatenHeader, XmlNameSpace) then
+        if not AddElement(XmlRootElem, XmlElemNew, 'DatenLieferant', DatenLieferantNutzdatenHeader, ElsterXmlNameSpace) then
             exit;
         if "Sales VAT Advance Notif."."Additional Information" <> '' then begin
-            if not AddElement(XmlRootElem, XmlElemNew, 'Zusatz', '', XmlNameSpace) then
+            if not AddElement(XmlRootElem, XmlElemNew, 'Zusatz', '', ElsterXmlNameSpace) then
                 exit;
-            if not AddElement(XmlRootElem, XmlElemNew, 'Info', AdditionalInformation, XmlNameSpace) then
+            if not AddElement(XmlRootElem, XmlElemNew, 'Info', AdditionalInformation, ElsterXmlNameSpace) then
                 exit;
         END;
         XmlRootElem.GetParent(XmlRootElem);
+
+        // determine the XML namespace to be used.
+        if ("Sales VAT Advance Notif."."Starting Date" <= DMY2Date(31, 12, 2020)) then
+            XmlNameSpace := ElsterXmlNameSpace
+        else
+            XmlNameSpace := UseDataXmlNameSpace; // ERiC v33.2.x uses a new XML namespace.
+
+        if not AddElement(XmlRootElem, XmlElemNew, 'Nutzdaten', '', ElsterXmlNameSpace) then
+            exit;
+        XmlRootElem := XmlElemNew;
     end;
 
-    local procedure AddUseData(var XmlRootElem: XmlElement)
+    local procedure AddUseData(var XmlRootElem: XmlElement; var XmlNameSpace: Text)
     var
         XmlElemNew: XmlElement;
         i: Integer;
@@ -371,9 +383,6 @@ report 11016 "Create XML-File VAT Adv.Notif."
         TaxAmtText: Text[30];
         NotificationVersion: Text[2];
     begin
-        if not AddElement(XmlRootElem, XmlElemNew, 'Nutzdaten', '', XmlNameSpace) then
-            exit;
-        XmlRootElem := XmlElemNew;
         if ("Sales VAT Advance Notif."."Starting Date" <= DMY2Date(31, 12, 2020)) then begin
             if not AddElement(XmlRootElem, XmlElemNew, 'Anmeldungssteuern', '', XmlNameSpace) then
                 exit;
@@ -407,7 +416,7 @@ report 11016 "Create XML-File VAT Adv.Notif."
             if not AddElement(XmlRootElem, XmlElemNew, 'Erstellungsdatum', Format(Today(), 0, '<year4><month,2><day,2>'), XmlNameSpace) then
                 exit;
         end else begin
-            if not AddElement(XmlRootElem, XmlElemNew, 'Anmeldungssteuern', '', StrSubstNo(AnmeldungssteuernXmlNameSpaceTxt, Date2DMY("Sales VAT Advance Notif."."Starting Date", 3))) then
+            if not AddElement(XmlRootElem, XmlElemNew, 'Anmeldungssteuern', '', XmlNameSpace) then
                 exit;
             XmlRootElem := XmlElemNew;
             if not XmlRootElem.Add(XmlAttribute.Create('version', Format(Date2DMY("Sales VAT Advance Notif."."Starting Date", 3)))) then

--- a/Apps/DE/Elster/app/src/Reports/CreateXMLFileVATAdvNotif.Report.al
+++ b/Apps/DE/Elster/app/src/Reports/CreateXMLFileVATAdvNotif.Report.al
@@ -407,11 +407,9 @@ report 11016 "Create XML-File VAT Adv.Notif."
             if not AddElement(XmlRootElem, XmlElemNew, 'Erstellungsdatum', Format(Today(), 0, '<year4><month,2><day,2>'), XmlNameSpace) then
                 exit;
         end else begin
-            if not AddElement(XmlRootElem, XmlElemNew, 'Anmeldungssteuern', '', XmlNameSpace) then
+            if not AddElement(XmlRootElem, XmlElemNew, 'Anmeldungssteuern', '', StrSubstNo(AnmeldungssteuernXmlNameSpaceTxt, Date2DMY("Sales VAT Advance Notif."."Starting Date", 3))) then
                 exit;
             XmlRootElem := XmlElemNew;
-            if not XmlRootElem.Add(XmlAttribute.Create('xmlns', StrSubstNo(AnmeldungssteuernXmlNameSpaceTxt, Date2DMY("Sales VAT Advance Notif."."Starting Date", 3)))) then
-                exit;
             if not XmlRootElem.Add(XmlAttribute.Create('version', Format(Date2DMY("Sales VAT Advance Notif."."Starting Date", 3)))) then
                 exit;
             if not AddElement(XmlRootElem, XmlElemNew, 'Erstellungsdatum', Format(Today(), 0, '<year4><month,2><day,2>'), XmlNameSpace) then


### PR DESCRIPTION
According to #9905 the following changes were made:
 - Updated XML-file creation for ELSTER/ERiC v.33.2.x
 - Implemented UseDataXmlNameSpace
 - Added support for both, 2020 and 2021+ Sales VAT Adv. Notifications

I've tested both (see [ERiC-UStVA_v33.2.8.0.zip](https://github.com/microsoft/ALAppExtensions/files/5574275/ERiC-UStVA_v33.2.8.0.zip): VAT0001 = 2020, VAT0002 = 2021) both XML-files against the newest version of ERiC (33.2.8.0). Attached you find the XML-files and Submission confirmation (PDF).



