### PR TITLE
Get all upgrade tag and set skipped field

### DIFF
--- a/Modules/System/Upgrade Tags/src/UpgradeTag.Codeunit.al
+++ b/Modules/System/Upgrade Tags/src/UpgradeTag.Codeunit.al
@@ -51,7 +51,7 @@ codeunit 9999 "Upgrade Tag"
     /// <summary>
     /// Sets the upgrade tag to skipped.
     /// </summary>
-    /// <param name="ExistingTag">Tag code to get the Tag</param>
+    /// <param name="ExistingTag">Tag code to set the skipped field</param>
     procedure SetSkippedUpgrade(ExistingTag: Code[250])
     begin
         UpgradeTagImpl.SetSkippedUpgrade(ExistingTag);
@@ -60,7 +60,8 @@ codeunit 9999 "Upgrade Tag"
     /// <summary>
     /// Sets the upgrade tag to skipped.
     /// </summary>
-    /// <param name="ExistingTag">Tag code to get the Tag</param>
+    /// <param name="ExistingTag">Tag code to set the skipped field</param>
+    /// <param name="TagCompanyName">Name of the company to check existance of tag</param>
     procedure SetSkippedUpgrade(ExistingTag: Code[250]; TagCompanyName: Code[30])
     begin
         UpgradeTagImpl.SetSkippedUpgrade(ExistingTag, TagCompanyName);

--- a/Modules/System/Upgrade Tags/src/UpgradeTag.Codeunit.al
+++ b/Modules/System/Upgrade Tags/src/UpgradeTag.Codeunit.al
@@ -49,6 +49,24 @@ codeunit 9999 "Upgrade Tag"
     end;
 
     /// <summary>
+    /// Sets the upgrade tag to skipped.
+    /// </summary>
+    /// <param name="ExistingTag">Tag code to get the Tag</param>
+    procedure SetSkippedUpgrade(ExistingTag: Code[250])
+    begin
+        UpgradeTagImpl.SetSkippedUpgrade(ExistingTag);
+    end;
+
+    /// <summary>
+    /// Sets the upgrade tag to skipped.
+    /// </summary>
+    /// <param name="ExistingTag">Tag code to get the Tag</param>
+    procedure SetSkippedUpgrade(ExistingTag: Code[250]; TagCompanyName: Code[30])
+    begin
+        UpgradeTagImpl.SetSkippedUpgrade(ExistingTag, TagCompanyName);
+    end;
+
+    /// <summary>
     /// This method should be used to set all upgrade tags in a new company. 
     /// The method is called from codeunit 2 - Company Initialize.
     /// </summary>
@@ -74,7 +92,7 @@ codeunit 9999 "Upgrade Tag"
     /// List of upgrade tags that should be inserted if they do not exist.
     /// </param>
     [IntegrationEvent(false, false)]
-    internal procedure OnGetPerCompanyUpgradeTags(var PerCompanyUpgradeTags: List of [Code[250]])
+    procedure OnGetPerCompanyUpgradeTags(var PerCompanyUpgradeTags: List of [Code[250]])
     begin
     end;
 
@@ -85,7 +103,7 @@ codeunit 9999 "Upgrade Tag"
     /// List of upgrade tags that should be inserted if they do not exist.
     /// </param>
     [IntegrationEvent(false, false)]
-    internal procedure OnGetPerDatabaseUpgradeTags(var PerDatabaseUpgradeTags: List of [Code[250]])
+    procedure OnGetPerDatabaseUpgradeTags(var PerDatabaseUpgradeTags: List of [Code[250]])
     begin
     end;
 }

--- a/Modules/System/Upgrade Tags/src/UpgradeTagImpl.Codeunit.al
+++ b/Modules/System/Upgrade Tags/src/UpgradeTagImpl.Codeunit.al
@@ -29,6 +29,30 @@ codeunit 9996 "Upgrade Tag Impl."
         SetUpgradeTagForCompany(NewTag, CopyStr(CompanyName(), 1, MaxStrLen(ConstUpgradeTags.Company)));
     end;
 
+    procedure SetSkippedUpgrade(ExistingTag: Code[250])
+    var
+        ConstUpgradeTags: Record "Upgrade Tags";
+    begin
+        ConstUpgradeTags.Reset;
+        ConstUpgradeTags.SetRange(Tag, ExistingTag);
+        if ConstUpgradeTags.FindSet then
+            repeat
+                ConstUpgradeTags.ModifyAll(ConstUpgradeTags."Skipped Upgrade", true);
+            until ConstUpgradeTags.next = 0;
+    end;
+
+    procedure SetSkippedUpgrade(ExistingTag: Code[250]; TagCompanyName: Code[30])
+    var
+        ConstUpgradeTags: Record "Upgrade Tags";
+    begin
+        ConstUpgradeTags.Reset;
+        ConstUpgradeTags.SetRange(Tag, ExistingTag);
+        ConstUpgradeTags.SetRange(Company, TagCompanyName);
+        if ConstUpgradeTags.FindSet then begin
+            ConstUpgradeTags.ModifyAll(ConstUpgradeTags."Skipped Upgrade", true);
+        end;
+    end;
+
     procedure SetAllUpgradeTags()
     var
         ConstUpgradeTags: Record "Upgrade Tags";


### PR DESCRIPTION
As discussed with Nikola Kukrika
We would like to get all the upgrade tags from a company and the database to compare if a upgrade tag is in the table or not.
Also we are going to use this not be part of the Automated Data Upgrade but in a seperate page.
That is why we want to use the skipped field.