### PR TITLE
Throw inner exception message

### DIFF
--- a/Modules/System Tests/XML Validation/src/XmlValidationTest.Codeunit.al
+++ b/Modules/System Tests/XML Validation/src/XmlValidationTest.Codeunit.al
@@ -9,7 +9,7 @@ codeunit 135051 "Xml Validation Test"
     var
         Assert: Codeunit "Library Assert";
         XmlValidationTestHelper: Codeunit "Xml Validation Test Helper";
-        ValidationErrorTxt: Label 'A call to System.Xml.XmlDocument.Validate failed with this message: The element ''bookstore'' in namespace ''http://www.contoso.com/books'' has invalid child element ''anotherNode''.';
+        ValidationErrorTxt: Label 'The element ''bookstore'' in namespace ''http://www.contoso.com/books'' has invalid child element ''anotherNode''.';
         InvalidXmlErrTxt: Label 'The XML definition is invalid.';
         InvalidSchemaErrTxt: Label 'The schema definition is not valid XML.';
 

--- a/Modules/System/XML Validation/src/XmlValidationImpl.Codeunit.al
+++ b/Modules/System/XML Validation/src/XmlValidationImpl.Codeunit.al
@@ -46,7 +46,6 @@ codeunit 6241 "Xml Validation Impl."
     var
         XmlDoc: DotNet XmlDocument;
         XmlReader: DotNet XmlReader;
-        ValidationEventHandler: DotNet ValidationEventHandler;
     begin
         XmlDoc := XmlDoc.XmlDocument();
         XmlDoc.Load(XmlDocStream);
@@ -54,6 +53,23 @@ codeunit 6241 "Xml Validation Impl."
         XmlReader := XmlReader.Create(XmlSchemaStream);
         XmlDoc.Schemas.Add(Namespace, XmlReader);
 
+        if not TryValidate(XmlDoc) then
+            HandleValidateException();
+    end;
+
+    [TryFunction]
+    local procedure TryValidate(XmlDoc: DotNet XmlDocument)
+    var
+        ValidationEventHandler: DotNet ValidationEventHandler;
+    begin
         XmlDoc.Validate(ValidationEventHandler);
+    end;
+
+    local procedure HandleValidateException()
+    var
+        Exception: DotNet Exception;
+    begin
+        Exception := GetLastErrorObject();
+        Error(Exception.InnerException.Message);
     end;
 }


### PR DESCRIPTION
Strip the text 'A call to System.Xml.XmlDocument.Validate failed with this message' from the error message

Before:
![image](https://user-images.githubusercontent.com/19155831/101552615-6b79b680-39b3-11eb-9bbb-ffe8dab0b99f.png)


After:
![image](https://user-images.githubusercontent.com/19155831/101552592-6288e500-39b3-11eb-997c-d9c909a5b5bf.png)



