### PR TITLE
Fix to show caption instead of name when choosing the Email Scenario

### DIFF
--- a/Modules/System/Email/src/Scenario/EmailScenarioImpl.Codeunit.al
+++ b/Modules/System/Email/src/Scenario/EmailScenarioImpl.Codeunit.al
@@ -209,6 +209,7 @@ codeunit 8892 "Email Scenario Impl."
     procedure GetAvailableScenariosForAccount(EmailAccount: Record "Email Account Scenario"; var EmailScenarios: Record "Email Account Scenario")
     var
         Scenario: Record "Email Scenario";
+        EmailScenario: Enum "Email Scenario";
         CurrentScenario, i : Integer;
         IsAvailable: Boolean;
     begin
@@ -229,7 +230,8 @@ codeunit 8892 "Email Scenario Impl."
                 EmailScenarios."Account Id" := EmailAccount."Account Id";
                 EmailScenarios.Connector := EmailAccount.Connector;
                 EmailScenarios.Scenario := CurrentScenario;
-                EmailScenarios."Display Name" := Format(Enum::"Email Scenario".Names().Get(i));
+                EmailScenario := Enum::"Email Scenario".FromInteger(Enum::"Email Scenario".Ordinals().Get(i));
+                EmailScenarios."Display Name" := Format(EmailScenario);
 
                 EmailScenarios.Insert();
             end;


### PR DESCRIPTION
When choosing the Email Scenario then instead of Caption the Name of Enum values is shown.

Before the change (names with prefix XXX):
![image](https://user-images.githubusercontent.com/37371997/101657741-85170e80-3a44-11eb-91c7-06e40e048062.png)

and after then change (captions):
![image](https://user-images.githubusercontent.com/37371997/101657944-c3acc900-3a44-11eb-8a96-04f09ba3535d.png)
