### PR TITLE
Show Dialogs in some TestRunner long-running actions

### DIFF
--- a/Modules/DevTools/TestFramework/TestRunner/src/ALTestTool.Page.al
+++ b/Modules/DevTools/TestFramework/TestRunner/src/ALTestTool.Page.al
@@ -194,7 +194,7 @@ page 130451 "AL Test Tool"
                     PromotedCategory = Process;
                     PromotedIsBig = true;
                     PromotedOnly = true;
-                    ToolTip = 'Runs selected tests.';
+                    ToolTip = 'Runs marked tests.';
 
                     trigger OnAction()
                     var
@@ -215,6 +215,7 @@ page 130451 "AL Test Tool"
                     PromotedCategory = Process;
                     PromotedIsBig = true;
                     PromotedOnly = true;
+                    ToolTip = 'Runs selected tests.';
 
                     trigger OnAction()
                     var
@@ -303,7 +304,13 @@ page 130451 "AL Test Tool"
                     var
                         TestMethodLine: Record "Test Method Line";
                         TestSuiteMgt: Codeunit "Test Suite Mgt.";
+                        DeleteQuestion: Label 'Are you sure you want to Delete the Selected Lines?';
                     begin
+                        if GuiAllowed() then begin
+                            if not Confirm(DeleteQuestion, false) then
+                                exit;
+                        end;
+
                         CurrPage.SetSelectionFilter(TestMethodLine);
                         TestMethodLine.DeleteAll(true);
                         TestSuiteMgt.CalcTestResults(Rec, Success, Failure, Skipped, NotExecuted);

--- a/Modules/DevTools/TestFramework/TestRunner/src/ALTestTool.Page.al
+++ b/Modules/DevTools/TestFramework/TestRunner/src/ALTestTool.Page.al
@@ -304,7 +304,6 @@ page 130451 "AL Test Tool"
                     var
                         TestMethodLine: Record "Test Method Line";
                         TestSuiteMgt: Codeunit "Test Suite Mgt.";
-                        DeleteQuestion: Label 'Are you sure you want to Delete the Selected Lines?';
                     begin
                         if GuiAllowed() then begin
                             if not Confirm(DeleteQuestion, false) then
@@ -316,55 +315,50 @@ page 130451 "AL Test Tool"
                         TestSuiteMgt.CalcTestResults(Rec, Success, Failure, Skipped, NotExecuted);
                     end;
                 }
-
-                action(SwitchRunCheckLines)
+                action(InvertRunCheckLines)
                 {
                     ApplicationArea = All;
-                    Caption = '&Switch Run Check';
+                    Caption = '&Invert Run Check';
                     Image = Change;
                     Promoted = true;
                     PromotedCategory = Process;
                     PromotedIsBig = true;
                     PromotedOnly = true;
-                    ToolTip = 'Switch Run Check on selected lines.';
+                    ToolTip = 'Invert Run Check on selected lines.';
 
                     trigger OnAction()
                     var
                         TestMethodLine: Record "Test Method Line";
-                        SwitchQuestion: Label 'Are you sure you want to %1 the Selected Lines?';
-                        Check: Label 'Check';
-                        Uncheck: Label 'Uncheck';
                         NewRunValue: Boolean;
-                        ActionToDo: Text[30];
-                        DialogContent: Label '-- Switch Run Check --\#1#\#2#';
-                        i: Integer;
-                        n: Integer;
-                        d: Dialog;
+                        Counter: Integer;
+                        TotalCount: Integer;
+                        Window: Dialog;
+                        InvertQuestion: Text;
                     begin
                         CurrPage.SetSelectionFilter(TestMethodLine);
                         NewRunValue := not Rec.Run;
 
                         if GuiAllowed() then begin
                             if (NewRunValue = true) then
-                                ActionToDo := Check
+                                InvertQuestion := InvertToCheckQuestion
                             else
-                                ActionToDo := Uncheck;
+                                InvertQuestion := InvertToUncheckQuestion;
 
                             if TestMethodLine.Count() > 1 then
-                                if not Confirm(SwitchQuestion, false, ActionToDo) then
+                                if not Confirm(InvertQuestion, false) then
                                     exit;
 
-                            i := 0;
-                            n := TestMethodLine.Count();
-                            d.Open(DialogContent);
+                            Counter := 0;
+                            TotalCount := TestMethodLine.Count();
+                            Window.Open(DialogContentInvertingRunCheck);
                         end;
 
                         if TestMethodLine.FindSet(true, false) then
                             repeat
                                 if GuiAllowed() then begin
-                                    i += 1;
-                                    d.Update(1, format(TestMethodLine."Line Type") + '-' + format(TestMethodLine."Test Codeunit") + ' - ' + TestMethodLine.Name);
-                                    d.Update(2, format(i) + ' / ' + format(n) + ' ... ' + format(round(i / n * 100, 1)) + ' %');
+                                    Counter += 1;
+                                    Window.Update(1, format(TestMethodLine."Line Type") + '-' + format(TestMethodLine."Test Codeunit") + ' - ' + TestMethodLine.Name);
+                                    Window.Update(2, format(Counter) + ' / ' + format(TotalCount) + ' ... ' + format(round(Counter / TotalCount * 100, 1)) + ' %');
                                 end;
 
                                 if TestMethodLine.Run <> NewRunValue then begin
@@ -374,7 +368,7 @@ page 130451 "AL Test Tool"
                             until TestMethodLine.Next() = 0;
 
                         if GuiAllowed() then
-                            d.Close();
+                            Window.Close();
                     end;
                 }
             }
@@ -437,6 +431,10 @@ page 130451 "AL Test Tool"
         RunDuration: Duration;
         TestRunnerDisplayName: Text;
         ErrorMessageWithStackTraceTxt: Text;
+        DeleteQuestion: Label 'Are you sure you want to Delete the Selected Lines?';
+        InvertToCheckQuestion: Label 'Are you sure you want to Check the Selected Lines?';
+        InvertToUncheckQuestion: Label 'Are you sure you want to Uncheck the Selected Lines?';
+        DialogContentInvertingRunCheck: Label '-- Inverting Run Check --\#1#\#2#';
 
     local procedure ChangeTestSuite()
     var

--- a/Modules/DevTools/TestFramework/TestRunner/src/ALTestTool.Page.al
+++ b/Modules/DevTools/TestFramework/TestRunner/src/ALTestTool.Page.al
@@ -316,6 +316,67 @@ page 130451 "AL Test Tool"
                         TestSuiteMgt.CalcTestResults(Rec, Success, Failure, Skipped, NotExecuted);
                     end;
                 }
+
+                action(SwitchRunCheckLines)
+                {
+                    ApplicationArea = All;
+                    Caption = '&Switch Run Check';
+                    Image = Change;
+                    Promoted = true;
+                    PromotedCategory = Process;
+                    PromotedIsBig = true;
+                    PromotedOnly = true;
+                    ToolTip = 'Switch Run Check on selected lines.';
+
+                    trigger OnAction()
+                    var
+                        TestMethodLine: Record "Test Method Line";
+                        SwitchQuestion: Label 'Are you sure you want to %1 the Selected Lines?';
+                        Check: Label 'Check';
+                        Uncheck: Label 'Uncheck';
+                        NewRunValue: Boolean;
+                        ActionToDo: Text[30];
+                        DialogContent: Label '-- Switch Run Check --\#1#\#2#';
+                        i: Integer;
+                        n: Integer;
+                        d: Dialog;
+                    begin
+                        CurrPage.SetSelectionFilter(TestMethodLine);
+                        NewRunValue := not Rec.Run;
+
+                        if GuiAllowed() then begin
+                            if (NewRunValue = true) then
+                                ActionToDo := Check
+                            else
+                                ActionToDo := Uncheck;
+
+                            if TestMethodLine.Count() > 1 then
+                                if not Confirm(SwitchQuestion, false, ActionToDo) then
+                                    exit;
+
+                            i := 0;
+                            n := TestMethodLine.Count();
+                            d.Open(DialogContent);
+                        end;
+
+                        if TestMethodLine.FindSet(true, false) then
+                            repeat
+                                if GuiAllowed() then begin
+                                    i += 1;
+                                    d.Update(1, format(TestMethodLine."Line Type") + '-' + format(TestMethodLine."Test Codeunit") + ' - ' + TestMethodLine.Name);
+                                    d.Update(2, format(i) + ' / ' + format(n) + ' ... ' + format(round(i / n * 100, 1)) + ' %');
+                                end;
+
+                                if TestMethodLine.Run <> NewRunValue then begin
+                                    TestMethodLine.Validate(Run, NewRunValue);
+                                    TestMethodLine.Modify(true);
+                                end;
+                            until TestMethodLine.Next() = 0;
+
+                        if GuiAllowed() then
+                            d.Close();
+                    end;
+                }
             }
             group("Test Suite")
             {

--- a/Modules/DevTools/TestFramework/TestRunner/src/TestSuiteMgt.Codeunit.al
+++ b/Modules/DevTools/TestFramework/TestRunner/src/TestSuiteMgt.Codeunit.al
@@ -17,6 +17,8 @@ codeunit 130456 "Test Suite Mgt."
         SelectTestsToRunQst: Label '&All,Active &Codeunit,Active &Line', Locked = true;
         SelectCodeunitsToRunQst: Label '&All,Active &Codeunit', Locked = true;
         DefaultTestSuiteNameTxt: Label 'DEFAULT', Locked = true;
+        DialogContentGettingTestMethods: Label '-- Getting Test Methods --\#1#\#2#';
+        DialogContentUpdatingTestMethods: Label '-- Updating Test Methods --\#1#\#2#';
 
     procedure RunTestSuiteSelection(var TestMethodLine: Record "Test Method Line")
     var
@@ -250,25 +252,24 @@ codeunit 130456 "Test Suite Mgt."
     procedure GetTestMethods(var ALTestSuite: Record "AL Test Suite"; var AllObjWithCaption: Record AllObjWithCaption)
     var
         TestLineNo: Integer;
-        DialogContent: Label '-- Get Test Methods --\#1#\#2#';
-        i: Integer;
-        n: Integer;
-        d: Dialog;
+        Counter: Integer;
+        TotalCount: Integer;
+        Window: Dialog;
     begin
         if not AllObjWithCaption.FindSet() then
             exit;
 
         if GuiAllowed() then begin
-            i := 0;
-            n := AllObjWithCaption.Count();
-            d.Open(DialogContent);
+            Counter := 0;
+            TotalCount := AllObjWithCaption.Count();
+            Window.Open(DialogContentGettingTestMethods);
         end;
 
         repeat
             if GuiAllowed() then begin
-                i += 1;
-                d.Update(1, format(AllObjWithCaption."Object Type") + '-' + format(AllObjWithCaption."Object ID") + ' - ' + AllObjWithCaption."Object Caption");
-                d.Update(2, format(i) + ' / ' + format(n) + ' ... ' + format(round(i / n * 100, 1)) + ' %');
+                Counter += 1;
+                Window.Update(1, format(AllObjWithCaption."Object Type") + '-' + format(AllObjWithCaption."Object ID") + ' - ' + AllObjWithCaption."Object Caption");
+                Window.Update(2, format(Counter) + ' / ' + format(TotalCount) + ' ... ' + format(round(Counter / TotalCount * 100, 1)) + ' %');
             end;
 
             // Must be inside of loop. Test Runner used for discovering tests is adding methods
@@ -277,17 +278,16 @@ codeunit 130456 "Test Suite Mgt."
         until AllObjWithCaption.Next() = 0;
 
         if GuiAllowed() then
-            d.Close();
+            Window.Close();
     end;
 
     procedure UpdateTestMethods(var TestMethodLine: record "Test Method Line")
     var
         BackupTestMethodLine: Record "Test Method Line";
         TestRunnerGetMethods: Codeunit "Test Runner - Get Methods";
-        DialogContent: Label '-- Update Test Methods --\#1#\#2#';
-        i: Integer;
-        n: Integer;
-        d: Dialog;
+        Counter: Integer;
+        TotalCount: Integer;
+        Window: Dialog;
     begin
         BackupTestMethodLine.Copy(TestMethodLine);
         TestMethodLine.Reset();
@@ -297,17 +297,17 @@ codeunit 130456 "Test Suite Mgt."
         TestMethodLine.SetRange("Line Type", TestMethodLine."Line Type"::Codeunit);
 
         if GuiAllowed() then begin
-            i := 0;
-            n := TestMethodLine.Count();
-            d.Open(DialogContent);
+            Counter := 0;
+            TotalCount := TestMethodLine.Count();
+            Window.Open(DialogContentUpdatingTestMethods);
         end;
 
         if TestMethodLine.FindSet() then
             repeat
                 if GuiAllowed() then begin
-                    i += 1;
-                    d.Update(1, format(TestMethodLine."Line Type") + '-' + format(TestMethodLine."Test Codeunit") + ' - ' + TestMethodLine.Name);
-                    d.Update(2, format(i) + ' / ' + format(n) + ' ... ' + format(round(i / n * 100, 1)) + ' %');
+                    Counter += 1;
+                    Window.Update(1, format(TestMethodLine."Line Type") + '-' + format(TestMethodLine."Test Codeunit") + ' - ' + TestMethodLine.Name);
+                    Window.Update(2, format(Counter) + ' / ' + format(TotalCount) + ' ... ' + format(round(Counter / TotalCount * 100, 1)) + ' %');
                 end;
 
                 TestRunnerGetMethods.SetUpdateTests(true);
@@ -315,7 +315,7 @@ codeunit 130456 "Test Suite Mgt."
             until TestMethodLine.Next() = 0;
 
         if GuiAllowed() then
-            d.Close();
+            Window.Close();
 
         TestMethodLine.SetRange("Test Suite", BackupTestMethodLine."Test Suite");
         TestMethodLine.SetRange("Test Codeunit", BackupTestMethodLine."Test Codeunit");


### PR DESCRIPTION
I have added a dialog box to the Get and Update Test actions of the Test Runner Module because I have noticed that when you select all the codeunits it takes a long time and the system is completely blocked without the user being able to know what is really happening.

I hope you find it useful to do the merge.

![image](https://user-images.githubusercontent.com/5801847/103835154-c1f71500-5085-11eb-8953-b167ef4ec134.png)
