### PR TITLE
Revealing Procedures related to the QR-Report for Extension Development

### DIFF
--- a/Apps/CH/SwissQRBill/app/src/core/Buffer.Table.al
+++ b/Apps/CH/SwissQRBill/app/src/core/Buffer.Table.al
@@ -374,14 +374,14 @@ table 11510 "Swiss QR-Bill Buffer"
     var
         SwissQRBillMgt: Codeunit "Swiss QR-Bill Mgt.";
 
-    internal procedure AddBufferRecord(SourceSwissQRBillBuffer: Record "Swiss QR-Bill Buffer")
+    procedure AddBufferRecord(SourceSwissQRBillBuffer: Record "Swiss QR-Bill Buffer")
     begin
         "Entry No." += 1;
         TransferFields(SourceSwissQRBillBuffer, false);
         Insert();
     end;
 
-    internal procedure InitBuffer(QRBillLayoutCode: Code[20])
+    procedure InitBuffer(QRBillLayoutCode: Code[20])
     var
         SwissQRBillSetup: Record "Swiss QR-Bill Setup";
     begin
@@ -576,7 +576,7 @@ table 11510 "Swiss QR-Bill Buffer"
                 "Unstructured Message" := '';
     end;
 
-    internal procedure SetSourceRecord(CustomerLedgerEntryNo: Integer)
+    procedure SetSourceRecord(CustomerLedgerEntryNo: Integer)
     var
         CustLedgerEntry: Record "Cust. Ledger Entry";
         PaymentMethod: Record "Payment Method";

--- a/Apps/CH/SwissQRBill/app/src/core/Mgt.Codeunit.al
+++ b/Apps/CH/SwissQRBill/app/src/core/Mgt.Codeunit.al
@@ -112,7 +112,7 @@ codeunit 11518 "Swiss QR-Bill Mgt."
         exit(SwissQRBillPrint.SaveAs('', ReportFormat::Pdf, PDFFileOutStream));
     end;
 
-    internal procedure GenerateImage(var SwissQRBillBuffer: Record "Swiss QR-Bill Buffer")
+    procedure GenerateImage(var SwissQRBillBuffer: Record "Swiss QR-Bill Buffer")
     var
         TempBlob: Codeunit "Temp Blob";
         SwissQRBillImageMgt: Codeunit "Swiss QR-Bill Image Mgt.";


### PR DESCRIPTION
Hello, I would like to propose removing the internal access modifier of the procedures AddBufferRecord, InitBuffer, SetSourceRecord and GenerateImage. We need to access these in an extension to create a specialized QR Report for a customer.