### PR TITLE
Added BCPTLine in function as var

### DIFF
--- a/Modules/DevTools/BusinessCentralPerformanceToolkit/src/BCPTLine.Table.al
+++ b/Modules/DevTools/BusinessCentralPerformanceToolkit/src/BCPTLine.Table.al
@@ -260,13 +260,13 @@ table 149001 "BCPT Line"
     local procedure GetDefaultParametersIfAvailable(): Text[1000]
     begin
         if SetParametersProvider() then
-            exit(BCPTTestParamProvider.GetDefaultParameters());
+            exit(BCPTTestParamProvider.GetDefaultParameters(Rec));
     end;
 
     local procedure ValidateParameters(Params: Text[1000])
     begin
         if SetParametersProvider() then
-            BCPTTestParamProvider.ValidateParameters(Params)
+            BCPTTestParamProvider.ValidateParameters(Rec, Params)
         else
             if Params <> '' then
                 Error(ParameterNotSupportedErr);

--- a/Modules/DevTools/BusinessCentralPerformanceToolkit/src/BCPTTestParamProvider.Interface.al
+++ b/Modules/DevTools/BusinessCentralPerformanceToolkit/src/BCPTTestParamProvider.Interface.al
@@ -1,6 +1,6 @@
 interface "BCPT Test Param. Provider"
 {
-    procedure GetDefaultParameters(): Text[1000];
+    procedure GetDefaultParameters(BCPTLine: Record "BCPT Line"): Text[1000];
 
-    procedure ValidateParameters(Params: Text[1000]);
+    procedure ValidateParameters(BCPTLine: Record "BCPT Line"; Params: Text[1000]);
 }

--- a/Modules/DevTools/BusinessCentralPerformanceToolkit/src/BCPTTestParamProvider.Interface.al
+++ b/Modules/DevTools/BusinessCentralPerformanceToolkit/src/BCPTTestParamProvider.Interface.al
@@ -1,6 +1,8 @@
 interface "BCPT Test Param. Provider"
 {
+    procedure GetDefaultParameters(): Text[1000];
     procedure GetDefaultParameters(BCPTLine: Record "BCPT Line"): Text[1000];
 
+    procedure ValidateParameters(Params: Text[1000]);
     procedure ValidateParameters(BCPTLine: Record "BCPT Line"; Params: Text[1000]);
 }


### PR DESCRIPTION
Added the "BCPT Line" record into the functions GetDefaultParameters and ValidateParameters.
In this way you can define parameters per test codeunit.
Added the functions 2 times because of any breaking changes. But please advice if this is correct.
@BardurKnudsen 