### PR TITLE
Issue with translation in Assisted Setup

### DIFF
--- a/Modules/System/Assisted Setup/src/AssistedSetupImpl.Codeunit.al
+++ b/Modules/System/Assisted Setup/src/AssistedSetupImpl.Codeunit.al
@@ -78,8 +78,7 @@ codeunit 1813 "Assisted Setup Impl."
     begin
         if not AssistedSetup.Get(PageID) then
             exit;
-        if LanguageID <> GlobalLanguage() THEN
-            Translation.Set(AssistedSetup, AssistedSetup.FIELDNO(Name), LanguageID, CopyStr(TranslatedName, 1, 2048));
+        Translation.Set(AssistedSetup, AssistedSetup.FieldNo(Name), LanguageID, CopyStr(TranslatedName, 1, 2048));
     end;
 
     procedure IsComplete(PageID: Integer): Boolean


### PR DESCRIPTION
Dear Team,

Today @ajkauffmann showed me an issue that is related to translations of Assisted Setup. The same issue I face.

When the function AddTranslation is run before it the GlobalLanguage need to be changed to language which should be translated to get translation from 

```
GlobalLanguage(1030);
AssistedSetup.AddTranslation(Page::"My Page", 1030, MyPageAssistedNameLbl);
AssistedSetup.AddTranslation(Page::"My Page 2", 1030, MyPage2AssistedNameLbl);
```

It means that the line in the code 
`
if LanguageID <> GlobalLanguage() THEN
`
Always will be false - we run function with already changed language to the same as sent in the function.

I hope you can approve below quick fix which delete the checking for language id before insert. 

Best Regards,
Krzysztof