### PR TITLE
Move dimensions before lines

### DIFF
--- a/Apps/W1/APIV2/app/src/pages/APIV2PurchaseInvoices.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2PurchaseInvoices.Page.al
@@ -391,6 +391,13 @@ page 30042 "APIV2 - Purchase Invoices"
                         RegisterFieldSet(FieldNo("Prices Including VAT"));
                     end;
                 }
+                part(dimensionSetLines; "APIV2 - Dimension Set Lines")
+                {
+                    Caption = 'Dimension Set Lines';
+                    EntityName = 'dimensionSetLine';
+                    EntitySetName = 'dimensionSetLines';
+                    SubPageLink = "Parent Id" = Field(Id), "Parent Type" = const(10);
+                }
                 part(purchaseInvoiceLines; "APIV2 - Purchase Invoice Lines")
                 {
                     Caption = 'Lines';
@@ -460,13 +467,6 @@ page 30042 "APIV2 - Purchase Invoices"
                     EntityName = 'attachment';
                     EntitySetName = 'attachments';
                     SubPageLink = "Document Id" = Field(Id), "Document Type" = const(6);
-                }
-                part(dimensionSetLines; "APIV2 - Dimension Set Lines")
-                {
-                    Caption = 'Dimension Set Lines';
-                    EntityName = 'dimensionSetLine';
-                    EntitySetName = 'dimensionSetLines';
-                    SubPageLink = "Parent Id" = Field(Id), "Parent Type" = const(10);
                 }
             }
         }

--- a/Apps/W1/APIV2/app/src/pages/APIV2SalesCreditMemos.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2SalesCreditMemos.Page.al
@@ -390,6 +390,13 @@ page 30038 "APIV2 - Sales Credit Memos"
                         RegisterFieldSet(FieldNo("Prices Including VAT"));
                     end;
                 }
+                part(dimensionSetLines; "APIV2 - Dimension Set Lines")
+                {
+                    Caption = 'Dimension Set Lines';
+                    EntityName = 'dimensionSetLine';
+                    EntitySetName = 'dimensionSetLines';
+                    SubPageLink = "Parent Id" = Field(Id), "Parent Type" = const(6);
+                }
                 part(salesCreditMemoLines; "APIV2 - Sales Credit Mem Lines")
                 {
                     Caption = 'Lines';
@@ -520,13 +527,6 @@ page 30038 "APIV2 - Sales Credit Memos"
                     begin
                         RegisterFieldSet(FieldNo("Sell-to E-Mail"));
                     end;
-                }
-                part(dimensionSetLines; "APIV2 - Dimension Set Lines")
-                {
-                    Caption = 'Dimension Set Lines';
-                    EntityName = 'dimensionSetLine';
-                    EntitySetName = 'dimensionSetLines';
-                    SubPageLink = "Parent Id" = Field(Id), "Parent Type" = const(6);
                 }
                 part(attachments; "APIV2 - Attachments")
                 {

--- a/Apps/W1/APIV2/app/src/pages/APIV2SalesInvoices.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2SalesInvoices.Page.al
@@ -484,6 +484,13 @@ page 30012 "APIV2 - Sales Invoices"
                     Caption = 'Remaining Amount';
                     Editable = false;
                 }
+                part(dimensionSetLines; "APIV2 - Dimension Set Lines")
+                {
+                    Caption = 'Dimension Set Lines';
+                    EntityName = 'dimensionSetLine';
+                    EntitySetName = 'dimensionSetLines';
+                    SubPageLink = "Parent Id" = Field(Id), "Parent Type" = const(8);
+                }
                 part(salesInvoiceLines; "APIV2 - Sales Invoice Lines")
                 {
                     Caption = 'Lines';
@@ -574,13 +581,6 @@ page 30012 "APIV2 - Sales Invoices"
                     EntityName = 'attachment';
                     EntitySetName = 'attachments';
                     SubPageLink = "Document Id" = Field(Id), "Document Type" = const(5);
-                }
-                part(dimensionSetLines; "APIV2 - Dimension Set Lines")
-                {
-                    Caption = 'Dimension Set Lines';
-                    EntityName = 'dimensionSetLine';
-                    EntitySetName = 'dimensionSetLines';
-                    SubPageLink = "Parent Id" = Field(Id), "Parent Type" = const(8);
                 }
             }
         }

--- a/Apps/W1/APIV2/app/src/pages/APIV2SalesOrders.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2SalesOrders.Page.al
@@ -465,6 +465,13 @@ page 30028 "APIV2 - Sales Orders"
                         RegisterFieldSet(FieldNo("Requested Delivery Date"));
                     end;
                 }
+                part(dimensionSetLines; "APIV2 - Dimension Set Lines")
+                {
+                    Caption = 'Dimension Set Lines';
+                    EntityName = 'dimensionSetLine';
+                    EntitySetName = 'dimensionSetLines';
+                    SubPageLink = "Parent Id" = Field(Id), "Parent Type" = const(2);
+                }
                 part(salesOrderLines; "APIV2 - Sales Order Lines")
                 {
                     Caption = 'Lines';
@@ -556,13 +563,6 @@ page 30028 "APIV2 - Sales Orders"
                     EntityName = 'attachment';
                     EntitySetName = 'attachments';
                     SubPageLink = "Document Id" = Field(Id), "Document Type" = const(2);
-                }
-                part(dimensionSetLines; "APIV2 - Dimension Set Lines")
-                {
-                    Caption = 'Dimension Set Lines';
-                    EntityName = 'dimensionSetLine';
-                    EntitySetName = 'dimensionSetLines';
-                    SubPageLink = "Parent Id" = Field(Id), "Parent Type" = const(2);
                 }
             }
         }

--- a/Apps/W1/APIV2/app/src/pages/APIV2SalesQuotes.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2SalesQuotes.Page.al
@@ -473,6 +473,13 @@ page 30037 "APIV2 - Sales Quotes"
                         RegisterFieldSet(FieldNo("Salesperson Code"));
                     end;
                 }
+                part(dimensionSetLines; "APIV2 - Dimension Set Lines")
+                {
+                    Caption = 'Dimension Set Lines';
+                    EntityName = 'dimensionSetLine';
+                    EntitySetName = 'dimensionSetLines';
+                    SubPageLink = "Parent Id" = Field(Id), "Parent Type" = const(4);
+                }
                 part(salesQuoteLines; "APIV2 - Sales Quote Lines")
                 {
                     Caption = 'Lines';
@@ -585,13 +592,6 @@ page 30037 "APIV2 - Sales Quotes"
                     EntityName = 'attachment';
                     EntitySetName = 'attachments';
                     SubPageLink = "Document Id" = Field(Id), "Document Type" = const(3);
-                }
-                part(dimensionSetLines; "APIV2 - Dimension Set Lines")
-                {
-                    Caption = 'Dimension Set Lines';
-                    EntityName = 'dimensionSetLine';
-                    EntitySetName = 'dimensionSetLines';
-                    SubPageLink = "Parent Id" = Field(Id), "Parent Type" = const(4);
                 }
             }
         }


### PR DESCRIPTION
Dimensions are placed after the lines in sales and purchase document APIs. Because of that, a deep insert with dimensions and lines will create the lines first and then the dimensions on the document. As a result, the lines do not inherit the dimensions from the header, while that is default behavior.

When inserting lines individually this works as expected. But the order in which lines and dimensions are defined in the API prevents this for deep inserts. The only workaround is to include the dimensions on the individual lines as well.

Moving up the dimensions before the lines solves this issue.

See also this thread on Yammer: https://www.yammer.com/dynamicsnavdev/#/Threads/show?threadId=1085532101779456