### PR TITLE
Add Escape Uri String

### DIFF
--- a/Modules/System/URI/src/Uri.Codeunit.al
+++ b/Modules/System/URI/src/Uri.Codeunit.al
@@ -129,6 +129,17 @@ codeunit 3060 Uri
     end;
 
     /// <summary>
+    /// Converts a uri string to its escaped representation.
+    /// </summary>
+    /// <remarks>Visit https://docs.microsoft.com/en-us/dotnet/api/system.uri.escapeuristring for more information.</remarks>
+    /// <param name="TextToEscape"></param>
+    /// <returns>A string that contains the escaped representation of <paramref name="TextToEscape:"/>.</returns>
+    procedure EscapeUriString(TextToEscape: Text): Text
+    begin
+        exit(Uri.EscapeUriString(TextToEscape));
+    end;
+
+    /// <summary>
     /// Checks if the provded string is a valid URI.
     /// </summary>
     /// <param name="UriString">The string to check.</param>


### PR DESCRIPTION
Hi al-team, 

I have added one more function to the Uri codeunit.
Actually only the C# function EscapeUriString is called. https://docs.microsoft.com/en-us/dotnet/api/system.uri.escapeuristring?view=net-5.0

Can you include the customization in the base version?