### PR TITLE
(fix): 0 value name changed from "" to " "

### DIFF
--- a/Apps/CZ/CoreLocalizationPack/app/Src/Enums/CreditMemoType.Enum.al
+++ b/Apps/CZ/CoreLocalizationPack/app/Src/Enums/CreditMemoType.Enum.al
@@ -2,8 +2,9 @@ enum 11786 "Credit Memo Type CZL"
 {
     Extensible = true;
 
-    value(0; "")
+    value(0; " ")
     {
+    	Caption = '';
     }
     value(1; "Corrective Tax Document")
     {


### PR DESCRIPTION
If the value is "" it cannot be used in the AL code. Standard for BC is that empty value is " " (one space) not "".

If used in al code, you get error:
```
'"Credit Memo Type CZL"' does not contain a definition for ' '
```