### PR TITLE
"Azure AD Device Plan

### DIFF
--- a/Modules/System/Azure AD Licensing/src/AzureADLicensingImpl.Codeunit.al
+++ b/Modules/System/Azure AD Licensing/src/AzureADLicensingImpl.Codeunit.al
@@ -49,7 +49,7 @@ codeunit 460 "Azure AD Licensing Impl."
             IsInitialized := true;
         end;
 
-        MembershipEntitlement.SetRange(Type, MembershipEntitlement.Type::"Azure AD Plan");
+        MembershipEntitlement.SetFilter(Type, '%1|%2', MembershipEntitlement.Type::"Azure AD Plan", MembershipEntitlement.type::"Azure AD Device Plan");
 
         TempSubscribedSku := SubscribedSku;
         TempServicePlanEnumerator := ServicePlanEnumerator;


### PR DESCRIPTION
Added MembershipEntitlement.type::"Azure AD Device Plan" to the filter of know plans to include , since the device plan is also a known plan to business central.