### PR TITLE
Added Tag and Parameters in BCPT Import/Export

### DIFF
--- a/Modules/DevTools/BusinessCentralPerformanceToolkit/src/BCPTImportExport.xmlport.al
+++ b/Modules/DevTools/BusinessCentralPerformanceToolkit/src/BCPTImportExport.xmlport.al
@@ -19,6 +19,10 @@ xmlport 149001 "BCPT Import/Export"
                 {
                     Occurrence = Optional;
                 }
+                fieldattribute(Tag; "BCPTSuite".Tag)
+                {
+                    Occurrence = Optional;
+                }
                 fieldattribute(Duration; "BCPTSuite"."Duration (minutes)")
                 {
                     Occurrence = Optional;
@@ -49,6 +53,10 @@ xmlport 149001 "BCPT Import/Export"
                     fieldattribute(CodeunitID; BCPTSuiteLine."Codeunit ID")
                     {
                         Occurrence = Required;
+                    }
+                    fieldattribute(Parameters; BCPTSuiteLine.Parameters)
+                    {
+                        Occurrence = Optional;
                     }
                     fieldattribute(DelayBetwnItr; BCPTSuiteLine."Delay (sec. btwn. iter.)")
                     {


### PR DESCRIPTION
In our devops pipelines we import a standard suite. And with this suite we are using parameters.
So we need the field parameters and tag in our import to get more detail for analyses and parameters to set the right parameters and not only the standard parameters.

@BardurKnudsen you now we work with parameters :)