### PR TITLE
VAT Specification shows incorrect LCY values

### DIFF
--- a/Apps/CZ/CoreLocalizationPack/app/Src/TableExtensions/VATAmountLine.TableExt.al
+++ b/Apps/CZ/CoreLocalizationPack/app/Src/TableExtensions/VATAmountLine.TableExt.al
@@ -225,10 +225,10 @@ tableextension 11793 "VAT Amount Line CZL" extends "VAT Amount Line"
     begin
         if TempTotalVATAmountLine.FindSet(true) then
             repeat
-                TempVATEntry.SetRange("VAT Identifier CZL", Rec."VAT Identifier");
-                TempVATEntry.SetRange("VAT Calculation Type", Rec."VAT Calculation Type");
-                TempVATEntry.SetRange("Tax Group Code", Rec."Tax Group Code");
-                TempVATEntry.SetRange("Use Tax", Rec."Use Tax");
+                TempVATEntry.SetRange("VAT Identifier CZL", TempTotalVATAmountLine."VAT Identifier");
+                TempVATEntry.SetRange("VAT Calculation Type", TempTotalVATAmountLinev."VAT Calculation Type");
+                TempVATEntry.SetRange("Tax Group Code", TempTotalVATAmountLine."Tax Group Code");
+                TempVATEntry.SetRange("Use Tax", TempTotalVATAmountLine."Use Tax");
                 if TempVATEntry.FindSet() then
                     repeat
                         TempTotalVATAmountLine."VAT Base (LCY) CZL" += Sign * TempVATEntry.Base;

--- a/Apps/CZ/CoreLocalizationPack/app/Src/TableExtensions/VATAmountLine.TableExt.al
+++ b/Apps/CZ/CoreLocalizationPack/app/Src/TableExtensions/VATAmountLine.TableExt.al
@@ -226,7 +226,7 @@ tableextension 11793 "VAT Amount Line CZL" extends "VAT Amount Line"
         if TempTotalVATAmountLine.FindSet(true) then
             repeat
                 TempVATEntry.SetRange("VAT Identifier CZL", TempTotalVATAmountLine."VAT Identifier");
-                TempVATEntry.SetRange("VAT Calculation Type", TempTotalVATAmountLinev."VAT Calculation Type");
+                TempVATEntry.SetRange("VAT Calculation Type", TempTotalVATAmountLine."VAT Calculation Type");
                 TempVATEntry.SetRange("Tax Group Code", TempTotalVATAmountLine."Tax Group Code");
                 TempVATEntry.SetRange("Use Tax", TempTotalVATAmountLine."Use Tax");
                 if TempVATEntry.FindSet() then


### PR DESCRIPTION
VAT Specification shows incorrect LCY values when multiple vat identifiers are present on the document

In document shown on screenshots LCY is CZK.

Broken baseapp functionality:
![Broken baseapp functionality](https://user-images.githubusercontent.com/7270284/116543674-71cee780-a8ee-11eb-81f1-d77f1f0c4550.png)

Fixed:
![Fixed](https://user-images.githubusercontent.com/7270284/116543677-72677e00-a8ee-11eb-8939-94d951284f45.png)

This error broke VAT Specification table on multiple CZL reports like Posted Sales Invoice, Posted Cr. Memo, etc.