### PR TITLE
Allow sending emails without the "To" recipients

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -1,7 +1,7 @@
 name: Build
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ master ]
 
 jobs:

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -1,7 +1,7 @@
 name: Build
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 
 jobs:

--- a/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
+++ b/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
@@ -290,7 +290,7 @@ codeunit 134689 "Email Message Unit Test"
 
         // [WHEN] An email is sent
         // [THEN] A validation error occurs
-        Email.Send(EmailMessage, TempEmailAccount."Account Id", TempEmailAccount.Connector);
+        asserterror Email.Send(EmailMessage, TempEmailAccount."Account Id", TempEmailAccount.Connector);
 
         // [THEN] The validation error is as expected
         Assert.ExpectedError(NoAccountErr);

--- a/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
+++ b/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
@@ -285,7 +285,7 @@ codeunit 134689 "Email Message Unit Test"
         ConnectorMock.Initialize();
         ConnectorMock.AddAccount(TempEmailAccount);
 
-        // [GIVEN] The message doesn't have any recipients
+        // [GIVEN] The message does not have any recipients
         EmailMessage.Create(Recipients, 'Test subject', 'Test body', true, RecipientsCC, RecipientsBCC);
 
         // [WHEN] An email is sent

--- a/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
+++ b/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
@@ -18,6 +18,7 @@ codeunit 134689 "Email Message Unit Test"
         EmailMessageSentCannotDeleteRecipientErr: Label 'Cannot delete the recipient because the email has already been sent.';
         EmailMessageQueuedCannotInsertRecipientErr: Label 'Cannot add a recipient because the email is queued to be sent.';
         EmailMessageSentCannotInsertRecipientErr: Label 'Cannot add the recipient because the email has already been sent.';
+        NoAccountErr: Label 'You must specify a valid email account to send the message to.';
 
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
@@ -245,6 +246,54 @@ codeunit 134689 "Email Message Unit Test"
         // Exercise/Verify// Exercise/Verify
         asserterror Message.AddAttachment('Attachment1', 'text/plain', Base64Convert.ToBase64('Content'));
         Assert.ExpectedError(EmailMessageQueuedCannotInsertAttachmentErr);
+    end;
+
+    [Test]
+    procedure SendMessageBccOnly()
+    var
+        TempEmailAccount: Record "Email Account" temporary;
+        EmailMessage: Codeunit "Email Message";
+        ConnectorMock: Codeunit "Connector Mock";
+        Recipients: List of [Text];
+        RecipientsCC: List of [Text];
+        RecipientsBCC: List of [Text];
+    begin
+        // Initialize
+        ConnectorMock.Initialize();
+        ConnectorMock.AddAccount(TempEmailAccount);
+
+        // [GIVEN] The message only has recipients in BCC
+        RecipientsBCC.Add('recipient@test.com');
+        EmailMessage.Create(Recipients, 'Test subject', 'Test body', true, RecipientsCC, RecipientsBCC);
+
+        // [WHEN] An email is sent
+        // [THEN] No error occurs
+        Email.Send(EmailMessage, TempEmailAccount."Account Id", TempEmailAccount.Connector);
+    end;
+
+    [Test]
+    procedure SendMessageNoRecipientsError()
+    var
+        TempEmailAccount: Record "Email Account" temporary;
+        EmailMessage: Codeunit "Email Message";
+        ConnectorMock: Codeunit "Connector Mock";
+        Recipients: List of [Text];
+        RecipientsCC: List of [Text];
+        RecipientsBCC: List of [Text];
+    begin
+        // Initialize
+        ConnectorMock.Initialize();
+        ConnectorMock.AddAccount(TempEmailAccount);
+
+        // [GIVEN] The message doesn't have any recipients
+        EmailMessage.Create(Recipients, 'Test subject', 'Test body', true, RecipientsCC, RecipientsBCC);
+
+        // [WHEN] An email is sent
+        // [THEN] A validation error occurs
+        Email.Send(EmailMessage, TempEmailAccount."Account Id", TempEmailAccount.Connector);
+
+        // [THEN] The validation error is as expected
+        Assert.ExpectedError(NoAccountErr);
     end;
 
     [Test]

--- a/Modules/System/Email/src/Email/EmailImpl.Codeunit.al
+++ b/Modules/System/Email/src/Email/EmailImpl.Codeunit.al
@@ -162,9 +162,7 @@ codeunit 8900 "Email Impl"
         if EmailMessageSent(EmailMessage.GetId()) then
             Error(EmailMessageSentErr);
 
-        EmailMessageImpl.ValidateRecipients(Enum::"Email Recipient Type"::"To");
-        EmailMessageImpl.ValidateRecipients(Enum::"Email Recipient Type"::Cc);
-        EmailMessageImpl.ValidateRecipients(Enum::"Email Recipient Type"::Bcc);
+        EmailMessageImpl.ValidateRecipients();
 
         // Validate email account
         EmailAccount.GetAllAccounts(false, Accounts);

--- a/Modules/System/Email/src/Email/Outbox/EmailEditor.Codeunit.al
+++ b/Modules/System/Email/src/Email/Outbox/EmailEditor.Codeunit.al
@@ -134,9 +134,7 @@ codeunit 8906 "Email Editor"
             Error(NoFromAccountErr);
 
         // Validate recipients
-        EmailMessage.ValidateRecipients(Enum::"Email Recipient Type"::"To");
-        EmailMessage.ValidateRecipients(Enum::"Email Recipient Type"::Cc);
-        EmailMessage.ValidateRecipients(Enum::"Email Recipient Type"::Bcc);
+        EmailMessage.ValidateRecipients();
 
         if EmailMessage.GetSubject() = '' then
             exit(Dialog.Confirm(NoSubjectlineQst, false));

--- a/Modules/System/Email/src/Message/EmailMessage.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessage.Codeunit.al
@@ -112,7 +112,7 @@ codeunit 8904 "Email Message"
     /// <param name="Recipients">Out parameter filled with the recipients' email addresses.</param>
     procedure GetRecipients(RecipientType: Enum "Email Recipient Type"; var Recipients: list of [Text])
     begin
-        EmailMessageImpl.GetRecipients(RecipientType, Recipients)
+        Recipients := EmailMessageImpl.GetRecipients(RecipientType);
     end;
 
     /// <summary>

--- a/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -246,18 +246,32 @@ codeunit 8905 "Email Message Impl."
         EmailAttachment."Content Id" := ContentId;
     end;
 
-    procedure GetRecipients(RecipientType: Enum "Email Recipient Type"; var Recipients: list of [Text])
+    procedure GetRecipients(): List of [Text]
     var
         EmailRecipients: Record "Email Recipient";
     begin
-        Clear(Recipients);
+        EmailRecipients.SetRange("Email Message Id", Message.Id);
+        exit(GetEmailAddressesOfRecipients(EmailRecipients));
+    end;
+
+    procedure GetRecipients(RecipientType: Enum "Email Recipient Type"): List of [Text]
+    var
+        EmailRecipients: Record "Email Recipient";
+    begin
         EmailRecipients.SetRange("Email Message Id", Message.Id);
         EmailRecipients.SetRange("Email Recipient Type", RecipientType);
-        if not EmailRecipients.FindSet() then
-            exit;
+        exit(GetEmailAddressesOfRecipients(EmailRecipients));
+    end;
+
+    local procedure GetEmailAddressesOfRecipients(var EmailRecipients: Record "Email Recipient"): List of [Text]
+    var
+        Recipients: List of [Text];
+    begin
+        if EmailRecipients.FindSet() then
         repeat
             Recipients.Add(EmailRecipients."Email Address");
         until EmailRecipients.Next() = 0;
+        exit(Recipients);
     end;
 
     procedure GetRecipientsAsText(RecipientType: Enum "Email Recipient Type"): Text
@@ -265,12 +279,12 @@ codeunit 8905 "Email Message Impl."
         RecipientList: List of [Text];
         Recipient, Result : Text;
     begin
-        GetRecipients(RecipientType, RecipientList);
+        RecipientList := GetRecipients(RecipientType);
 
         foreach Recipient in RecipientList do
-            Result := Result + ';' + Recipient;
+            Result += ';' + Recipient;
 
-        Result := DelChr(Result, '<>', ';'); // trim extra semicolons
+        Result := Result.TrimStart(';'); // trim extra semicolon
         exit(Result);
     end;
 
@@ -377,22 +391,16 @@ codeunit 8905 "Email Message Impl."
         exit(Message.Get(MessageId));
     end;
 
-    procedure ValidateRecipients(RecipientType: Enum "Email Recipient Type")
-    var
-        Recipients: List of [Text];
-    begin
-        GetRecipients(RecipientType, Recipients);
-
-        ValidateRecipients(Recipients, RecipientType);
-    end;
-
-    procedure ValidateRecipients(Recipients: List of [Text]; RecipientType: Enum "Email Recipient Type")
+    procedure ValidateRecipients()
     var
         EmailAccount: Codeunit "Email Account";
+        Recipients: List of [Text];
         Recipient: Text;
     begin
-        if (RecipientType = RecipientType::"To") and (Recipients.Count() = 0) then
-            Error(NoToAccountErr);
+        Recipients := GetRecipients();
+
+        if Recipients.Count() = 0 then
+            Error(NoAccountErr);
 
         foreach Recipient in Recipients do
             EmailAccount.ValidateEmailAddress(Recipient, false);
@@ -588,7 +596,7 @@ codeunit 8905 "Email Message Impl."
         EmailMessageSentCannotDeleteRecipientErr: Label 'Cannot delete the recipient because the email has already been sent.';
         EmailMessageQueuedCannotInsertRecipientErr: Label 'Cannot add a recipient because the email is queued to be sent.';
         EmailMessageSentCannotInsertRecipientErr: Label 'Cannot add the recipient because the email has already been sent.';
-        NoToAccountErr: Label 'You must specify a valid email account to send the message to.';
+        NoAccountErr: Label 'You must specify a valid email account to send the message to.';
         RgbReplacementTok: Label 'rgb($1, $2, $3)', Locked = true;
         RbgaPatternTok: Label 'rgba\((\d+), ?(\d+), ?(\d+), ?\d+\)', Locked = true;
 }


### PR DESCRIPTION
**Problem:**
It is not possible to send emails from BC if there is no email address in the "To" field.

**Solution:**
Change the validation logic so that it's enough to have at least one recipient in either of the fields: "To", "CC", "BCC"