### PR TITLE
Added Tenant in "Email Application AAD Registration"

### DIFF
--- a/Apps/W1/Email - Outlook REST API/app/src/EmailOAuthClient.Codeunit.al
+++ b/Apps/W1/Email - Outlook REST API/app/src/EmailOAuthClient.Codeunit.al
@@ -40,7 +40,7 @@ codeunit 4507 "Email - OAuth Client" implements "Email - OAuth Client"
                 if OAuth2.AcquireOnBehalfOfToken('', GraphResourceURLTxt, AccessToken) then;
         end else begin
             Initialize();
-            if (not OAuth2.AcquireAuthorizationCodeTokenFromCache(ClientId, ClientSecret, RedirectURL, StrSubstNo(OAuthAuthorityUrlTxt, TenantId), GraphResourceURLTxt, AccessToken)) or (AccessToken = '') or Force then
+            if (not OAuth2.AcquireAuthorizationCodeTokenFromCache(ClientId, ClientSecret, StrSubstNo(RedirectURL, TenantId), StrSubstNo(OAuthAuthorityUrlTxt, TenantId), GraphResourceURLTxt, AccessToken)) or (AccessToken = '') or Force then
                 OAuth2.AcquireTokenByAuthorizationCode(ClientId, ClientSecret, StrSubstNo(OAuthAuthorityUrlTxt, TenantId), StrSubstNo(RedirectURL, TenantId), GraphResourceURLTxt, Enum::"Prompt Interaction"::None, AccessToken, OAuthErr);
         end;
 
@@ -184,7 +184,6 @@ codeunit 4507 "Email - OAuth Client" implements "Email - OAuth Client"
 
     var
         OAuth2: Codeunit OAuth2;
-        
         [NonDebuggable]
         ClientId: Text;
         [NonDebuggable]

--- a/Apps/W1/Email - Outlook REST API/app/src/EmailOAuthClient.Codeunit.al
+++ b/Apps/W1/Email - Outlook REST API/app/src/EmailOAuthClient.Codeunit.al
@@ -169,7 +169,7 @@ codeunit 4507 "Email - OAuth Client" implements "Email - OAuth Client"
         AccessToken: Text;
     begin
         Initialize();
-        exit(OAuth2.AcquireAuthorizationCodeTokenFromCache(ClientId, ClientSecret, RedirectURL, StrSubstNo(OAuthAuthorityUrlTxt, TenantId), GraphResourceURLTxt, AccessToken) and (AccessToken <> ''))
+        exit(OAuth2.AcquireAuthorizationCodeTokenFromCache(ClientId, ClientSecret, StrSubstNo(RedirectURL, TenantId), StrSubstNo(OAuthAuthorityUrlTxt, TenantId), GraphResourceURLTxt, AccessToken) and (AccessToken <> ''))
     end;
 
     internal procedure SignInUsingAuthorizationCode(): Boolean
@@ -179,7 +179,7 @@ codeunit 4507 "Email - OAuth Client" implements "Email - OAuth Client"
         OAuthErr: Text;
     begin
         Initialize();
-        exit(OAuth2.AcquireTokenByAuthorizationCode(ClientID, ClientSecret, StrSubstNo(OAuthAuthorityUrlTxt, TenantId), RedirectURL, GraphResourceURLTxt, Enum::"Prompt Interaction"::"Select Account", AccessToken, OAuthErr) and (AccessToken <> ''));
+        exit(OAuth2.AcquireTokenByAuthorizationCode(ClientID, ClientSecret, StrSubstNo(OAuthAuthorityUrlTxt, TenantId), StrSubstNo(RedirectURL, TenantId), GraphResourceURLTxt, Enum::"Prompt Interaction"::"Select Account", AccessToken, OAuthErr) and (AccessToken <> ''));
     end;
 
     var

--- a/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPIHelper.Codeunit.al
+++ b/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPIHelper.Codeunit.al
@@ -197,14 +197,6 @@ codeunit 4509 "Email - Outlook API Helper"
             exit(Setup.RedirectURL);
     end;
 
-    procedure GetTenantID(): Text
-    var
-        Setup: Record "Email - Outlook API Setup";
-    begin
-        if Setup.Get() then
-            exit(Setup.TenantID);
-    end;
-
     procedure IsAzureAppRegistrationSetup(): Boolean
     var
         Setup: Record "Email - Outlook API Setup";

--- a/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPIHelper.Codeunit.al
+++ b/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPIHelper.Codeunit.al
@@ -197,6 +197,14 @@ codeunit 4509 "Email - Outlook API Helper"
             exit(Setup.RedirectURL);
     end;
 
+    procedure GetTenantID(): Text
+    var
+        Setup: Record "Email - Outlook API Setup";
+    begin
+        if Setup.Get() then
+            exit(Setup.TenantID);
+    end;
+
     procedure IsAzureAppRegistrationSetup(): Boolean
     var
         Setup: Record "Email - Outlook API Setup";

--- a/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPISetup.Page.al
+++ b/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPISetup.Page.al
@@ -112,6 +112,13 @@ page 4509 "Email - Outlook API Setup"
                             ValidateUri(Rec.RedirectURL);
                         end;
                     }
+
+                    field(TenantID; Rec.TenantID)
+                    {
+                        ApplicationArea = All;
+                        ToolTip = 'Specifies the Tenant ID.';
+                        Caption = 'Tenant ID';
+                    }
                 }
             }
         }
@@ -187,6 +194,7 @@ page 4509 "Email - Outlook API Setup"
                     Rec.ClientId := DummyGuid;
                     Rec.ClientSecret := DummyGuid;
                     Rec.RedirectURL := '';
+                    Rec.TenantID := '';
                     ClientSecretText := '';
                     ClientIdText := '';
 
@@ -215,6 +223,11 @@ page 4509 "Email - Outlook API Setup"
         if Rec.RedirectURL = '' then begin
             OAuth2.GetDefaultRedirectUrl(RedirectURLTxt);
             Rec.RedirectURL := CopyStr(RedirectURLTxt, 1, MaxStrLen(Rec.RedirectURL));
+            Rec.Modify();
+        end;
+
+        if Rec.TenantID = '' then begin
+            Rec.TenantID := CopyStr(DefaultTenantId, 1, MaxStrLen(Rec.TenantID));
             Rec.Modify();
         end;
 
@@ -249,7 +262,7 @@ page 4509 "Email - Outlook API Setup"
         [NonDebuggable]
         AccessToken: Text;
     begin
-        if not EmailOAuthClient.TryGetAccessToken(AccessToken) then
+        if not EmailOAuthClient.TryGetAccessToken(AccessToken, true) then
             Message(UnsuccessfulTestMsg)
         else
             Message(SuccessfulTestMsg);
@@ -268,6 +281,7 @@ page 4509 "Email - Outlook API Setup"
         UnsuccessfulTestMsg: Label 'We could not get access token with the current setup.\\Please verify the values on the page and try again.';
         SuccessfulTestMsg: Label 'Success! Your authentication was verified.';
         HiddenValueTxt: Label '******', Locked = true;
+        DefaultTenantId: Label 'Common', Locked = true;
         TopBannerVisible: Boolean;
         [InDataSet]
         IsUserLoggedIn: Boolean;

--- a/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPISetup.Page.al
+++ b/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPISetup.Page.al
@@ -230,7 +230,7 @@ page 4509 "Email - Outlook API Setup"
         end;
 
         if Rec.TenantID = '' then begin
-            if EnvInfo.IsSaaS() then
+            if EnvInfo.IsSaaSInfrastructure() then
                 Rec.TenantID := TenantInformation.GetTenantId()
             else
                 Rec.TenantID := CopyStr(DefaultTenantId, 1, MaxStrLen(Rec.TenantID));

--- a/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPISetup.Page.al
+++ b/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPISetup.Page.al
@@ -210,6 +210,9 @@ page 4509 "Email - Outlook API Setup"
         EmailOAuthClient: Codeunit "Email - OAuth Client";
         OAuth2: Codeunit "OAuth2";
         RedirectURLTxt: Text;
+        TenantInformation: Codeunit "Tenant Information";
+        EnvInfo: Codeunit "Environment Information";
+
     begin
         if not Rec.Get() then
             Rec.Insert();
@@ -227,7 +230,10 @@ page 4509 "Email - Outlook API Setup"
         end;
 
         if Rec.TenantID = '' then begin
-            Rec.TenantID := CopyStr(DefaultTenantId, 1, MaxStrLen(Rec.TenantID));
+            if EnvInfo.IsSaaS() then
+                Rec.TenantID := TenantInformation.GetTenantId()
+            else
+                Rec.TenantID := CopyStr(DefaultTenantId, 1, MaxStrLen(Rec.TenantID));
             Rec.Modify();
         end;
 

--- a/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPISetup.Table.al
+++ b/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPISetup.Table.al
@@ -29,11 +29,10 @@ table 4509 "Email - Outlook API Setup"
             Caption = 'Redirect URL';
             DataClassification = CustomerContent;
         }
-        field(5; TenantID; Text[36])
+        field(5; TenantID; Guid)
         {
             Caption = 'TenantID';
             DataClassification = CustomerContent;
-            InitValue = 'Common';
         }
     }
 
@@ -44,4 +43,25 @@ table 4509 "Email - Outlook API Setup"
             Clustered = true;
         }
     }
+
+    procedure GetNullGuidDefaultValue(): Text
+    var
+        DefaultTenantId: Label 'common', Locked = true;
+    begin
+        exit(DefaultTenantId);
+    end;
+
+    procedure GetTenantIDAsText(): Text
+    var
+        Setup: Record "Email - Outlook API Setup";
+        DummyGuid: Guid;
+        TExt2: Text;
+    begin
+        if Setup.Get() then
+            if IsNullGuid(Setup.TenantID) or (DummyGuid = Setup.TenantID) then
+                Setup.GetNullGuidDefaultValue()
+            else
+                // Remove braces
+                exit(format(Setup.TenantID).Substring(2, StrLen(Setup.TenantID) - 2));
+    end;
 }

--- a/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPISetup.Table.al
+++ b/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPISetup.Table.al
@@ -29,6 +29,12 @@ table 4509 "Email - Outlook API Setup"
             Caption = 'Redirect URL';
             DataClassification = CustomerContent;
         }
+        field(5; TenantID; Text[36])
+        {
+            Caption = 'TenantID';
+            DataClassification = CustomerContent;
+            InitValue = 'Common';
+        }
     }
 
     keys


### PR DESCRIPTION
Modified "Email Application AAD Registration" adding the Tenant field, I've kept the old value "Common" as default, but we also needed to use a custom value.

There is still a problem I wasn't able to fix with the cache.
When closing the "Email Application AAD Registration" page, the cache should be cleared and the new setup should be cached.
Currently, if you set the TenantID with a valid TenantID and send some emails, then you change the value with a not working one (Common in my case), emails are still sent due to the cache and the setup is skipped.