### PR TITLE
 Possibility to refresh a OBO token from cache for another Tenant

### DIFF
--- a/Modules/System/OAuth2/OAuth2.Codeunit.al
+++ b/Modules/System/OAuth2/OAuth2.Codeunit.al
@@ -551,6 +551,23 @@ codeunit 501 OAuth2
     /// <summary>
     /// Gets the token and token cache via the On-Behalf-Of OAuth2 v1.0 protocol flow. 
     /// </summary>
+    /// <param name="OAuthAuthorityUrl">The identity authorization provider URL.</param>
+    /// <param name="LoginHint">The user login hint, i.e. authentication email.</param>
+    /// <param name="RedirectURL">The redirectURL of your app, where authentication responses can be sent and received by your app. It must exactly match one of the redirectURLs you registered in the portal. If this parameter is empty, the default Business Central URL will be used.</param>
+    /// <param name="Scopes">A list of scopes that you want the user to consent to.</param>
+    /// <param name="TokenCache">The token cache acquired when the access token was requested .</param>
+    /// <param name="AccessToken">Exit parameter containing the access token.</param>
+    /// <param name="NewTokenCache">Exit parameter containing the new token cache.</param>
+    [NonDebuggable]
+    [TryFunction]
+    procedure AcquireOnBehalfOfTokenByTokenCache(OAuthAuthorityUrl: Text; LoginHint: Text; RedirectURL: Text; Scopes: List of [Text]; TokenCache: Text; var AccessToken: Text; var NewTokenCache: Text)
+    begin
+        OAuth2Impl.AcquireOnBehalfOfTokenByTokenCache(OAuthAuthorityUrl, LoginHint, RedirectURL, Scopes, TokenCache, AccessToken, NewTokenCache);
+    end;
+
+    /// <summary>
+    /// Gets the token and token cache via the On-Behalf-Of OAuth2 v1.0 protocol flow. 
+    /// </summary>
     /// <param name="LoginHint">The user login hint, i.e. authentication email.</param>
     /// <param name="RedirectURL">The redirectURL of your app, where authentication responses can be sent and received by your app. It must exactly match one of the redirectURLs you registered in the portal. If this parameter is empty, the default Business Central URL will be used.</param>
     /// <param name="Scopes">A list of scopes that you want the user to consent to.</param>

--- a/Modules/System/OAuth2/OAuth2Impl.Codeunit.al
+++ b/Modules/System/OAuth2/OAuth2Impl.Codeunit.al
@@ -459,6 +459,16 @@ codeunit 502 OAuth2Impl
     end;
 
     [NonDebuggable]
+    procedure AcquireOnBehalfOfTokenByTokenCache(OAuthAuthorityUrl: Text; LoginHint: Text; RedirectURL: Text; Scopes: List of [Text]; RefreshToken: Text; var AccessToken: Text; var NewRefreshToken: Text)
+    var
+        ScopesArray: DotNet StringArray;
+    begin
+        FillScopesArray(Scopes, ScopesArray);
+        Initialize(OAuthAuthorityUrl, RedirectURL);
+        AccessToken := AuthFlow.ALAcquireTokenFromTokenCacheState(ScopesArray, LoginHint, RefreshToken, NewRefreshToken);
+    end;
+
+    [NonDebuggable]
     procedure AcquireOnBehalfOfTokensByTokenCache(LoginHint: Text; RedirectURL: Text; Scopes: List of [Text]; RefreshToken: Text; var AccessToken: Text; var IdToken: Text; var NewRefreshToken: Text)
     var
         ScopesArray: DotNet StringArray;


### PR DESCRIPTION
Implements #12833.

There are no tests of the OAuth2 module since before, so there are no tests for this either.
I'm having a hard time to get the OBO functions in the OAuth2 module to work in my docker environment (they all work fine in SaaS), so I don't have the possibility to test this code at all. But it _should_ work, according to how the other code is working.

If someone could push me in the right direction to get the OBO flow to work in a docker environment I could confirm that this works as intended.