### PR TITLE
Message added as dimension to AddLogAppInsights

### DIFF
--- a/Modules/DevTools/BusinessCentralPerformanceToolkit/src/BCPTLine.Codeunit.al
+++ b/Modules/DevTools/BusinessCentralPerformanceToolkit/src/BCPTLine.Codeunit.al
@@ -200,6 +200,7 @@ codeunit 149005 "BCPT Line"
         Dimensions.Add('endTime', Format(BCPTLogEntry."End Time"));
         Dimensions.Add('duration', Format(BCPTLogEntry."Duration (ms)"));
         Dimensions.Add('sessionNo', Format(BCPTLogEntry."Session No."));
+        Dimensions.Add('message', BCPTLogEntry.Message);
         Session.LogMessage(
             '0000DGF',
             StrSubstNo(TelemetryLogLbl, BCPTLogEntry."BCPT Code", BCPTRoleWrapperImpl.GetScenarioLbl(), BCPTLogEntry.Status),


### PR DESCRIPTION
If the test is getting in an error you want also investigate the message.
This because the docker system will be removed because the performance toolkit you run periodic and you want also save the message.
@BardurKnudsen 