### PR TITLE
Add the possibility of using AddObject method

### DIFF
--- a/Modules/System/Cryptography Management/src/Xml/SignedXml.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/Xml/SignedXml.Codeunit.al
@@ -112,6 +112,23 @@ codeunit 1460 SignedXml
     end;
 
     /// <summary>
+    /// Initializes a new instance of the DataObject class.
+    /// </summary>
+    procedure InitializeDataObject()
+    begin
+        SignedXmlImpl.InitializeDataObject();
+    end;
+
+    /// <summary>
+    /// Adds a xml element of DataObject object to the list of objects to be signed.
+    /// </summary>
+    /// <param name="DataObjectXmlElement">The xml element of DataObject to add to the list of objects to be signed.</param>
+    procedure AddObject(DataObjectXmlElement: XmlElement)
+    begin
+        SignedXmlImpl.AddObject(DataObjectXmlElement);
+    end;
+
+    /// <summary>
     /// Adds a AddXmlDsigExcC14NTransformToReference object to the list of transforms to be performed on the data before passing it to the digest algorithm.
     /// </summary>
     procedure AddXmlDsigExcC14NTransformToReference()

--- a/Modules/System/Cryptography Management/src/Xml/SignedXmlImpl.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/Xml/SignedXmlImpl.Codeunit.al
@@ -136,6 +136,7 @@ codeunit 1461 "SignedXml Impl."
         DotNetSignedXml.AddObject(DotNetDataObject);
     end;
     #endregion
+    
     procedure SetSigningKey(var SignatureKey: Record "Signature Key")
     begin
         if SignatureKey.TryGetInstance(DotNetAsymmetricAlgorithm) then

--- a/Modules/System/Cryptography Management/src/Xml/SignedXmlImpl.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/Xml/SignedXmlImpl.Codeunit.al
@@ -128,11 +128,6 @@ codeunit 1461 "SignedXml Impl."
     begin
         XmlDotNetConvert.ToDotNet(DataObjectXmlElement, DotNetXmlElement);
         DotNetDataObject.LoadXml(DotNetXmlElement);
-        AddObject();
-    end;
-
-    local procedure AddObject()
-    begin
         DotNetSignedXml.AddObject(DotNetDataObject);
     end;
     #endregion

--- a/Modules/System/Cryptography Management/src/Xml/SignedXmlImpl.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/Xml/SignedXmlImpl.Codeunit.al
@@ -131,7 +131,7 @@ codeunit 1461 "SignedXml Impl."
         DotNetSignedXml.AddObject(DotNetDataObject);
     end;
     #endregion
-    
+
     procedure SetSigningKey(var SignatureKey: Record "Signature Key")
     begin
         if SignatureKey.TryGetInstance(DotNetAsymmetricAlgorithm) then

--- a/Modules/System/Cryptography Management/src/Xml/SignedXmlImpl.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/Xml/SignedXmlImpl.Codeunit.al
@@ -12,6 +12,7 @@ codeunit 1461 "SignedXml Impl."
         DotNetKeyInfo: DotNet KeyInfo;
         DotNetReference: DotNet Reference;
         DotNetSignedXml: DotNet SignedXml;
+        DotNetDataObject: DotNet DataObject;
 
 
     #region Constructors
@@ -114,6 +115,27 @@ codeunit 1461 "SignedXml Impl."
     end;
     #endregion
 
+    #region DataObject
+    procedure InitializeDataObject()
+    begin
+        DotNetDataObject := DotNetDataObject.DataObject();
+    end;
+
+    procedure AddObject(DataObjectXmlElement: XmlElement)
+    var
+        XmlDotNetConvert: Codeunit "Xml DotNet Convert";
+        DotNetXmlElement: DotNet XmlElement;
+    begin
+        XmlDotNetConvert.ToDotNet(DataObjectXmlElement, DotNetXmlElement);
+        DotNetDataObject.LoadXml(DotNetXmlElement);
+        AddObject();
+    end;
+
+    local procedure AddObject()
+    begin
+        DotNetSignedXml.AddObject(DotNetDataObject);
+    end;
+    #endregion
     procedure SetSigningKey(var SignatureKey: Record "Signature Key")
     begin
         if SignatureKey.TryGetInstance(DotNetAsymmetricAlgorithm) then

--- a/Modules/System/DotNet Aliases/src/dotnet.al
+++ b/Modules/System/DotNet Aliases/src/dotnet.al
@@ -1932,6 +1932,10 @@ dotnet
         Culture = 'neutral';
         PublicKeyToken = 'b03f5f7f11d50a3a';
 
+        type("System.Security.Cryptography.Xml.DataObject"; DataObject)
+        {
+        }
+
         type("System.Security.Cryptography.Xml.KeyInfo"; "KeyInfo")
         {
         }
@@ -1988,9 +1992,6 @@ dotnet
         }
 
         type("System.Security.Cryptography.Xml.XmlLicenseTransform"; "XmlLicenseTransform")
-        {
-        }
-        type("System.Security.Cryptography.Xml.DataObject"; DataObject)
         {
         }
     }

--- a/Modules/System/DotNet Aliases/src/dotnet.al
+++ b/Modules/System/DotNet Aliases/src/dotnet.al
@@ -1990,6 +1990,9 @@ dotnet
         type("System.Security.Cryptography.Xml.XmlLicenseTransform"; "XmlLicenseTransform")
         {
         }
+        type("System.Security.Cryptography.Xml.DataObject"; DataObject)
+        {
+        }
     }
 
     assembly("System.ServiceModel")


### PR DESCRIPTION
This adds the possibility to Add Object Element to the SignedXml and it simply uses method AddObject from SignedXml DotNet.

There was DataObject DotNet missing in the DotNet Aliases, that is why I have added the "System.Security.Cryptography.Xml.DataObject" under "System.Security" assembly.