### PR TITLE
Add GetPrinterType procedure to Printer Setup

### DIFF
--- a/Modules/System/Printer Management/src/PrinterManagement.Page.al
+++ b/Modules/System/Printer Management/src/PrinterManagement.Page.al
@@ -142,7 +142,7 @@ page 2616 "Printer Management"
     }
     trigger OnAfterGetRecord()
     begin
-        PrinterSetupImpl.GetPrinterCategory(PrinterType, Device);
+        PrinterType := PrinterSetupImpl.GetPrinterType(Rec);
     end;
 
     trigger OnOpenPage()

--- a/Modules/System/Printer Management/src/PrinterSetup.Codeunit.al
+++ b/Modules/System/Printer Management/src/PrinterSetup.Codeunit.al
@@ -11,16 +11,16 @@ codeunit 2616 "Printer Setup"
     Access = Public;
 
     /// <summary>
-    /// Retrieves the Printer Type for a printer.
+    /// Gets the type of a printer.
     /// </summary>
-    /// <param name="PrinterType">The Printer Type</param>
-    /// <param name="Device">The Device property value for the printer.</param>
+    /// <param name="Printer">The printer.</param>
+    /// <returns>The printer type.</returns>
     [Scope('OnPrem')]
-    procedure GetPrinterCategory(var PrinterType: Enum "Printer Type"; Device: Text[50])
+    procedure GetPrinterType(Printer: Record Printer): Enum "Printer Type"
     var
         PrinterSetupImpl: Codeunit "Printer Setup Impl.";
     begin
-        PrinterSetupImpl.GetPrinterCategory(PrinterType, Device);
+        exit(PrinterSetupImpl.GetPrinterType(Printer));
     end;
 
     /// <summary>

--- a/Modules/System/Printer Management/src/PrinterSetup.Codeunit.al
+++ b/Modules/System/Printer Management/src/PrinterSetup.Codeunit.al
@@ -11,10 +11,23 @@ codeunit 2616 "Printer Setup"
     Access = Public;
 
     /// <summary>
-    /// Integration event that is called to view and edit the settings of a printer. 
+    /// Retrieves the Printer Type for a printer.
+    /// </summary>
+    /// <param name="PrinterType">The Printer Type</param>
+    /// <param name="Device">The Device property value for the printer.</param>
+    [Scope('OnPrem')]
+    procedure GetPrinterCategory(var PrinterType: Enum "Printer Type"; Device: Text[50])
+    var
+        PrinterSetupImpl: Codeunit "Printer Setup Impl.";
+    begin
+        PrinterSetupImpl.GetPrinterCategory(PrinterType, Device);
+    end;
+
+    /// <summary>
+    /// Integration event that is called to view and edit the settings of a printer.
     /// Subscribe to this event if you want to introduce user configurable settings for a printer.
     /// </summary>
-    /// <param name="PrinterID">A value that determines the printer being drilled down.</param>    
+    /// <param name="PrinterID">A value that determines the printer being drilled down.</param>
     /// <param name="IsHandled">Stores whether the operation was successful.</param>
     [IntegrationEvent(false, false)]
     internal procedure OnOpenPrinterSettings(PrinterID: Text; var IsHandled: Boolean)
@@ -22,11 +35,11 @@ codeunit 2616 "Printer Setup"
     end;
 
     /// <summary>
-    /// Integration event that is called to set the default printer for all reports. 
+    /// Integration event that is called to set the default printer for all reports.
     ///  Subscribe to this event to specify a value in the Printer Name field and leave the User ID and Report ID fields blank in Printers Selection.
     /// </summary>
     /// <param name="PrinterID">A value that determines the printer being set as default.</param>
-    /// <param name="UserID">A value that determines the user for whom the printer is being set as default. Empty value implies all users.</param>  
+    /// <param name="UserID">A value that determines the user for whom the printer is being set as default. Empty value implies all users.</param>
     /// <param name="IsHandled">Stores whether the operation was successful.</param>
     [IntegrationEvent(false, false)]
     internal procedure OnSetAsDefaultPrinter(PrinterID: Text; UserID: Text; var IsHandled: Boolean)

--- a/Modules/System/Printer Management/src/PrinterSetupImpl.Codeunit.al
+++ b/Modules/System/Printer Management/src/PrinterSetupImpl.Codeunit.al
@@ -18,12 +18,12 @@ codeunit 2617 "Printer Setup Impl."
         SetMyDefaultPrinterSucessMsg: Label 'Printer %1 is set as default printer for all reports. You can open Printer Selections page to see the created entry.', Comment = '%1 = Printer ID';
         SetDefaultPrinterForAllUsersSucessMsg: Label 'Printer %1 is set as default printer for all reports of all users. You can open Printer Selections page to see the created entry.', Comment = '%1 = Printer ID';
 
-    procedure GetPrinterCategory(var PrinterType: Enum "Printer Type"; Device: Text[50])
+    procedure GetPrinterType(Printer: Record Printer): Enum "Printer Type"
     begin
-        if Device = NetworkPrinterTxt then
-            PrinterType := PrinterType::"Network Printer"
+        if Printer.Device = NetworkPrinterTxt then
+            exit(Enum::"Printer Type"::"Network Printer")
         else
-            PrinterType := PrinterType::"Local Printer";
+            exit(Enum::"Printer Type"::"Local Printer");
     end;
 
     procedure OpenPrinterSettings(PrinterID: Text)


### PR DESCRIPTION
Adds (exposes) a `GetPrinterType` procedure to the `"Printer Setup"` codeunit.

Restricted to `[Scope('OnPrem')]`. 

To be used for On-Premise extensions, as a more stable alternative to copying the implementation of `GetPrinterCategory` in the `"Printer Setup Impl."` codeunit.

Addresses #7549.