### PR TITLE
Bugfix for new property "ImmutableStorageWithVersioningEnabled"

### DIFF
--- a/Modules/System/Azure Blob Services API/src/Helper/ABSHelperLibrary.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSHelperLibrary.Codeunit.al
@@ -192,7 +192,7 @@ codeunit 9043 "ABS Helper Library"
         Clear(FldNo);
         Fld.Reset();
         Fld.SetRange(TableNo, TableNo);
-        Fld.SetRange(FieldName, FldName);
+        Fld.SetRange(FieldName, CopyStr(FldName, 1, MaxStrLen(Fld.FieldName)));
         if Fld.FindFirst() then
             FldNo := Fld."No.";
         exit(FldNo <> 0);


### PR DESCRIPTION
In the current version of Azure Storage API (2020-10-02) a new property was introduced in the response of the "List Containers"-operation.

In the previous version (2020-04-08) the response looked like this:
```
<?xml version="1.0" encoding="utf-8"?>
<EnumerationResults ServiceEndpoint="https://azstortest002.blob.core.windows.net/">
  <Containers>
    <Container>
      <Name>test</Name>
      <Properties>
        <Last-Modified>Fri, 08 Oct 2021 13:37:18 GMT</Last-Modified>
        <Etag>"0x8D98A60BF92258B"</Etag>
        <LeaseStatus>unlocked</LeaseStatus>
        <LeaseState>available</LeaseState>
        <DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope>
        <DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride>
        <HasImmutabilityPolicy>false</HasImmutabilityPolicy>
        <HasLegalHold>false</HasLegalHold>
      </Properties>
    </Container>
  </Containers>
  <NextMarker />
</EnumerationResults>
```

In the current version (2020-10-02) it looks like this, because blob versioning was introduced (see https://azure.microsoft.com/en-us/updates/immutable-storage-with-versioning-for-blob-storage-is-now-in-public-preview/)
```
<?xml version="1.0" encoding="utf-8"?>
<EnumerationResults ServiceEndpoint="https://azstortest002.blob.core.windows.net/">
  <Containers>
    <Container>
      <Name>test</Name>
      <Properties>
        <Last-Modified>Fri, 08 Oct 2021 13:37:18 GMT</Last-Modified>
        <Etag>"0x8D98A60BF92258B"</Etag>
        <LeaseStatus>unlocked</LeaseStatus>
        <LeaseState>available</LeaseState>
        <DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope>
        <DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride>
        <HasImmutabilityPolicy>false</HasImmutabilityPolicy>
        <HasLegalHold>false</HasLegalHold>
        <ImmutableStorageWithVersioningEnabled>false</ImmutableStorageWithVersioningEnabled>
      </Properties>
    </Container>
  </Containers>
  <NextMarker />
</EnumerationResults>
```

The SetRange in `codeunit 9043 "ABS Helper Library"` now causes an error, since the value it's looking for (ImmutableStorageWithVersioningEnabled) is longer than the max length of `FieldName`. So when ListContainers is called you'll receive the error:

`The length of the string 37, but it must be less than or equal to 30 characters. Value: ImmutableStorageWithVersioningEnabled`

If you test it, please test against a real storage account, as I don't think that Azurite already reflects this change. 