### PR TITLE
Regex allowing precompiled patterns for subsequent calls

### DIFF
--- a/Modules/System Tests/Regex/src/RegexTests.Codeunit.al
+++ b/Modules/System Tests/Regex/src/RegexTests.Codeunit.al
@@ -10,6 +10,7 @@ codeunit 135057 RegexTests
 
     var
         Regex: Codeunit Regex;
+        InstanceRegex: Codeunit Regex;
         Assert: Codeunit "Library Assert";
 
     [Test]
@@ -20,10 +21,13 @@ codeunit 135057 RegexTests
     begin
         // [Given] A pattern that matches american phone numbers
         Pattern := '\G[a-zA-Z0-9]\d{2}[a-zA-Z0-9](-\d{3}){2}[A-Za-z0-9]$';
+        InstanceRegex.Regex(Pattern);
 
         // [Then] It returns true for an american number and false for a danish number
         Assert.IsTrue(Regex.IsMatch('1298-673-4192', Pattern), 'Number does not match pattern');
         Assert.IsFalse(Regex.IsMatch('12 23 45 67', Pattern), 'Number wrongly matches pattern');
+        Assert.IsTrue(InstanceRegex.IsMatch('1298-673-4192'), 'Number does not match pattern');
+        Assert.IsFalse(InstanceRegex.IsMatch('12 23 45 67'), 'Number wrongly matches pattern');
 
         // [When] Starting position is set to an index 
         StartAt := 6;
@@ -31,6 +35,8 @@ codeunit 135057 RegexTests
         // [Then] It only matches on string with that starting positon
         Assert.IsFalse(Regex.IsMatch('Test: 1298-673-4192', Pattern), 'Number wrongly matches pattern');
         Assert.IsTrue(Regex.IsMatch('Test: 1298-673-4192', Pattern, StartAt), 'Number does not match pattern');
+        Assert.IsFalse(InstanceRegex.IsMatch('Test: 1298-673-4192'), 'Number wrongly matches pattern');
+        Assert.IsTrue(InstanceRegex.IsMatch('Test: 1298-673-4192', StartAt), 'Number does not match pattern');
     end;
 
     [Test]
@@ -42,10 +48,15 @@ codeunit 135057 RegexTests
     begin
         // [Given] A pattern that matches two words that are the same
         Pattern := '\b  p  \S*';
+        InstanceRegex.Regex(Pattern);
 
         // [Then] Regex does match anything because of the whitespaces in
         Assert.IsFalse(Regex.IsMatch('Empower every person and organization...', Pattern), 'Wrongly found a match');
+        Assert.IsFalse(InstanceRegex.IsMatch('Empower every person and organization...'), 'Wrongly found a match');
+
         Regex.Match('Empower every person and organization...', Pattern, Match);
+        Assert.AreEqual('', Match.ReadValue(), 'Wrongly found a match, despite whitespace in pattern');
+        InstanceRegex.Match('Empower every person and organization...', Match);
         Assert.AreEqual('', Match.ReadValue(), 'Wrongly found a match, despite whitespace in pattern');
 
         // [When] Regex is initialized with pattern and IgnorePatternWhiteSpace option
@@ -54,6 +65,14 @@ codeunit 135057 RegexTests
         // [Then] Regex matches with "person"
         Assert.IsTrue(Regex.IsMatch('Empower every person and organization...', Pattern, RegexOptions), 'Did not find a match');
         Regex.Match('Empower every person and organization...', Pattern, RegexOptions, Match);
+        Assert.AreEqual('person', Match.ReadValue(), 'Did not match the right word');
+
+        // [When] Regex is initialized with pattern and IgnorePatternWhiteSpace option
+        InstanceRegex.Regex(Pattern, RegexOptions);
+
+        // [Then] Regex matches with "person"
+        Assert.IsTrue(InstanceRegex.IsMatch('Empower every person and organization...'), 'Did not find a match');
+        InstanceRegex.Match('Empower every person and organization...', Match);
         Assert.AreEqual('person', Match.ReadValue(), 'Did not match the right word');
     end;
 
@@ -74,6 +93,35 @@ codeunit 135057 RegexTests
         Assert.AreEqual('person', Matches.ReadValue(), 'Did not match the right words');
         Matches.Get(1);
         Assert.AreEqual('organization', Matches.ReadValue(), Format(Matches.MatchIndex));
+
+        // [When] Regex matches pattern
+        InstanceRegex.Regex(Pattern);
+        InstanceRegex.Match('Empower every person and every organization on the planet to achieve more.', Matches);
+
+        // [Then] Regex finds two words that match and the second one is 'organization'. 
+        Assert.AreEqual(2, Matches.Count(), 'Did not match correct number of words on sentence');
+        Assert.AreEqual('person', Matches.ReadValue(), 'Did not match the right words');
+        Matches.Get(1);
+        Assert.AreEqual('organization', Matches.ReadValue(), Format(Matches.MatchIndex));
+    end;
+
+    local procedure RegexGroupsTestCheckGroups(var CheckMatches: Record Matches; var CheckGroups: Record Groups)
+    begin
+        // [Then] Regex recognizes multiple Regex Groups on the first match "Microsoft®"
+        Assert.AreEqual('Microsoft®', CheckGroups.ReadValue(), 'Did not match first group item correctly');
+        Assert.AreEqual('0', CheckGroups.Name, 'Group name is wrong');
+
+        CheckGroups.Next();
+        Assert.AreEqual('Microsoft', CheckGroups.ReadValue(), 'Did not match second group item correctly');
+        Assert.AreEqual('1', CheckGroups.Name, 'Group name is wrong');
+
+        // [And] recognizes the next Regex Group as "Excel®"
+        CheckMatches.Next();
+        Regex.Groups(CheckMatches, CheckGroups);
+
+        Assert.AreEqual('Excel®', CheckGroups.ReadValue(), 'Did not match first group item of second group correctly');
+        CheckGroups.Next();
+        Assert.AreEqual('Excel', CheckGroups.ReadValue(), 'Did not match first group item of second group correctly');
     end;
 
     [Test]
@@ -90,24 +138,18 @@ codeunit 135057 RegexTests
 
         // [When] Regex matches pattern, and the resulting MatchCollection is copied to an array 
         Regex.Match(Input, Pattern, Matches);
-
-        // [Then] Regex recognizes multiple Regex Groups on the first match "Microsoft®"
         Regex.Groups(Matches, Groups);
 
-        Assert.AreEqual('Microsoft®', Groups.ReadValue(), 'Did not match first group item correctly');
-        Assert.AreEqual('0', Groups.Name, 'Group name is wrong');
+        // [Then] Checks are performed
+        RegexGroupsTestCheckGroups(Matches, Groups);
 
-        Groups.Next();
-        Assert.AreEqual('Microsoft', Groups.ReadValue(), 'Did not match second group item correctly');
-        Assert.AreEqual('1', Groups.Name, 'Group name is wrong');
+        // [When] Regex matches pattern, and the resulting MatchCollection is copied to an array 
+        InstanceRegex.Regex(Pattern);
+        InstanceRegex.Match(Input, Matches);
+        InstanceRegex.Groups(Matches, Groups);
 
-        // [And] recognizes the next Regex Group as "Excel®"
-        Matches.Next();
-        Regex.Groups(Matches, Groups);
-
-        Assert.AreEqual('Excel®', Groups.ReadValue(), 'Did not match first group item of second group correctly');
-        Groups.Next();
-        Assert.AreEqual('Excel', Groups.ReadValue(), 'Did not match first group item of second group correctly');
+        // [Then] Checks are performed
+        RegexGroupsTestCheckGroups(Matches, Groups);
     end;
 
     [Test]
@@ -118,16 +160,21 @@ codeunit 135057 RegexTests
     begin
         // [Given] A pattern that matches two words that are the same
         Pattern := '\b(?<word>\w+)\s+(\k<word>)\b';
+        InstanceRegex.Regex(Pattern);
 
         // [Then] Module replaces words that are the same (sensitive to casing)
         Assert.AreEqual('This is a Test test', Regex.Replace('This is a Test test', Pattern, 'test'), 'Regex wrongly replaced words with different casing');
+        Assert.AreEqual('This is a Test test', InstanceRegex.Replace('This is a Test test', 'test'), 'Regex wrongly replaced words with different casing');
         Assert.AreEqual('This is a test', Regex.Replace('This is a test test', Pattern, 'test'), 'Regex did not replace pattern');
+        Assert.AreEqual('This is a test', InstanceRegex.Replace('This is a test test', 'test'), 'Regex did not replace pattern');
 
         // [When] Regex is initialized with pattern and Ignore Case option 
         RegexOptions.IgnoreCase := true;
+        InstanceRegex.Regex(Pattern, RegexOptions);
 
         // [Then] Module replaces words that are the same (insensitive to casing)
         Assert.AreEqual('This is a test', Regex.Replace('This is a Test test', Pattern, 'test', RegexOptions), 'Regex correctly replaced words with different casing');
+        Assert.AreEqual('This is a test', InstanceRegex.Replace('This is a Test test', 'test'), 'Regex correctly replaced words with different casing');
     end;
 
     [Test]
@@ -142,16 +189,19 @@ codeunit 135057 RegexTests
         Pattern := '(.)\1+';
         Replacement := '$1';
         "Count" := 1;
+        InstanceRegex.Regex(Pattern);
 
         // [When] Replacing based on the pattern and count
         // [Then] It replaces only the first sequence of characters (aa -> a)
         Assert.AreEqual('abbccdd', Regex.Replace('aabbccdd', Pattern, Replacement, "Count"), 'Did not replace correct character');
+        Assert.AreEqual('abbccdd', InstanceRegex.Replace('aabbccdd', Replacement, "Count"), 'Did not replace correct character');
 
         // [When] Starting position is 1
         StartAt := 1;
 
         // [Then] It replaces only the first sequence of characters after starting position (bb -> b)
         Assert.AreEqual('aabccdd', Regex.Replace('aabbccdd', Pattern, Replacement, "Count", StartAt), 'Did not replace correct character');
+        Assert.AreEqual('aabccdd', InstanceRegex.Replace('aabbccdd', Replacement, "Count", StartAt), 'Did not replace correct character');
     end;
 
     [Test]
@@ -166,9 +216,18 @@ codeunit 135057 RegexTests
         Pattern := '[a-z]+';
         "Count" := 2;
         StartAt := 6;
+        InstanceRegex.Regex(Pattern);
 
         // [When] Running Split on a string 
         Regex.Split('1234Def5678Ghi9012', Pattern, TextSplitList);
+
+        // [Then] It is split into three items and the first one is '1234D'
+        Assert.AreEqual(3, TextSplitList.Count(), 'Did not split string into correct number of subsentences');
+        Assert.AreEqual('1234D', TextSplitList.Get(1), 'Incorrect split');
+        System.Clear(TextSplitList);
+
+        // [When] Running Split on a string using the Regex pattern constructor
+        InstanceRegex.Split('1234Def5678Ghi9012', TextSplitList);
 
         // [Then] It is split into three items and the first one is '1234D'
         Assert.AreEqual(3, TextSplitList.Count(), 'Did not split string into correct number of subsentences');
@@ -183,12 +242,29 @@ codeunit 135057 RegexTests
         Assert.AreEqual('1234D', TextSplitList.Get(1), 'Incorrect split with count');
         System.Clear(TextSplitList);
 
+        // [When] Running Split on a string with count using the Regex pattern constructor
+        InstanceRegex.Split('1234Def5678Ghi9012abc', "Count", TextSplitList);
+
+        // [Then] String is only split into two items
+        Assert.AreEqual(2, TextSplitList.Count(), 'Did not split (w. count) string into correct number of subsentences');
+        Assert.AreEqual('1234D', TextSplitList.Get(1), 'Incorrect split with count');
+        System.Clear(TextSplitList);
+
         // [When] Running Split on a string with count and starting position
         Regex.Split('1234Def5678Ghi9012abc', Pattern, "Count", StartAt, TextSplitList);
 
         // [Then] String is only split into two items
         Assert.AreEqual(2, TextSplitList.Count(), 'Did not split string (w. count & starting pos.) into correct number of subsentences');
         Assert.AreEqual('1234De', TextSplitList.Get(1), 'Incorrect split with count and starting positions');
+        System.Clear(TextSplitList);
+
+        // [When] Running Split on a string with count and starting position using the Regex pattern constructor
+        InstanceRegex.Split('1234Def5678Ghi9012abc', "Count", StartAt, TextSplitList);
+
+        // [Then] String is only split into two items
+        Assert.AreEqual(2, TextSplitList.Count(), 'Did not split string (w. count & starting pos.) into correct number of subsentences');
+        Assert.AreEqual('1234De', TextSplitList.Get(1), 'Incorrect split with count and starting positions');
+        System.Clear(TextSplitList);
     end;
 
     [Test]
@@ -216,15 +292,19 @@ codeunit 135057 RegexTests
         // [Given] A Regex pattern, and a string of danish characters
         Pattern := '\b(\w+\s*)+';
         Evaluator := 'æøå';
+        InstanceRegex.Regex(Pattern);
 
         // [Then] It matches the string
         Assert.IsTrue(Regex.IsMatch(Evaluator, Pattern), 'Did not match string of danish characters');
+        Assert.IsTrue(InstanceRegex.IsMatch(Evaluator), 'Did not match string of danish characters');
 
         // [When] Running IsMatch with ECMAScript option
         RegexOptions.ECMAScript := true;
+        InstanceRegex.Regex(Pattern, RegexOptions);
 
         // [Then] It will not match anything
         Assert.IsFalse(Regex.IsMatch(Evaluator, Pattern, RegexOptions), 'Wrongly matched string of danish characters');
+        Assert.IsFalse(InstanceRegex.IsMatch(Evaluator), 'Wrongly matched string of danish characters');
     end;
 
     [Test]
@@ -240,9 +320,21 @@ codeunit 135057 RegexTests
         // [Given] A Regex pattern, and a string of danish characters
         Pattern := '\b\(?((?>\w+),?\s?)+[\.!?]\)?';
         Evaluator := 'This is a sentence.';
+        InstanceRegex.Regex(Pattern);
 
         // [When] Running Matches, and extracting the captures in the first group of the first match.
         Regex.Match(Evaluator, Pattern, Matches);
+        Regex.Groups(Matches, Groups);
+        Groups.Get(1);
+
+        Regex.Captures(Groups, Captures);
+
+        // [Then] There are 2 GroupCollections, where the second one contains 4 captures (one for each word)
+        Assert.AreEqual(2, Groups.Count(), 'Did not find 2 groups');
+        Assert.AreEqual(4, Captures.Count(), 'Did not find 4 captures');
+
+        // [When] Running Matches, and extracting the captures in the first group of the first match using the Regex pattern constructor.
+        InstanceRegex.Match(Evaluator, Matches);
         Regex.Groups(Matches, Groups);
         Groups.Get(1);
 
@@ -261,6 +353,18 @@ codeunit 135057 RegexTests
         // [Then] There is 1 GroupCollections, that contains 1 capture (the entire sentence)
         Assert.AreEqual(1, Groups.Count(), 'Did not find 1 Group');
         Assert.AreEqual(1, Captures.Count(), 'Did not find 1 Capture');
+
+        // [When] Running Matches with explicit capture, and extracting the captures in the first group of the first match using the Regex pattern constructor.
+        RegexOptions.ExplicitCapture := true;
+        InstanceRegex.Regex(Pattern, RegexOptions);
+
+        InstanceRegex.Match(Evaluator, Matches);
+        InstanceRegex.Groups(Matches, Groups);
+        InstanceRegex.Captures(Groups, Captures);
+
+        // [Then] There is 1 GroupCollections, that contains 1 capture (the entire sentence)
+        Assert.AreEqual(1, Groups.Count(), 'Did not find 1 Group');
+        Assert.AreEqual(1, Captures.Count(), 'Did not find 1 Capture');
     end;
 
     [Test]
@@ -274,6 +378,7 @@ codeunit 135057 RegexTests
         // [Given] A Regex pattern that matches words beginning with 't', and a test string.
         Pattern := '\bt\w+\s';
         Evaluator := 'testing right-left';
+        InstanceRegex.Regex(Pattern);
 
         // [When] Matching without RegexOptions starting from index 8
         IsMatched := Regex.IsMatch(Evaluator, Pattern, 8);
@@ -281,11 +386,54 @@ codeunit 135057 RegexTests
         // [Then] Nothing will match
         Assert.IsFalse(IsMatched, 'Wrongly matched word');
 
+        // [When] Matching without RegexOptions starting from index 8
+        IsMatched := InstanceRegex.IsMatch(Evaluator, 8);
+
+        // [Then] Nothing will match
+        Assert.IsFalse(IsMatched, 'Wrongly matched word');
+
         // [When] Matching with Right-To-Left RegexOption starting from index 8
         RegexOptions.RightToLeft := true;
+        InstanceRegex.Regex(Pattern, RegexOptions);
 
         // [Then] It will match the word 'testing', since it in the substring we match against. 
         Assert.IsTrue(Regex.IsMatch(Evaluator, Pattern, 8, RegexOptions), 'Did not match word');
+        Assert.IsTrue(InstanceRegex.IsMatch(Evaluator, 8), 'Did not match word');
+    end;
+
+    local procedure GroupNameGroupNumberTestCheck(var ThisRegex: Codeunit Regex)
+    var
+        GroupNames: List of [Text];
+        GroupNumbers: List of [Integer];
+        GroupName: Text;
+        GroupNumber: Integer;
+    begin
+        // [Then] It matches 5 groups (5 group names and 5 group numbers)
+        ThisRegex.GetGroupNames(GroupNames);
+        Assert.AreEqual(5, GroupNames.Count(), 'Not the right number of Groupnames');
+
+        ThisRegex.GetGroupNumbers(GroupNumbers);
+        Assert.AreEqual(5, GroupNumbers.Count(), 'Not the right number of Groupnumbers');
+
+        // [When] Getting GroupNumberFromName FirstWord
+        GroupNumber := ThisRegex.GroupNumberFromName('FirstWord');
+
+        // [Then] We get GroupNumber 3
+        Assert.AreEqual(3, GroupNumber, 'Firstword Groupname did not match');
+
+        // [And] The GroupName for Group 3 is FirstWord
+        GroupName := ThisRegex.GroupNameFromNumber(GroupNumber);
+        Assert.AreEqual('FirstWord', GroupName, 'Firstword Groupname did not match');
+
+        // [When] Getting GroupNumberFromName LastWord
+        GroupNumber := ThisRegex.GroupNumberFromName('LastWord');
+
+        // [Then] We get GroupNumber 4
+        Assert.AreEqual(4, GroupNumber, 'LastWord Groupname did not match');
+
+        // [And] The GroupName for Group 4 is LastWord
+        GroupName := ThisRegex.GroupNameFromNumber(GroupNumber);
+        Assert.AreEqual('LastWord', GroupName, 'LastWord Groupname did not match');
     end;
 
     [Test]
@@ -294,10 +442,6 @@ codeunit 135057 RegexTests
         Match: Record Matches;
         Pattern: Text;
         Input: Text;
-        GroupNames: List of [Text];
-        GroupNumbers: List of [Integer];
-        GroupName: Text;
-        GroupNumber: Integer;
     begin
         // [Given] A Regex pattern that matches all words but creates a Regex Group for the first and last word.
         Pattern := '\b(?<FirstWord>\w+)\s?((\w+)\s)*(?<LastWord>\w+)';
@@ -306,32 +450,15 @@ codeunit 135057 RegexTests
         // [When] Matching with an arbitrary sentence   
         Regex.Match(Input, Pattern, Match);
 
-        // [Then] It matches 5 groups (5 group names and 5 group numbers)
-        Regex.GetGroupNames(GroupNames);
-        Assert.AreEqual(5, GroupNames.Count(), 'Not the right number of Groupnames');
+        // [Then] Checks are performed
+        GroupNameGroupNumberTestCheck(Regex);
 
-        Regex.GetGroupNumbers(GroupNumbers);
-        Assert.AreEqual(5, GroupNumbers.Count(), 'Not the right number of Groupnumbers');
+        // [When] Matching with an arbitrary sentence   
+        InstanceRegex.Regex(Pattern);
+        InstanceRegex.Match(Input, Match);
 
-        // [When] Getting GroupNumberFromName FirstWord
-        GroupNumber := Regex.GroupNumberFromName('FirstWord');
-
-        // [Then] We get GroupNumber 3
-        Assert.AreEqual(3, GroupNumber, 'Firstword Groupname did not match');
-
-        // [And] The GroupName for Group 3 is FirstWord
-        GroupName := Regex.GroupNameFromNumber(GroupNumber);
-        Assert.AreEqual('FirstWord', GroupName, 'Firstword Groupname did not match');
-
-        // [When] Getting GroupNumberFromName LastWord
-        GroupNumber := Regex.GroupNumberFromName('LastWord');
-
-        // [Then] We get GroupNumber 4
-        Assert.AreEqual(4, GroupNumber, 'LastWord Groupname did not match');
-
-        // [And] The GroupName for Group 4 is LastWord
-        GroupName := Regex.GroupNameFromNumber(GroupNumber);
-        Assert.AreEqual('LastWord', GroupName, 'LastWord Groupname did not match');
+        // [Then] Checks are performed
+        GroupNameGroupNumberTestCheck(InstanceRegex);
     end;
 
     [Test]
@@ -343,20 +470,31 @@ codeunit 135057 RegexTests
     begin
         // [Given] A pattern that matches two words that are the same
         Pattern := '\b  P  \S*';
+        InstanceRegex.Regex(Pattern);
 
         // [Then] Regex does match anything because of the whitespaces in
         Assert.IsFalse(Regex.IsMatch('Empower every person and organization...', Pattern), 'Wrongly found a match');
+        Assert.IsFalse(InstanceRegex.IsMatch('Empower every person and organization...'), 'Wrongly found a match');
+
         Regex.Match('Empower every person and organization...', Pattern, Match);
+        Assert.AreEqual('', Match.ReadValue(), 'Wrongly found a match, despite whitespace in pattern');
+
+        InstanceRegex.Match('Empower every person and organization...', Match);
         Assert.AreEqual('', Match.ReadValue(), 'Wrongly found a match, despite whitespace in pattern');
 
         // [When] Regex is initialized with pattern and IgnorePatternWhiteSpace option
         RegexOptions.IgnorePatternWhitespace := true;
         RegexOptions.IgnoreCase := true;
         RegexOptions.Compiled := true;
+        InstanceRegex.Regex(Pattern, RegexOptions);
 
         // [Then] Regex matches with "person"
         Assert.IsTrue(Regex.IsMatch('Empower every person and organization...', Pattern, RegexOptions), 'Did not find a match');
         Regex.Match('Empower every person and organization...', Pattern, RegexOptions, Match);
+        Assert.AreEqual('person', Match.ReadValue(), 'Did not match the right word');
+
+        Assert.IsTrue(InstanceRegex.IsMatch('Empower every person and organization...'), 'Did not find a match');
+        InstanceRegex.Match('Empower every person and organization...', Match);
         Assert.AreEqual('person', Match.ReadValue(), 'Did not match the right word');
     end;
 
@@ -385,6 +523,20 @@ codeunit 135057 RegexTests
 
         // [Then] The double hyphens were replaced with parentheses 
         Assert.AreEqual('(decisively)', ResultingText, 'Did not replace correctly');
+
+        // [When] Matching using the Regex pattern constructor
+        InstanceRegex.Regex(Pattern);
+        InstanceRegex.Match(Input, Matches);
+
+        // [Then] Then it matches the first word within double hyphens 
+        Assert.AreEqual('--decisively--', Matches.ReadValue(), 'Did not match correctly');
+
+        // [When] Running MatchResult with replacement pattern 
+        Replacement := '($1)';
+        ResultingText := InstanceRegex.MatchResult(Matches, Replacement);
+
+        // [Then] The double hyphens were replaced with parentheses 
+        Assert.AreEqual('(decisively)', ResultingText, 'Did not replace correctly');
     end;
 
     [Test]
@@ -403,14 +555,88 @@ codeunit 135057 RegexTests
         RegexOptions.MatchTimeoutInMs := 100;
 
         // [Then] We get an error, because the timeout should be minimum 1000 ms 
-        Asserterror Regex.Match(Input, Pattern, RegexOptions, Matches);
+        asserterror Regex.Match(Input, Pattern, RegexOptions, Matches);
+        Assert.ExpectedError('The regular expression timeout should be at least 1000 ms');
+
+        asserterror InstanceRegex.Regex(Pattern, RegexOptions);
         Assert.ExpectedError('The regular expression timeout should be at least 1000 ms');
 
         // [When] Setting the match timeout to 10001
         RegexOptions.MatchTimeoutInMs := 10001;
 
         // [Then] We get an error, because the timeout should be maximum 10000 ms 
-        Asserterror Regex.Match(Input, Pattern, RegexOptions, Matches);
+        asserterror Regex.Match(Input, Pattern, RegexOptions, Matches);
         Assert.ExpectedError('The regular expression timeout should be at most 10000 ms');
+
+        asserterror InstanceRegex.Regex(Pattern, RegexOptions);
+        Assert.ExpectedError('The regular expression timeout should be at most 10000 ms');
+    end;
+
+    [Test]
+    procedure RegexNotInstanciatedTest()
+    var
+        Matches: Record Matches;
+        Input: Text;
+        RegexIsNotInstanciatedErr: Label 'Regex is not instanciated. Consider calling Regex() first or use an overload supporting a pattern.', Locked = true;
+    begin
+        // [Given] An input 
+        Input := 'ba-ba-ba-ba-ba-nana ba-ba-ba-ba-ba-nana potato-na-ah-ah...';
+
+        // [When] an instance procedure is called prior to calling the constructor
+        Clear(InstanceRegex);
+        asserterror InstanceRegex.Match(Input, Matches);
+
+        // [Then] We get an error, because the DotNet class is not instanciated
+        Assert.ExpectedError(RegexIsNotInstanciatedErr);
+    end;
+
+    var
+        RegexPerformanceUrlMatchTxt: Label '^https*://(?<storageAccount>(?:bcartifacts|bcinsider))\.[\w\.]+/(?<type>(?:Sandbox|OnPrem))/(?<version>(?:(?:\d+)*(?:\.\d+)*(?:\.\d+)*(?:\.\d+)*))/(?<country>\w{2})', Locked = true;
+
+    local procedure RegexPerformanceCall(var ThisRegex: Codeunit Regex; RegexOptions: Record "Regex Options"; RunOnInstance: Boolean)
+    var
+        Matches: Record Matches;
+        Groups: Record Groups;
+        Counter: Integer;
+        UrlTxt: Label 'https://bcartifacts.azureedge.net/onprem/18.3.27240.27480/de', Locked = true;
+    begin
+        for counter := 0 to 100 do begin
+            case RunOnInstance of
+                true:
+                    ThisRegex.Match(UrlTxt, Matches);
+                false:
+                    ThisRegex.Match(UrlTxt, RegexPerformanceUrlMatchTxt, RegexOptions, Matches);
+            end;
+
+            if Matches.Success then
+                ThisRegex.Groups(Matches, Groups);
+        end;
+    end;
+
+    [Test]
+    procedure RegexPerformanceStaticCalls()
+    var
+        RegexOptions: Record "Regex Options";
+        Regex: Codeunit Regex;
+        Counter: Integer;
+    begin
+        RegexOptions.Compiled := true;
+        RegexOptions.IgnoreCase := true;
+
+        RegexPerformanceCall(Regex, RegexOptions, false);
+    end;
+
+    [Test]
+    procedure RegexPerformanceInstanceCalls()
+    var
+        RegexOptions: Record "Regex Options";
+        Regex: Codeunit Regex;
+        Counter: Integer;
+    begin
+        RegexOptions.Compiled := true;
+        RegexOptions.IgnoreCase := true;
+        Regex.Regex(RegexPerformanceUrlMatchTxt, RegexOptions);
+
+        RegexPerformanceCall(Regex, RegexOptions, true);
     end;
 }

--- a/Modules/System/Regex/src/Regex.Codeunit.al
+++ b/Modules/System/Regex/src/Regex.Codeunit.al
@@ -14,7 +14,26 @@ codeunit 3960 Regex
         RegexImpl: Codeunit "Regex Impl.";
 
     /// <summary>
-    /// Gets the maximum number of entries in the current static cache of compiled regular expressions
+    /// Initializes a new instance of the Regex class for the specified regular expression.
+    /// </summary>
+    /// <param name="Pattern">A regular expression pattern to match.</param>
+    procedure Regex(Pattern: Text)
+    begin
+        RegexImpl.Regex(Pattern);
+    end;
+
+    /// <summary>
+    /// Initializes a new instance of the Regex class for the specified regular expression, with options that modify the pattern.
+    /// </summary>
+    /// <param name="Pattern">A regular expression pattern to match.</param>
+    /// <param name="RegexOptions">A combination of the enumeration values that modify the regular expression.</param>
+    procedure Regex(Pattern: Text; var RegexOptions: Record "Regex Options")
+    begin
+        RegexImpl.Regex(Pattern, RegexOptions);
+    end;
+
+    /// <summary>
+    /// Gets the maximum number of entries in the current static cache of compiled regular expressions.
     /// </summary>
     /// <returns>The maximum number of entries in the static cache.</returns>
     procedure GetCacheSize(): Integer
@@ -23,7 +42,7 @@ codeunit 3960 Regex
     end;
 
     /// <summary>
-    /// Sets the maximum number of entries in the current static cache of compiled regular expressions
+    /// Sets the maximum number of entries in the current static cache of compiled regular expressions.
     /// </summary>
     /// <param name="CacheSize">The maximum number of entries in the static cache.</param>
     procedure SetCacheSize(CacheSize: Integer)
@@ -82,6 +101,17 @@ codeunit 3960 Regex
     end;
 
     /// <summary>
+    /// Indicates whether the regular expression specified in the Regex constructor finds a match in the input string, beginning at the specified starting position in the string.
+    /// </summary>
+    /// <param name="Input">The string to search for a match.</param>
+    /// <param name="StartAt">The character position at which to start the search.</param>
+    /// <returns>True if the regular expression finds a match; otherwise, false.</returns>
+    procedure IsMatch(Input: Text; StartAt: Integer): Boolean
+    begin
+        exit(RegexImpl.IsMatch(Input, StartAt));
+    end;
+
+    /// <summary>
     /// Indicates whether the regular expression finds a match in the input string, beginning at the specified starting position in the string.
     /// </summary>
     /// <param name="Input">The string to search for a match.</param>
@@ -103,6 +133,16 @@ codeunit 3960 Regex
     procedure IsMatch(Input: Text; Pattern: Text): Boolean
     begin
         exit(RegexImpl.IsMatch(Input, Pattern));
+    end;
+
+    /// <summary>
+    /// Indicates whether the regular expression specified in the Regex constructor finds a match in the input string.
+    /// </summary>
+    /// <param name="Input">The string to search for a match.</param>
+    /// <returns>True if the regular expression finds a match; otherwise, false.</returns>
+    procedure IsMatch(Input: Text): Boolean
+    begin
+        exit(RegexImpl.IsMatch(Input));
     end;
 
     /// <summary>
@@ -130,6 +170,17 @@ codeunit 3960 Regex
     end;
 
     /// <summary>
+    /// Searches the input string for the first occurrence of a regular expression specified in the Regex constructor, beginning at the specified starting position in the string.
+    /// </summary>
+    /// <param name="Input">The string to search for a match.</param>
+    /// <param name="StartAt">The zero-based character position at which to start the search.</param>
+    /// <param name="Matches">The Match object to write information about the match to.</param>
+    procedure Match(Input: Text; StartAt: Integer; var Matches: Record Matches)
+    begin
+        RegexImpl.Match(Input, StartAt, Matches);
+    end;
+
+    /// <summary>
     /// Searches the input string for the first occurrence of a regular expression, beginning at the specified starting position in the string.
     /// </summary>
     /// <param name="Input">The string to search for a match.</param>
@@ -147,12 +198,24 @@ codeunit 3960 Regex
     /// </summary>
     /// <param name="Input">The string to search for a match.</param>
     /// <param name="Pattern">A regular expression pattern to match.</param>
-    /// <param name="Beginning">The zero-based character position in the input string that defines the leftmost position to be searched.</param>
+    /// <param name="StartAt">The zero-based character position in the input string that defines the leftmost position to be searched.</param>
     /// <param name="Length">The number of characters in the substring to include in the search.</param>
     /// <param name="Matches">The Match object to write information about the match to.</param>
-    procedure Match(Input: Text; Pattern: Text; Beginning: Integer; Length: Integer; var Matches: Record Matches)
+    procedure Match(Input: Text; Pattern: Text; StartAt: Integer; Length: Integer; var Matches: Record Matches)
     begin
-        RegexImpl.Match(Input, Pattern, Beginning, Length, Matches);
+        RegexImpl.Match(Input, Pattern, StartAt, Length, Matches);
+    end;
+
+    /// <summary>
+    /// Searches the input string for the first occurrence of a regular expression specified in the Regex constructor, beginning at the specified starting position and searching only the specified number of characters.
+    /// </summary>
+    /// <param name="Input">The string to search for a match.</param>
+    /// <param name="StartAt">The zero-based character position in the input string that defines the leftmost position to be searched.</param>
+    /// <param name="Length">The number of characters in the substring to include in the search.</param>
+    /// <param name="Matches">The Match object to write information about the match to.</param>
+    procedure Match(Input: Text; StartAt: Integer; Length: Integer; var Matches: Record Matches)
+    begin
+        RegexImpl.Match(Input, StartAt, Length, Matches);
     end;
 
     /// <summary>
@@ -160,13 +223,13 @@ codeunit 3960 Regex
     /// </summary>
     /// <param name="Input">The string to search for a match.</param>
     /// <param name="Pattern">A regular expression pattern to match.</param>
-    /// <param name="Beginning">The zero-based character position in the input string that defines the leftmost position to be searched.</param>
+    /// <param name="StartAt">The zero-based character position in the input string that defines the leftmost position to be searched.</param>
     /// <param name="Length">The number of characters in the substring to include in the search.</param>
     /// <param name="RegexOptions">A combination of the enumeration values that provide options for matching.</param>
     /// <param name="Matches">The Match object to write information about the match to.</param>
-    procedure Match(Input: Text; Pattern: Text; Beginning: Integer; Length: Integer; var RegexOptions: Record "Regex Options"; var Matches: Record Matches)
+    procedure Match(Input: Text; Pattern: Text; StartAt: Integer; Length: Integer; var RegexOptions: Record "Regex Options"; var Matches: Record Matches)
     begin
-        RegexImpl.Match(Input, Pattern, Beginning, Length, RegexOptions, Matches);
+        RegexImpl.Match(Input, Pattern, StartAt, Length, RegexOptions, Matches);
     end;
 
     /// <summary>
@@ -178,6 +241,17 @@ codeunit 3960 Regex
     procedure Match(Input: Text; Pattern: Text; var Matches: Record Matches)
     begin
         RegexImpl.Match(Input, Pattern, Matches);
+    end;
+
+    /// <summary>
+    /// Searches the input string for the first occurrence of the specified regular expression specified in the Regex constructor, using the specified matching options.
+    /// </summary>
+    /// <param name="Input">The string to search for a match.</param>
+    /// <param name="Pattern">A regular expression pattern to match.</param>
+    /// <param name="Matches">The Match object to write information about the match to.</param>
+    procedure Match(Input: Text; var Matches: Record Matches)
+    begin
+        RegexImpl.Match(Input, Matches);
     end;
 
     /// <summary>
@@ -203,6 +277,18 @@ codeunit 3960 Regex
     procedure Replace(Input: Text; Pattern: Text; Replacement: Text; "Count": Integer): Text
     begin
         exit(RegexImpl.Replace(Input, Pattern, Replacement, "Count"));
+    end;
+
+    /// <summary>
+    /// Replaces strings that match a regular expression pattern specified in the Regex constructor with a specified replacement string.
+    /// </summary>
+    /// <param name="Input">The string to search for a match.</param>
+    /// <param name="Replacement">The replacement string.</param>
+    /// <param name="Count">The maximum number of times the replacement can occur.</param>
+    /// <returns>A new string that is identical to the input string, except that the replacement string takes the place of each matched string. If the pattern is not matched the method returns the current instance unchanged</returns>
+    procedure Replace(Input: Text; Replacement: Text; "Count": Integer): Text
+    begin
+        exit(RegexImpl.Replace(Input, Replacement, "Count"));
     end;
 
     /// <summary>
@@ -234,6 +320,19 @@ codeunit 3960 Regex
     end;
 
     /// <summary>
+    /// In a specified input substring, replaces a specified maximum number of strings that match a regular expression pattern specified in the Regex constructor with a specified replacement string.
+    /// </summary>
+    /// <param name="Input">The string to search for a match.</param>
+    /// <param name="Replacement">The replacement string.</param>
+    /// <param name="Count">The maximum number of times the replacement can occur.</param>
+    /// <param name="StartAt">The character position in the input string where the search begins.</param>
+    /// <returns>A new string that is identical to the input string, except that the replacement string takes the place of each matched string. If the pattern is not matched the method returns the current instance unchanged</returns>
+    procedure Replace(Input: Text; Replacement: Text; "Count": Integer; StartAt: Integer): Text
+    begin
+        exit(RegexImpl.Replace(Input, Replacement, "Count", StartAt));
+    end;
+
+    /// <summary>
     /// In a specified input substring, replaces a specified maximum number of strings that match a regular expression pattern with a specified replacement string.
     /// </summary>
     /// <param name="Input">The string to search for a match.</param>
@@ -261,6 +360,17 @@ codeunit 3960 Regex
     end;
 
     /// <summary>
+    /// Replaces all strings that match a specified regular expression specified in the Regex constructor with a specified replacement string.
+    /// </summary>
+    /// <param name="Input">The string to search for a match.</param>
+    /// <param name="Replacement">The replacement string.</param>
+    /// <returns>A new string that is identical to the input string, except that the replacement string takes the place of each matched string. If the pattern is not matched the method returns the current instance unchanged</returns>
+    procedure Replace(Input: Text; Replacement: Text): Text
+    begin
+        exit(RegexImpl.Replace(Input, Replacement));
+    end;
+
+    /// <summary>
     /// Replaces all strings that match a specified regular expression with a specified replacement string. Specified options modify the matching operation.
     /// </summary>
     /// <param name="Input">The string to search for a match.</param>
@@ -274,7 +384,7 @@ codeunit 3960 Regex
     end;
 
     /// <summary>
-    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression specified in the Regex constructor.
+    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression pattern.
     /// </summary>
     /// <param name="Input">The string to split.</param>
     /// <param name="Pattern">A regular expression pattern to match.</param>
@@ -286,7 +396,18 @@ codeunit 3960 Regex
     end;
 
     /// <summary>
-    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression specified in the Regex constructor.
+    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression pattern specified in the Regex constructor.
+    /// </summary>
+    /// <param name="Input">The string to split.</param>
+    /// <param name="Count">The maximum number of times the split can occur.</param>
+    /// <param name="Array">An empty list that will be populated with the result of the split query.</param>
+    procedure Split(Input: Text; "Count": Integer; var "Array": List of [Text])
+    begin
+        RegexImpl.Split(Input, "Count", "Array");
+    end;
+
+    /// <summary>
+    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression pattern.
     /// </summary>
     /// <param name="Input">The string to split.</param>
     /// <param name="Pattern">A regular expression pattern to match.</param>
@@ -299,7 +420,7 @@ codeunit 3960 Regex
     end;
 
     /// <summary>
-    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression specified in the Regex constructor. The search for the regular expression pattern starts at a specified character position in the input string.
+    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression pattern. The search for the pattern starts at a specified character position in the input string.
     /// </summary>
     /// <param name="Input">The string to split.</param>
     /// <param name="Pattern">A regular expression pattern to match.</param>
@@ -312,7 +433,19 @@ codeunit 3960 Regex
     end;
 
     /// <summary>
-    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression specified in the Regex constructor. The search for the regular expression pattern starts at a specified character position in the input string.
+    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression pattern specified in the Regex constructor. The search for the pattern starts at a specified character position in the input string.
+    /// </summary>
+    /// <param name="Input">The string to split.</param>
+    /// <param name="Count">The maximum number of times the split can occur.</param>
+    /// <param name="StartAt">The character position in the input string where the search will begin.</param>
+    /// <param name="Array">An empty list that will be populated with the result of the split query.</param>
+    procedure Split(Input: Text; "Count": Integer; StartAt: Integer; var "Array": List of [Text])
+    begin
+        RegexImpl.Split(Input, "Count", StartAt, "Array");
+    end;
+
+    /// <summary>
+    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression pattern. The search for the pattern starts at a specified character position in the input string.
     /// </summary>
     /// <param name="Input">The string to split.</param>
     /// <param name="Pattern">A regular expression pattern to match.</param>
@@ -326,7 +459,7 @@ codeunit 3960 Regex
     end;
 
     /// <summary>
-    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression specified in the Regex constructor. Specified options modify the matching operation.
+    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression pattern. Specified options modify the matching operation.
     /// </summary>
     /// <param name="Input">The string to split.</param>
     /// <param name="Pattern">A regular expression pattern to match.</param>
@@ -337,7 +470,17 @@ codeunit 3960 Regex
     end;
 
     /// <summary>
-    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression specified in the Regex constructor. Specified options modify the matching operation.
+    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression pattern specified in the Regex constructor. Specified options modify the matching operation.
+    /// </summary>
+    /// <param name="Input">The string to split.</param>
+    /// <param name="Array">An empty list that will be populated with the result of the split query.</param>
+    procedure Split(Input: Text; var "Array": List of [Text])
+    begin
+        RegexImpl.Split(Input, "Array");
+    end;
+
+    /// <summary>
+    /// Splits an input string a specified maximum number of times into an array of substrings, at the positions defined by a regular expression pattern. Specified options modify the matching operation.
     /// </summary>
     /// <param name="Input">The string to split.</param>
     /// <param name="Pattern">A regular expression pattern to match.</param>
@@ -378,7 +521,7 @@ codeunit 3960 Regex
     end;
 
     /// <summary>
-    /// Get the Groups for one particular Match  
+    /// Get the Groups for one particular Match.
     /// </summary>
     /// <param name="Matches">The Match record to get Groups for.</param>
     /// <param name="Groups">Groups Record to write the resulting Groups to.</param>
@@ -388,7 +531,7 @@ codeunit 3960 Regex
     end;
 
     /// <summary>
-    /// Get the Captures for one particular Group  
+    /// Get the Captures for one particular Group.
     /// </summary>
     /// <param name="Group">The Group record to get Captures for.</param>
     /// <param name="Captures">Captures Record to write the resulting Captures to.</param>

--- a/Modules/System/Regex/src/RegexImpl.Codeunit.al
+++ b/Modules/System/Regex/src/RegexImpl.Codeunit.al
@@ -57,6 +57,11 @@ codeunit 3961 "Regex Impl."
     procedure IsMatch(Input: Text; Pattern: Text; StartAt: Integer): Boolean
     begin
         Regex(Pattern);
+        exit(IsMatch(Input, StartAt))
+    end;
+
+    procedure IsMatch(Input: Text; StartAt: Integer): Boolean
+    begin
         exit(DotNetRegex.IsMatch(Input, StartAt))
     end;
 
@@ -69,6 +74,12 @@ codeunit 3961 "Regex Impl."
     procedure IsMatch(Input: Text; Pattern: Text): Boolean
     begin
         Regex(Pattern);
+        exit(IsMatch(Input));
+    end;
+
+    procedure IsMatch(Input: Text): Boolean
+    begin
+        RaiseErrorIfNotInstanciated();
         exit(DotNetRegex.IsMatch(Input));
     end;
 
@@ -84,27 +95,48 @@ codeunit 3961 "Regex Impl."
         Match(Input, StartAt, Matches);
     end;
 
+    procedure Match(Input: Text; StartAt: Integer; var Matches: Record Matches)
+    begin
+        RaiseErrorIfNotInstanciated();
+        DotNetMatchCollection := DotNetRegex.Matches(Input, StartAt);
+        InsertMatch(Matches);
+    end;
+
     procedure Match(Input: Text; Pattern: Text; StartAt: Integer; var RegexOptions: Record "Regex Options"; var Matches: Record Matches)
     begin
         Regex(Pattern, RegexOptions);
         Match(Input, StartAt, Matches);
     end;
 
-    procedure Match(Input: Text; Pattern: Text; Beginning: Integer; Length: Integer; var Matches: Record Matches)
+    procedure Match(Input: Text; Pattern: Text; StartAt: Integer; Length: Integer; var Matches: Record Matches)
     begin
         Regex(Pattern);
-        Match(Input, Beginning, Length, Matches)
+        Match(Input, StartAt, Length, Matches)
     end;
 
-    procedure Match(Input: Text; Pattern: Text; Beginning: Integer; Length: Integer; var RegexOptions: Record "Regex Options"; var Matches: Record Matches)
+    procedure Match(Input: Text; StartAt: Integer; Length: Integer; var Matches: Record Matches)
+    begin
+        RaiseErrorIfNotInstanciated();
+        Input := Input.Substring(1, StartAt + Length);
+        DotNetMatchCollection := DotNetRegex.Matches(Input, StartAt);
+        InsertMatch(Matches);
+    end;
+
+    procedure Match(Input: Text; Pattern: Text; StartAt: Integer; Length: Integer; var RegexOptions: Record "Regex Options"; var Matches: Record Matches)
     begin
         Regex(Pattern, RegexOptions);
-        Match(Input, Beginning, Length, Matches)
+        Match(Input, StartAt, Length, Matches)
     end;
 
     procedure Match(Input: Text; Pattern: Text; var Matches: Record Matches)
     begin
         Regex(Pattern);
+        Match(Input, Matches);
+    end;
+
+    procedure Match(Input: Text; var Matches: Record Matches)
+    begin
+        RaiseErrorIfNotInstanciated();
         DotNetMatchCollection := DotNetRegex.Matches(Input);
         InsertMatch(Matches);
     end;
@@ -119,6 +151,12 @@ codeunit 3961 "Regex Impl."
     procedure Replace(Input: Text; Pattern: Text; Replacement: Text; "Count": Integer): Text
     begin
         Regex(Pattern);
+        exit(Replace(Input, Replacement, "Count"));
+    end;
+
+    procedure Replace(Input: Text; Replacement: Text; "Count": Integer): Text
+    begin
+        RaiseErrorIfNotInstanciated();
         exit(DotNetRegex.Replace(Input, Replacement, "Count"));
     end;
 
@@ -131,6 +169,12 @@ codeunit 3961 "Regex Impl."
     procedure Replace(Input: Text; Pattern: Text; Replacement: Text; "Count": Integer; StartAt: Integer): Text
     begin
         Regex(Pattern);
+        exit(Replace(Input, Replacement, "Count", StartAt));
+    end;
+
+    procedure Replace(Input: Text; Replacement: Text; "Count": Integer; StartAt: Integer): Text
+    begin
+        RaiseErrorIfNotInstanciated();
         exit(DotNetRegex.Replace(Input, Replacement, "Count", StartAt));
     end;
 
@@ -143,6 +187,12 @@ codeunit 3961 "Regex Impl."
     procedure Replace(Input: Text; Pattern: Text; Replacement: Text): Text
     begin
         Regex(Pattern);
+        exit(Replace(Input, Replacement));
+    end;
+
+    procedure Replace(Input: Text; Replacement: Text): Text
+    begin
+        RaiseErrorIfNotInstanciated();
         exit(DotNetRegex.Replace(Input, Replacement));
     end;
 
@@ -158,6 +208,16 @@ codeunit 3961 "Regex Impl."
         Split(Input, "Count", "Array");
     end;
 
+    procedure Split(Input: Text; "Count": Integer; var "Array": List of [Text])
+    var
+        StringsDotNetArray: DotNet Array;
+        SplitElement: Text;
+    begin
+        RaiseErrorIfNotInstanciated();
+        StringsDotNetArray := DotNetRegex.Split(Input, "Count");
+        foreach SplitElement in StringsDotNetArray do "Array".Add(SplitElement);
+    end;
+
     procedure Split(Input: Text; Pattern: Text; "Count": Integer; var RegexOptions: Record "Regex Options"; var "Array": List of [Text])
     begin
         Regex(Pattern, RegexOptions);
@@ -170,6 +230,16 @@ codeunit 3961 "Regex Impl."
         Split(Input, "Count", StartAt, "Array");
     end;
 
+    procedure Split(Input: Text; "Count": Integer; StartAt: Integer; var "Array": List of [Text])
+    var
+        StringsDotNetArray: DotNet Array;
+        SplitElement: Text;
+    begin
+        RaiseErrorIfNotInstanciated();
+        StringsDotNetArray := DotNetRegex.Split(Input, "Count", StartAt);
+        foreach SplitElement in StringsDotNetArray do "Array".Add(SplitElement);
+    end;
+
     procedure Split(Input: Text; Pattern: Text; "Count": Integer; StartAt: Integer; var RegexOptions: Record "Regex Options"; var "Array": List of [Text])
     begin
         Regex(Pattern, RegexOptions);
@@ -180,6 +250,16 @@ codeunit 3961 "Regex Impl."
     begin
         Regex(Pattern);
         Split(Input, "Array");
+    end;
+
+    procedure Split(Input: Text; var "Array": List of [Text])
+    var
+        StringsDotNetArray: DotNet Array;
+        SplitElement: Text;
+    begin
+        RaiseErrorIfNotInstanciated();
+        StringsDotNetArray := DotNetRegex.Split(Input);
+        foreach SplitElement in StringsDotNetArray do "Array".Add(SplitElement);
     end;
 
     procedure Split(Input: Text; Pattern: Text; var RegexOptions: Record "Regex Options"; var "Array": List of [Text])
@@ -229,7 +309,7 @@ codeunit 3961 "Regex Impl."
         InsertCaptures(Captures)
     end;
 
-    local procedure Regex(Pattern: Text)
+    procedure Regex(Pattern: Text)
     var
         RegexOptions: Record "Regex Options";
     begin
@@ -248,44 +328,12 @@ codeunit 3961 "Regex Impl."
         DotNetRegex := DotNetRegex.Regex(Pattern, DotNetRegexOptions, TimeoutDuration.FromMilliseconds(RegexOptions.MatchTimeoutInMs));
     end;
 
-    local procedure Match(Input: Text; StartAt: Integer; var Matches: Record Matches)
-    begin
-        DotNetMatchCollection := DotNetRegex.Matches(Input, StartAt);
-        InsertMatch(Matches);
-    end;
-
-    local procedure Match(Input: Text; Beginning: Integer; Length: Integer; var Matches: Record Matches)
-    begin
-        Input := Input.Substring(1, Beginning + Length);
-        DotNetMatchCollection := DotNetRegex.Matches(Input, Beginning);
-        InsertMatch(Matches);
-    end;
-
-    local procedure Split(Input: Text; var "Array": List of [Text])
+    local procedure RaiseErrorIfNotInstanciated()
     var
-        StringsDotNetArray: DotNet Array;
-        SplitElement: Text;
+        RegexIsNotInstanciatedErr: Label 'Regex is not instanciated. Consider calling Regex() first or use an overload supporting a pattern.';
     begin
-        StringsDotNetArray := DotNetRegex.Split(Input);
-        foreach SplitElement in StringsDotNetArray do "Array".Add(SplitElement);
-    end;
-
-    local procedure Split(Input: Text; "Count": Integer; StartAt: Integer; var "Array": List of [Text])
-    var
-        StringsDotNetArray: DotNet Array;
-        SplitElement: Text;
-    begin
-        StringsDotNetArray := DotNetRegex.Split(Input, "Count", StartAt);
-        foreach SplitElement in StringsDotNetArray do "Array".Add(SplitElement);
-    end;
-
-    local procedure Split(Input: Text; "Count": Integer; var "Array": List of [Text])
-    var
-        StringsDotNetArray: DotNet Array;
-        SplitElement: Text;
-    begin
-        StringsDotNetArray := DotNetRegex.Split(Input, "Count");
-        foreach SplitElement in StringsDotNetArray do "Array".Add(SplitElement);
+        if IsNull(DotNetRegex) then
+            Error(RegexIsNotInstanciatedErr);
     end;
 
     local procedure InsertMatch(var Matches: Record Matches)


### PR DESCRIPTION
Often Regex needs subsequent calls with the same pattern and options. This PR allows to pass pattern and options to the constructor and offers additional procedures working on that prepared instance.
I have added 2 Test procedures at the end to allow a performance comparision. Using the same Regex DotNet instance wth the same pattern reduced the runtime by factor 60+ (from 1000 down to 15 milliseconds for 100 matches).

Added Regex() constructors
Added instance specific procedures
Added instance tests
