### PR TITLE
Add support for Lease operations on Blobs and Containers

### DIFF
--- a/Modules/System Tests/Azure Blob Services API/src/ABSBlobClientTest.Codeunit.al
+++ b/Modules/System Tests/Azure Blob Services API/src/ABSBlobClientTest.Codeunit.al
@@ -80,13 +80,13 @@ codeunit 132920 "ABS Blob Client Test"
         Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseRenew failed');
 
         // This part works when testing against a "real" Azure Storage and not Azurite
-        // leaving this here for completeness
-        // // [3rd] Change Lease on Blob
-        // ProposedLeaseId := CreateGuid();
-        // Response := ABSBlobClient.LeaseChange(BlobName, LeaseId, ProposedLeaseId);
-        // Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseChange failed');
-        // LeaseId := Response.GetLeaseId();
-        // Assert.IsFalse(IsNullGuid(LeaseId), 'Operation LeaseChange failed (no LeaseId returned)');
+        if (AzuriteTestLibrary.GetStorageAccountName() <> 'devstoreaccount1') then begin // "devstoreaccount1" is the hardcoded name for Azurite test-account
+            // [3rd] Change Lease on Blob
+            ProposedLeaseId := CreateGuid();
+            Response := ABSBlobClient.LeaseChange(BlobName, LeaseId, ProposedLeaseId);
+            Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseChange failed');
+            Assert.IsFalse(IsNullGuid(LeaseId), 'Operation LeaseChange failed (no LeaseId returned)');
+        end;
 
         // [4th] Break Lease on Blob
         Response := ABSBlobClient.LeaseBreak(BlobName, LeaseId);

--- a/Modules/System Tests/Azure Blob Services API/src/ABSBlobClientTest.Codeunit.al
+++ b/Modules/System Tests/Azure Blob Services API/src/ABSBlobClientTest.Codeunit.al
@@ -71,9 +71,8 @@ codeunit 132920 "ABS Blob Client Test"
         Assert.IsTrue(Response.IsSuccessful(), 'Operation PutBlobBlockBlob failed');
 
         // [1st] Acquire Lease on Blob
-        Response := ABSBlobClient.LeaseAcquire(BlobName, 60);
+        Response := ABSBlobClient.LeaseAcquire(BlobName, 60, LeaseId);
         Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseAcquire failed');
-        LeaseId := Response.GetLeaseId();
         Assert.IsFalse(IsNullGuid(LeaseId), 'Operation LeaseAcquire failed (no LeaseId returned)');
 
         // [2nd] Renew Lease on Blob

--- a/Modules/System Tests/Azure Blob Services API/src/ABSBlobClientTest.Codeunit.al
+++ b/Modules/System Tests/Azure Blob Services API/src/ABSBlobClientTest.Codeunit.al
@@ -71,29 +71,29 @@ codeunit 132920 "ABS Blob Client Test"
         Assert.IsTrue(Response.IsSuccessful(), 'Operation PutBlobBlockBlob failed');
 
         // [1st] Acquire Lease on Blob
-        Response := ABSBlobClient.LeaseAcquire(BlobName, 60, LeaseId);
+        Response := ABSBlobClient.AcquireLease(BlobName, 60, LeaseId);
         Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseAcquire failed');
         Assert.IsFalse(IsNullGuid(LeaseId), 'Operation LeaseAcquire failed (no LeaseId returned)');
 
         // [2nd] Renew Lease on Blob
-        Response := ABSBlobClient.LeaseRenew(BlobName, LeaseId);
+        Response := ABSBlobClient.RenewLease(BlobName, LeaseId);
         Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseRenew failed');
 
         // This part works when testing against a "real" Azure Storage and not Azurite
         if (AzuriteTestLibrary.GetStorageAccountName() <> 'devstoreaccount1') then begin // "devstoreaccount1" is the hardcoded name for Azurite test-account
             // [3rd] Change Lease on Blob
             ProposedLeaseId := CreateGuid();
-            Response := ABSBlobClient.LeaseChange(BlobName, LeaseId, ProposedLeaseId);
+            Response := ABSBlobClient.ChangeLease(BlobName, LeaseId, ProposedLeaseId);
             Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseChange failed');
             Assert.IsFalse(IsNullGuid(LeaseId), 'Operation LeaseChange failed (no LeaseId returned)');
         end;
 
         // [4th] Break Lease on Blob
-        Response := ABSBlobClient.LeaseBreak(BlobName, LeaseId);
+        Response := ABSBlobClient.BreakLease(BlobName, LeaseId);
         Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseBreak failed');
 
         // [5th] Release Lease on Blob
-        Response := ABSBlobClient.LeaseRelease(BlobName, LeaseId);
+        Response := ABSBlobClient.ReleaseLease(BlobName, LeaseId);
         Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseRelease failed');
 
         // Clean-up

--- a/Modules/System Tests/Azure Blob Services API/src/ABSBlobClientTest.Codeunit.al
+++ b/Modules/System Tests/Azure Blob Services API/src/ABSBlobClientTest.Codeunit.al
@@ -7,7 +7,7 @@ codeunit 132920 "ABS Blob Client Test"
 {
     Subtype = Test;
 
-    //[Test]
+    [Test]
     procedure PutBlobBlockBlobStreamTest()
     var
         Response: Codeunit "ABS Operation Response";
@@ -36,6 +36,66 @@ codeunit 132920 "ABS Blob Client Test"
         Assert.IsTrue(Response.IsSuccessful(), 'Operation GetBlobAsText failed');
 
         Assert.AreEqual(BlobContent, NewBlobContent, 'Blob content mismatch');
+
+        // Clean-up
+        ABSContainerClient.DeleteContainer(ContainerName);
+    end;
+
+    [Test]
+    procedure LeaseBlobTest()
+    var
+        Response: Codeunit "ABS Operation Response";
+        ContainerName, BlobName, BlobContent, NewBlobContent : Text;
+        LeaseId: Guid;
+        ProposedLeaseId: Guid;
+    begin
+        // [Scenarion] Given a storage account and a container, PutBlobBlockBlob operation succeeds and subsequent lease-operations
+        // (1) create a lease, (2) renew a lease, [(3) change a lease], (4) break a lease and (5) release the lease
+
+        SharedKeyAuthorization := StorageServiceAuthorization.CreateSharedKey(AzuriteTestLibrary.GetAccessKey());
+
+        ContainerName := ABSTestLibrary.GetContainerName();
+        BlobName := ABSTestLibrary.GetBlobName();
+        BlobContent := ABSTestLibrary.GetSampleTextBlobContent();
+
+        ABSContainerClient.Initialize(AzuriteTestLibrary.GetStorageAccountName(), SharedKeyAuthorization);
+        ABSContainerClient.SetBaseUrl(AzuriteTestLibrary.GetBlobStorageBaseUrl());
+
+        ABSContainerClient.CreateContainer(ContainerName);
+
+        ABSBlobClient.Initialize(AzuriteTestLibrary.GetStorageAccountName(), ContainerName, SharedKeyAuthorization);
+        ABSBlobClient.SetBaseUrl(AzuriteTestLibrary.GetBlobStorageBaseUrl());
+
+        // Create blob for this test
+        Response := ABSBlobClient.PutBlobBlockBlobText(BlobName, BlobContent);
+        Assert.IsTrue(Response.IsSuccessful(), 'Operation PutBlobBlockBlob failed');
+
+        // [1st] Acquire Lease on Blob
+        Response := ABSBlobClient.LeaseAcquire(BlobName, 60);
+        Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseAcquire failed');
+        LeaseId := Response.GetLeaseId();
+        Assert.IsFalse(IsNullGuid(LeaseId), 'Operation LeaseAcquire failed (no LeaseId returned)');
+
+        // [2nd] Renew Lease on Blob
+        Response := ABSBlobClient.LeaseRenew(BlobName, LeaseId);
+        Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseRenew failed');
+
+        // This part works when testing against a "real" Azure Storage and not Azurite
+        // leaving this here for completeness
+        // // [3rd] Change Lease on Blob
+        // ProposedLeaseId := CreateGuid();
+        // Response := ABSBlobClient.LeaseChange(BlobName, LeaseId, ProposedLeaseId);
+        // Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseChange failed');
+        // LeaseId := Response.GetLeaseId();
+        // Assert.IsFalse(IsNullGuid(LeaseId), 'Operation LeaseChange failed (no LeaseId returned)');
+
+        // [4th] Break Lease on Blob
+        Response := ABSBlobClient.LeaseBreak(BlobName, LeaseId);
+        Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseBreak failed');
+
+        // [5th] Release Lease on Blob
+        Response := ABSBlobClient.LeaseRelease(BlobName, LeaseId);
+        Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseRelease failed');
 
         // Clean-up
         ABSContainerClient.DeleteContainer(ContainerName);

--- a/Modules/System Tests/Azure Blob Services API/src/ABSContainerClientTest.Codeunit.al
+++ b/Modules/System Tests/Azure Blob Services API/src/ABSContainerClientTest.Codeunit.al
@@ -119,13 +119,13 @@ codeunit 132919 "ABS Container Client Test"
         Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseRenew failed');
 
         // This part works when testing against a "real" Azure Storage and not Azurite
-        // leaving this here for completeness
-        // // [3rd] Change Lease on Container
-        // ProposedLeaseId := CreateGuid();
-        // Response := ABSContainerClient.LeaseChange(ContainerName, LeaseId, ProposedLeaseId);
-        // Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseChange failed');
-        // LeaseId := Response.GetLeaseId();
-        // Assert.IsFalse(IsNullGuid(LeaseId), 'Operation LeaseChange failed (no LeaseId returned)');
+        if (AzuriteTestLibrary.GetStorageAccountName() <> 'devstoreaccount1') then begin // "devstoreaccount1" is the hardcoded name for Azurite test-account
+            // [3rd] Change Lease on Container
+            ProposedLeaseId := CreateGuid();
+            Response := ABSContainerClient.LeaseChange(ContainerName, LeaseId, ProposedLeaseId);
+            Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseChange failed');
+            Assert.IsFalse(IsNullGuid(LeaseId), 'Operation LeaseChange failed (no LeaseId returned)');
+        end;
 
         // [4th] Break Lease on Container
         Response := ABSContainerClient.LeaseBreak(ContainerName, LeaseId);

--- a/Modules/System Tests/Azure Blob Services API/src/ABSContainerClientTest.Codeunit.al
+++ b/Modules/System Tests/Azure Blob Services API/src/ABSContainerClientTest.Codeunit.al
@@ -110,9 +110,8 @@ codeunit 132919 "ABS Container Client Test"
         Assert.IsTrue(Response.IsSuccessful(), 'Operation CreateContainer failed');
 
         // [1st] Acquire Lease on Container
-        Response := ABSContainerClient.LeaseAcquire(ContainerName, 60);
+        Response := ABSContainerClient.LeaseAcquire(ContainerName, 60, LeaseId);
         Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseAcquire failed');
-        LeaseId := Response.GetLeaseId();
         Assert.IsFalse(IsNullGuid(LeaseId), 'Operation LeaseAcquire failed (no LeaseId returned)');
 
         // [2nd] Renew Lease on Container

--- a/Modules/System Tests/Azure Blob Services API/src/ABSContainerClientTest.Codeunit.al
+++ b/Modules/System Tests/Azure Blob Services API/src/ABSContainerClientTest.Codeunit.al
@@ -7,7 +7,7 @@ codeunit 132919 "ABS Container Client Test"
 {
     Subtype = Test;
 
-    //[Test]
+    [Test]
     procedure CreateContainerSharedKeyTest()
     var
         Response: Codeunit "ABS Operation Response";
@@ -29,7 +29,7 @@ codeunit 132919 "ABS Container Client Test"
         Assert.IsTrue(Response.IsSuccessful(), 'Operation DeleteContainer failed');
     end;
 
-    //[Test]
+    [Test]
     procedure CreateContainerFailedTest()
     var
         Response: Codeunit "ABS Operation Response";
@@ -54,7 +54,7 @@ codeunit 132919 "ABS Container Client Test"
         Assert.IsTrue(Response.IsSuccessful(), 'Operation DeleteContainer failed');
     end;
 
-    //[Test]
+    [Test]
     procedure ListContainersTest()
     var
         Containers: Record "ABS Container";
@@ -87,6 +87,57 @@ codeunit 132919 "ABS Container Client Test"
             Response := ABSContainerClient.DeleteContainer(ContainerName);
             Assert.IsTrue(Response.IsSuccessful(), 'Operation DeleteContainer failed');
         end;
+    end;
+
+    [Test]
+    procedure LeaseContainerTest()
+    var
+        Response: Codeunit "ABS Operation Response";
+        ContainerName: Text;
+        LeaseId: Guid;
+        ProposedLeaseId: Guid;
+    begin
+        // [Scenarion] Given a storage account and a container name, CreateContainer creates a container and subsequent lease-operations
+        // (1) create a lease, (2) renew a lease, [(3) change a lease], (4) break a lease and (5) release the lease        
+        SharedKeyAuthorization := StorageServiceAuthorization.CreateSharedKey(AzuriteTestLibrary.GetAccessKey());
+
+        ABSContainerClient.Initialize(AzuriteTestLibrary.GetStorageAccountName(), SharedKeyAuthorization);
+        ABSContainerClient.SetBaseUrl(AzuriteTestLibrary.GetBlobStorageBaseUrl());
+
+        ContainerName := ABSTestLibrary.GetContainerName();
+        Response := ABSContainerClient.CreateContainer(ContainerName);
+
+        Assert.IsTrue(Response.IsSuccessful(), 'Operation CreateContainer failed');
+
+        // [1st] Acquire Lease on Container
+        Response := ABSContainerClient.LeaseAcquire(ContainerName, 60);
+        Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseAcquire failed');
+        LeaseId := Response.GetLeaseId();
+        Assert.IsFalse(IsNullGuid(LeaseId), 'Operation LeaseAcquire failed (no LeaseId returned)');
+
+        // [2nd] Renew Lease on Container
+        Response := ABSContainerClient.LeaseRenew(ContainerName, LeaseId);
+        Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseRenew failed');
+
+        // This part works when testing against a "real" Azure Storage and not Azurite
+        // leaving this here for completeness
+        // // [3rd] Change Lease on Container
+        // ProposedLeaseId := CreateGuid();
+        // Response := ABSContainerClient.LeaseChange(ContainerName, LeaseId, ProposedLeaseId);
+        // Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseChange failed');
+        // LeaseId := Response.GetLeaseId();
+        // Assert.IsFalse(IsNullGuid(LeaseId), 'Operation LeaseChange failed (no LeaseId returned)');
+
+        // [4th] Break Lease on Container
+        Response := ABSContainerClient.LeaseBreak(ContainerName, LeaseId);
+        Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseBreak failed');
+
+        // [5th] Release Lease on Container
+        Response := ABSContainerClient.LeaseRelease(ContainerName, LeaseId);
+        Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseRelease failed');
+
+        // Clean-up
+        ABSContainerClient.DeleteContainer(ContainerName);
     end;
 
     var

--- a/Modules/System Tests/Azure Blob Services API/src/ABSContainerClientTest.Codeunit.al
+++ b/Modules/System Tests/Azure Blob Services API/src/ABSContainerClientTest.Codeunit.al
@@ -110,29 +110,29 @@ codeunit 132919 "ABS Container Client Test"
         Assert.IsTrue(Response.IsSuccessful(), 'Operation CreateContainer failed');
 
         // [1st] Acquire Lease on Container
-        Response := ABSContainerClient.LeaseAcquire(ContainerName, 60, LeaseId);
+        Response := ABSContainerClient.AcquireLease(ContainerName, 60, LeaseId);
         Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseAcquire failed');
         Assert.IsFalse(IsNullGuid(LeaseId), 'Operation LeaseAcquire failed (no LeaseId returned)');
 
         // [2nd] Renew Lease on Container
-        Response := ABSContainerClient.LeaseRenew(ContainerName, LeaseId);
+        Response := ABSContainerClient.RenewLease(ContainerName, LeaseId);
         Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseRenew failed');
 
         // This part works when testing against a "real" Azure Storage and not Azurite
         if (AzuriteTestLibrary.GetStorageAccountName() <> 'devstoreaccount1') then begin // "devstoreaccount1" is the hardcoded name for Azurite test-account
             // [3rd] Change Lease on Container
             ProposedLeaseId := CreateGuid();
-            Response := ABSContainerClient.LeaseChange(ContainerName, LeaseId, ProposedLeaseId);
+            Response := ABSContainerClient.ChangeLease(ContainerName, LeaseId, ProposedLeaseId);
             Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseChange failed');
             Assert.IsFalse(IsNullGuid(LeaseId), 'Operation LeaseChange failed (no LeaseId returned)');
         end;
 
         // [4th] Break Lease on Container
-        Response := ABSContainerClient.LeaseBreak(ContainerName, LeaseId);
+        Response := ABSContainerClient.BreakLease(ContainerName, LeaseId);
         Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseBreak failed');
 
         // [5th] Release Lease on Container
-        Response := ABSContainerClient.LeaseRelease(ContainerName, LeaseId);
+        Response := ABSContainerClient.ReleaseLease(ContainerName, LeaseId);
         Assert.IsTrue(Response.IsSuccessful(), 'Operation LeaseRelease failed');
 
         // Clean-up

--- a/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
@@ -607,12 +607,12 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(BlobName: Text; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure AcquireLease(BlobName: Text; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, null Guid
+        exit(BlobServicesApiImpl.BlobAcquireLease(BlobName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, null Guid
     end;
 
     /// <summary>
@@ -623,11 +623,11 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure AcquireLease(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, null Guid
+        exit(BlobServicesApiImpl.BlobAcquireLease(BlobName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, null Guid
     end;
 
     /// <summary>
@@ -638,12 +638,12 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(BlobName: Text; DurationSeconds: Integer; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure AcquireLease(BlobName: Text; DurationSeconds: Integer; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId)); // Custom duration, null Guid
+        exit(BlobServicesApiImpl.BlobAcquireLease(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId)); // Custom duration, null Guid
     end;
 
     /// <summary>
@@ -655,11 +655,11 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(BlobName: Text; DurationSeconds: Integer; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure AcquireLease(BlobName: Text; DurationSeconds: Integer; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId)); // Custom duration, null Guid
+        exit(BlobServicesApiImpl.BlobAcquireLease(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId)); // Custom duration, null Guid
     end;
 
     /// <summary>
@@ -670,11 +670,11 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(BlobName: Text; ProposedLeaseId: Guid; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure AcquireLease(BlobName: Text; ProposedLeaseId: Guid; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, custom Guid
+        exit(BlobServicesApiImpl.BlobAcquireLease(BlobName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, custom Guid
     end;
 
     /// <summary>
@@ -686,9 +686,9 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(BlobName: Text; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure AcquireLease(BlobName: Text; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, custom Guid
+        exit(BlobServicesApiImpl.BlobAcquireLease(BlobName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, custom Guid
     end;
 
     /// <summary>
@@ -701,9 +701,9 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(BlobName: Text; DurationSeconds: Integer; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure AcquireLease(BlobName: Text; DurationSeconds: Integer; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId));
+        exit(BlobServicesApiImpl.BlobAcquireLease(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId));
     end;
 
     /// <summary>
@@ -713,11 +713,11 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be released</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseRelease(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure ReleaseLease(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(BlobServicesApiImpl.BlobLeaseRelease(BlobName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.BlobReleaseLease(BlobName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -728,9 +728,9 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="LeaseId">The Guid for the lease that should be released</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseRelease(BlobName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure ReleaseLease(BlobName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.BlobLeaseRelease(BlobName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.BlobReleaseLease(BlobName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -740,11 +740,11 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseRenew(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure RenewLease(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(BlobServicesApiImpl.BlobLeaseRenew(BlobName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.BlobRenewLease(BlobName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -755,9 +755,9 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseRenew(BlobName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure RenewLease(BlobName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.BlobLeaseRenew(BlobName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.BlobRenewLease(BlobName, OptionalParameters, LeaseId));
     end;
 
 
@@ -768,11 +768,11 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseBreak(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure BreakLease(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(BlobServicesApiImpl.BlobLeaseBreak(BlobName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.BlobBreakLease(BlobName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -783,9 +783,9 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseBreak(BlobName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure BreakLease(BlobName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.BlobLeaseBreak(BlobName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.BlobBreakLease(BlobName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -796,11 +796,11 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="LeaseId">The Guid for the lease that should be changed. Will contain the updated Guid after successful operation.</param>
     /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseChange(BlobName: Text; var LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure ChangeLease(BlobName: Text; var LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(BlobServicesApiImpl.BlobLeaseChange(BlobName, OptionalParameters, LeaseId, ProposedLeaseId));
+        exit(BlobServicesApiImpl.BlobChangeLease(BlobName, OptionalParameters, LeaseId, ProposedLeaseId));
     end;
 
     /// <summary>
@@ -812,9 +812,9 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseChange(BlobName: Text; LeaseId: Guid; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure ChangeLease(BlobName: Text; LeaseId: Guid; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.BlobLeaseChange(BlobName, OptionalParameters, LeaseId, ProposedLeaseId));
+        exit(BlobServicesApiImpl.BlobChangeLease(BlobName, OptionalParameters, LeaseId, ProposedLeaseId));
     end;
 
     var

--- a/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
@@ -604,92 +604,106 @@ codeunit 9053 "ABS Blob Client"
     /// Requests a new lease. If the blob does not have an active lease, the Blob service creates a lease on the blob. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>
+    /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(BlobName: Text): Codeunit "ABS Operation Response"
+    procedure LeaseAcquire(BlobName: Text; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, null Guid
+        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, null Guid
     end;
 
     /// <summary>
     /// Requests a new lease. If the blob does not have an active lease, the Blob service creates a lease on the blob. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure LeaseAcquire(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, null Guid
+        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, null Guid
     end;
 
     /// <summary>
     /// Requests a new lease. If the blob does not have an active lease, the Blob service creates a lease on the blob. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>    
+    /// <param name="BlobName">The name of the blob.</param>
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
+    /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(BlobName: Text; DurationSeconds: Integer): Codeunit "ABS Operation Response"
+    procedure LeaseAcquire(BlobName: Text; DurationSeconds: Integer; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId)); // Custom duration, null Guid
+        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId)); // Custom duration, null Guid
     end;
 
     /// <summary>
     /// Requests a new lease. If the blob does not have an active lease, the Blob service creates a lease on the blob. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>    
+    /// <param name="BlobName">The name of the blob.</param>
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(BlobName: Text; DurationSeconds: Integer; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure LeaseAcquire(BlobName: Text; DurationSeconds: Integer; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId)); // Custom duration, null Guid
+        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId)); // Custom duration, null Guid
     end;
 
     /// <summary>
     /// Requests a new lease. If the blob does not have an active lease, the Blob service creates a lease on the blob. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
+    /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(BlobName: Text; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure LeaseAcquire(BlobName: Text; ProposedLeaseId: Guid; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, custom Guid
+        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, custom Guid
     end;
 
     /// <summary>
     /// Requests a new lease. If the blob does not have an active lease, the Blob service creates a lease on the blob. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(BlobName: Text; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure LeaseAcquire(BlobName: Text; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, custom Guid
+        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, custom Guid
     end;
 
     /// <summary>
     /// Requests a new lease. If the blob does not have an active lease, the Blob service creates a lease on the blob. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
-    /// </summary>    
+    /// </summary>  
+    /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(BlobName: Text; DurationSeconds: Integer; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure LeaseAcquire(BlobName: Text; DurationSeconds: Integer; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId));
+        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId));
     end;
 
     /// <summary>

--- a/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
@@ -600,6 +600,201 @@ codeunit 9053 "ABS Blob Client"
         exit(BlobServicesApiImpl.PutBlockFromURL(BlobName, SourceUri, BlockId, OptionalParameters));
     end;
 
+    /// <summary>
+    /// Requests a new lease. If the blob does not have an active lease, the Blob service creates a lease on the blob. The lease duration can be 15 to 60 seconds or can be infinite
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseAcquire(BlobName: Text): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+        ProposedLeaseId: Guid;
+    begin
+        exit(LeaseAcquire(BlobName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, null Guid
+    end;
+
+    /// <summary>
+    /// Requests a new lease. If the blob does not have an active lease, the Blob service creates a lease on the blob. The lease duration can be 15 to 60 seconds or can be infinite
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseAcquire(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    var
+        ProposedLeaseId: Guid;
+    begin
+        exit(LeaseAcquire(BlobName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, null Guid
+    end;
+
+    /// <summary>
+    /// Requests a new lease. If the blob does not have an active lease, the Blob service creates a lease on the blob. The lease duration can be 15 to 60 seconds or can be infinite
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>    
+    /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseAcquire(BlobName: Text; DurationSeconds: Integer): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+        ProposedLeaseId: Guid;
+    begin
+        exit(LeaseAcquire(BlobName, DurationSeconds, ProposedLeaseId, OptionalParameters)); // Custom duration, null Guid
+    end;
+
+    /// <summary>
+    /// Requests a new lease. If the blob does not have an active lease, the Blob service creates a lease on the blob. The lease duration can be 15 to 60 seconds or can be infinite
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>    
+    /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseAcquire(BlobName: Text; DurationSeconds: Integer; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    var
+        ProposedLeaseId: Guid;
+    begin
+        exit(LeaseAcquire(BlobName, DurationSeconds, ProposedLeaseId, OptionalParameters)); // Custom duration, null Guid
+    end;
+
+    /// <summary>
+    /// Requests a new lease. If the blob does not have an active lease, the Blob service creates a lease on the blob. The lease duration can be 15 to 60 seconds or can be infinite
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>
+    /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseAcquire(BlobName: Text; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(LeaseAcquire(BlobName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, custom Guid
+    end;
+
+    /// <summary>
+    /// Requests a new lease. If the blob does not have an active lease, the Blob service creates a lease on the blob. The lease duration can be 15 to 60 seconds or can be infinite
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>
+    /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseAcquire(BlobName: Text; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(LeaseAcquire(BlobName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, custom Guid
+    end;
+
+    /// <summary>
+    /// Requests a new lease. If the blob does not have an active lease, the Blob service creates a lease on the blob. The lease duration can be 15 to 60 seconds or can be infinite
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>    
+    /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
+    /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseAcquire(BlobName: Text; DurationSeconds: Integer; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId));
+    end;
+
+    /// <summary>
+    /// Releases a lease on a Blob if it is no longer needed so that another client may immediately acquire a lease against the blob
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be released</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseRelease(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(LeaseRelease(BlobName, LeaseId, OptionalParameters));
+    end;
+
+    /// <summary>
+    /// Releases a lease on a Blob if it is no longer needed so that another client may immediately acquire a lease against the blob
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be released</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseRelease(BlobName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(BlobServicesApiImpl.BlobLeaseRelease(BlobName, OptionalParameters, LeaseId));
+    end;
+
+    /// <summary>
+    /// Renews a lease on a Blob to keep it locked again for the same amount of time as before
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseRenew(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(LeaseRenew(BlobName, LeaseId, OptionalParameters));
+    end;
+
+    /// <summary>
+    /// Renews a lease on a Blob to keep it locked again for the same amount of time as before
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseRenew(BlobName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(BlobServicesApiImpl.BlobLeaseRenew(BlobName, OptionalParameters, LeaseId));
+    end;
+
+
+    /// <summary>
+    /// Breaks a lease on a blob but ensures that another client cannot acquire a new lease until the current lease period has expired
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be broken</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseBreak(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(LeaseBreak(BlobName, LeaseId, OptionalParameters));
+    end;
+
+    /// <summary>
+    /// Breaks a lease on a blob but ensures that another client cannot acquire a new lease until the current lease period has expired
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be broken</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseBreak(BlobName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(BlobServicesApiImpl.BlobLeaseBreak(BlobName, OptionalParameters, LeaseId));
+    end;
+
+    /// <summary>
+    /// Changes the lease ID of an active lease
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be changed</param>
+    /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseChange(BlobName: Text; LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(LeaseChange(BlobName, LeaseId, ProposedLeaseId, OptionalParameters));
+    end;
+
+    /// <summary>
+    /// Changes the lease ID of an active lease
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be changed</param>
+    /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseChange(BlobName: Text; LeaseId: Guid; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(BlobServicesApiImpl.BlobLeaseChange(BlobName, OptionalParameters, LeaseId, ProposedLeaseId));
+    end;
+
     var
         BlobServicesApiImpl: Codeunit "ABS Client Impl.";
 }

--- a/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
@@ -786,10 +786,10 @@ codeunit 9053 "ABS Blob Client"
     /// Changes the lease ID of an active lease
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>
-    /// <param name="LeaseId">The Guid for the lease that should be changed</param>
+    /// <param name="LeaseId">The Guid for the lease that should be changed. Will contain the updated Guid after successful operation.</param>
     /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseChange(BlobName: Text; LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure LeaseChange(BlobName: Text; var LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin

--- a/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
@@ -610,7 +610,7 @@ codeunit 9053 "ABS Blob Client"
         OptionalParameters: Codeunit "ABS Optional Parameters";
         ProposedLeaseId: Guid;
     begin
-        exit(LeaseAcquire(BlobName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, null Guid
+        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, null Guid
     end;
 
     /// <summary>
@@ -623,7 +623,7 @@ codeunit 9053 "ABS Blob Client"
     var
         ProposedLeaseId: Guid;
     begin
-        exit(LeaseAcquire(BlobName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, null Guid
+        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, null Guid
     end;
 
     /// <summary>
@@ -637,7 +637,7 @@ codeunit 9053 "ABS Blob Client"
         OptionalParameters: Codeunit "ABS Optional Parameters";
         ProposedLeaseId: Guid;
     begin
-        exit(LeaseAcquire(BlobName, DurationSeconds, ProposedLeaseId, OptionalParameters)); // Custom duration, null Guid
+        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId)); // Custom duration, null Guid
     end;
 
     /// <summary>
@@ -651,7 +651,7 @@ codeunit 9053 "ABS Blob Client"
     var
         ProposedLeaseId: Guid;
     begin
-        exit(LeaseAcquire(BlobName, DurationSeconds, ProposedLeaseId, OptionalParameters)); // Custom duration, null Guid
+        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, DurationSeconds, ProposedLeaseId)); // Custom duration, null Guid
     end;
 
     /// <summary>
@@ -664,7 +664,7 @@ codeunit 9053 "ABS Blob Client"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(LeaseAcquire(BlobName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, custom Guid
+        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, custom Guid
     end;
 
     /// <summary>
@@ -676,7 +676,7 @@ codeunit 9053 "ABS Blob Client"
     /// <returns>An operation reponse object</returns>
     procedure LeaseAcquire(BlobName: Text; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(LeaseAcquire(BlobName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, custom Guid
+        exit(BlobServicesApiImpl.BlobLeaseAcquire(BlobName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, custom Guid
     end;
 
     /// <summary>
@@ -702,7 +702,7 @@ codeunit 9053 "ABS Blob Client"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(LeaseRelease(BlobName, LeaseId, OptionalParameters));
+        exit(BlobServicesApiImpl.BlobLeaseRelease(BlobName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -727,7 +727,7 @@ codeunit 9053 "ABS Blob Client"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(LeaseRenew(BlobName, LeaseId, OptionalParameters));
+        exit(BlobServicesApiImpl.BlobLeaseRenew(BlobName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -753,7 +753,7 @@ codeunit 9053 "ABS Blob Client"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(LeaseBreak(BlobName, LeaseId, OptionalParameters));
+        exit(BlobServicesApiImpl.BlobLeaseBreak(BlobName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -779,7 +779,7 @@ codeunit 9053 "ABS Blob Client"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(LeaseChange(BlobName, LeaseId, ProposedLeaseId, OptionalParameters));
+        exit(BlobServicesApiImpl.BlobLeaseChange(BlobName, OptionalParameters, LeaseId, ProposedLeaseId));
     end;
 
     /// <summary>

--- a/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
@@ -710,6 +710,7 @@ codeunit 9053 "ABS Blob Client"
     /// Releases a lease on a Blob if it is no longer needed so that another client may immediately acquire a lease against the blob
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be released</param>
     /// <returns>An operation reponse object</returns>
     procedure LeaseRelease(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
@@ -723,6 +724,7 @@ codeunit 9053 "ABS Blob Client"
     /// Releases a lease on a Blob if it is no longer needed so that another client may immediately acquire a lease against the blob
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be released</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
@@ -735,6 +737,7 @@ codeunit 9053 "ABS Blob Client"
     /// Renews a lease on a Blob to keep it locked again for the same amount of time as before
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
     /// <returns>An operation reponse object</returns>
     procedure LeaseRenew(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
@@ -748,6 +751,7 @@ codeunit 9053 "ABS Blob Client"
     /// Renews a lease on a Blob to keep it locked again for the same amount of time as before
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
@@ -761,6 +765,7 @@ codeunit 9053 "ABS Blob Client"
     /// Breaks a lease on a blob but ensures that another client cannot acquire a new lease until the current lease period has expired
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
     /// <returns>An operation reponse object</returns>
     procedure LeaseBreak(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
@@ -774,6 +779,7 @@ codeunit 9053 "ABS Blob Client"
     /// Breaks a lease on a blob but ensures that another client cannot acquire a new lease until the current lease period has expired
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
@@ -786,6 +792,7 @@ codeunit 9053 "ABS Blob Client"
     /// Changes the lease ID of an active lease
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be changed. Will contain the updated Guid after successful operation.</param>
     /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
     /// <returns>An operation reponse object</returns>
@@ -800,6 +807,7 @@ codeunit 9053 "ABS Blob Client"
     /// Changes the lease ID of an active lease
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
     /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be changed</param>
     /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>

--- a/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
@@ -772,7 +772,22 @@ codeunit 9053 "ABS Blob Client"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(BlobServicesApiImpl.BlobBreakLease(BlobName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.BlobBreakLease(BlobName, OptionalParameters, LeaseId, 0));
+    end;
+
+    /// <summary>
+    /// Breaks a lease on a blob but ensures that another client cannot acquire a new lease until the current lease period has expired
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>  
+    /// <param name="LeaseId">The Guid for the lease that should be broken</param>
+    /// <param name="LeaseBreakPeriod">The proposed duration the lease should continue before it is broken, in seconds, between 0 and 60.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure BreakLease(BlobName: Text; LeaseId: Guid; LeaseBreakPeriod: Integer): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(BlobServicesApiImpl.BlobBreakLease(BlobName, OptionalParameters, LeaseId, LeaseBreakPeriod));
     end;
 
     /// <summary>
@@ -785,7 +800,21 @@ codeunit 9053 "ABS Blob Client"
     /// <returns>An operation reponse object</returns>
     procedure BreakLease(BlobName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.BlobBreakLease(BlobName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.BlobBreakLease(BlobName, OptionalParameters, LeaseId, 0));
+    end;
+
+    /// <summary>
+    /// Breaks a lease on a blob but ensures that another client cannot acquire a new lease until the current lease period has expired
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob
+    /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>  
+    /// <param name="LeaseId">The Guid for the lease that should be broken</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <param name="LeaseBreakPeriod">The proposed duration the lease should continue before it is broken, in seconds, between 0 and 60.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure BreakLease(BlobName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseBreakPeriod: Integer): Codeunit "ABS Operation Response"
+    begin
+        exit(BlobServicesApiImpl.BlobBreakLease(BlobName, OptionalParameters, LeaseId, LeaseBreakPeriod));
     end;
 
     /// <summary>

--- a/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
@@ -840,11 +840,9 @@ codeunit 9051 "ABS Client Impl."
 
     local procedure TestParameterSpecified("Value": Variant; ParameterName: Text; HeaderIdentifer: Text)
     begin
-        case true of
-            "Value".IsGuid():
-                if IsNullGuid("Value") then
-                    Error(ParameterMissingErr, ParameterName, HeaderIdentifer);
-        end
+        if "Value".IsGuid() then
+            if IsNullGuid("Value") then
+                Error(ParameterMissingErr, ParameterName, HeaderIdentifer);
     end;
     #endregion
 }

--- a/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
@@ -30,6 +30,9 @@ codeunit 9051 "ABS Client Impl."
         BlockListOperationNotSuccessfulErr: Label 'Could not %2 block list on %1.', Comment = '%1 = Blob; %2 = Get/Set';
         PutBlockFromUrlOperationNotSuccessfulErr: Label 'Could not put block from URL %1 on %2.', Comment = '%1 = Source URI; %2 = Blob';
         ExpiryOperationNotSuccessfulErr: Label 'Could not set expiration on %1.', Comment = '%1 = Blob';
+        LeaseOperationNotSuccessfulErr: Label 'Could not %1 lease for %2 %3.', Comment = '%1 = Lease Action, %2 = Type (Container or Blob), %3 = Name';
+        ParameterDurationErr: Label 'Duration can be -1 (for infinite) or between 15 and 60 seconds. Parameter Value: %1', Comment = '%1 = Current Value';
+        ParameterMissingErr: Label 'You need to specify %1 (%2)', Comment = '%1 = Parameter Name, %2 = Header Identifer';
     #endregion
 
     [NonDebuggable]
@@ -109,6 +112,51 @@ codeunit 9051 "ABS Client Impl."
         HelperLibrary.BlobNodeListToTempRecord(NodeList, ContainerContent);
 
         exit(OperationResponse);
+    end;
+
+    procedure ContainerLeaseAcquire(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        Operation: Enum "ABS Operation";
+    begin
+        OperationPayload.SetOperation(Operation::LeaseContainer);
+        OperationPayload.SetContainerName(ContainerName);
+        exit(LeaseAcquire(OptionalParameters, DurationSeconds, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'acquire', 'Container', OperationPayload.GetContainerName())));
+    end;
+
+    procedure ContainerLeaseRelease(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        Operation: Enum "ABS Operation";
+    begin
+        OperationPayload.SetOperation(Operation::LeaseContainer);
+        OperationPayload.SetContainerName(ContainerName);
+        exit(LeaseRelease(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'release', 'Container', OperationPayload.GetContainerName())));
+    end;
+
+    procedure ContainerLeaseRenew(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        Operation: Enum "ABS Operation";
+    begin
+        OperationPayload.SetOperation(Operation::LeaseContainer);
+        OperationPayload.SetContainerName(ContainerName);
+        exit(LeaseRenew(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'renew', 'Container', OperationPayload.GetContainerName())));
+    end;
+
+    procedure ContainerLeaseBreak(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        Operation: Enum "ABS Operation";
+    begin
+        OperationPayload.SetOperation(Operation::LeaseContainer);
+        OperationPayload.SetContainerName(ContainerName);
+        exit(LeaseBreak(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'break', 'Container', OperationPayload.GetContainerName())));
+    end;
+
+    procedure ContainerLeaseChange(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        Operation: Enum "ABS Operation";
+    begin
+        OperationPayload.SetOperation(Operation::LeaseContainer);
+        OperationPayload.SetContainerName(ContainerName);
+        exit(LeaseChange(OptionalParameters, LeaseId, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'change', 'Container', OperationPayload.GetContainerName())));
     end;
     #endregion
 
@@ -637,6 +685,154 @@ codeunit 9051 "ABS Client Impl."
         OperationResponse := BlobAPIWebRequestHelper.PutOperation(OperationPayload, Content, StrSubstNo(PutBlockFromUrlOperationNotSuccessfulErr, SourceUri, OperationPayload.GetBlobName()));
 
         exit(OperationResponse);
+    end;
+
+    procedure BlobLeaseAcquire(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        Operation: Enum "ABS Operation";
+    begin
+        OperationPayload.SetOperation(Operation::LeaseBlob);
+        OperationPayload.SetBlobName(BlobName);
+        exit(LeaseAcquire(OptionalParameters, DurationSeconds, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'acquire', 'Blob', OperationPayload.GetBlobName())));
+    end;
+
+    procedure BlobLeaseRelease(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        Operation: Enum "ABS Operation";
+    begin
+        OperationPayload.SetOperation(Operation::LeaseBlob);
+        OperationPayload.SetBlobName(BlobName);
+        exit(LeaseRelease(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'release', 'Blob', OperationPayload.GetBlobName())));
+    end;
+
+    procedure BlobLeaseRenew(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        Operation: Enum "ABS Operation";
+    begin
+        OperationPayload.SetOperation(Operation::LeaseBlob);
+        OperationPayload.SetBlobName(BlobName);
+        exit(LeaseRenew(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'renew', 'Blob', OperationPayload.GetBlobName())));
+    end;
+
+    procedure BlobLeaseBreak(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        Operation: Enum "ABS Operation";
+    begin
+        OperationPayload.SetOperation(Operation::LeaseBlob);
+        OperationPayload.SetBlobName(BlobName);
+        exit(LeaseBreak(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'break', 'Blob', OperationPayload.GetBlobName())));
+    end;
+
+    procedure BlobLeaseChange(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        Operation: Enum "ABS Operation";
+    begin
+        OperationPayload.SetOperation(Operation::LeaseBlob);
+        OperationPayload.SetBlobName(BlobName);
+        exit(LeaseChange(OptionalParameters, LeaseId, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'change', 'Blob', OperationPayload.GetBlobName())));
+    end;
+    #endregion
+
+    #region Private Lease-functions
+    local procedure LeaseAcquire(OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
+    var
+        OperationResponse: Codeunit "ABS Operation Response";
+        LeaseAction: Enum "ABS Lease Action";
+    begin
+        // Duration can be:
+        //   between 15 and 60 seconds
+        //   -1 (= infinite)
+        if ((DurationSeconds > 0) and ((DurationSeconds < 15) or (DurationSeconds > 60))) xor (not (DurationSeconds <> -1)) then
+            Error(ParameterDurationErr, DurationSeconds);
+
+        OptionalParameters.LeaseAction(LeaseAction::acquire);
+        OptionalParameters.LeaseDuration(DurationSeconds);
+        if not IsNullGuid(ProposedLeaseId) then
+            OptionalParameters.ProposedLeaseId(ProposedLeaseId);
+
+        OperationPayload.SetOptionalParameters(OptionalParameters);
+
+        OperationResponse := BlobAPIWebRequestHelper.PutOperation(OperationPayload, OperationNotSuccessfulErr);
+        exit(OperationResponse);
+    end;
+
+    local procedure LeaseRelease(OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
+    var
+        OperationResponse: Codeunit "ABS Operation Response";
+        LeaseAction: Enum "ABS Lease Action";
+    begin
+        OptionalParameters.LeaseAction(LeaseAction::release);
+
+        TestParameterSpecified(LeaseId, 'LeaseId', 'x-ms-lease-id');
+
+        OptionalParameters.LeaseId(LeaseId);
+
+        OperationPayload.SetOptionalParameters(OptionalParameters);
+
+        OperationResponse := BlobAPIWebRequestHelper.PutOperation(OperationPayload, OperationNotSuccessfulErr);
+        exit(OperationResponse);
+    end;
+
+    local procedure LeaseRenew(OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
+    var
+        OperationResponse: Codeunit "ABS Operation Response";
+        LeaseAction: Enum "ABS Lease Action";
+    begin
+        OptionalParameters.LeaseAction(LeaseAction::renew);
+
+        TestParameterSpecified(LeaseId, 'LeaseId', 'x-ms-lease-id');
+
+        OptionalParameters.LeaseId(LeaseId);
+
+        OperationPayload.SetOptionalParameters(OptionalParameters);
+
+        OperationResponse := BlobAPIWebRequestHelper.PutOperation(OperationPayload, OperationNotSuccessfulErr);
+        exit(OperationResponse);
+    end;
+
+    local procedure LeaseBreak(OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
+    var
+        OperationResponse: Codeunit "ABS Operation Response";
+        LeaseAction: Enum "ABS Lease Action";
+    begin
+        OptionalParameters.LeaseAction(LeaseAction::break);
+
+        TestParameterSpecified(LeaseId, 'LeaseId', 'x-ms-lease-id');
+
+        OptionalParameters.LeaseId(LeaseId);
+
+        OperationPayload.SetOptionalParameters(OptionalParameters);
+
+        OperationResponse := BlobAPIWebRequestHelper.PutOperation(OperationPayload, OperationNotSuccessfulErr);
+        exit(OperationResponse);
+    end;
+
+    local procedure LeaseChange(OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; ProposedLeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
+    var
+        OperationResponse: Codeunit "ABS Operation Response";
+        LeaseAction: Enum "ABS Lease Action";
+    begin
+        OptionalParameters.LeaseAction(LeaseAction::change);
+
+        TestParameterSpecified(LeaseId, 'LeaseId', 'x-ms-lease-id');
+        TestParameterSpecified(ProposedLeaseId, 'ProposedLeaseId', 'x-ms-proposed-lease-id');
+
+        OptionalParameters.LeaseId(LeaseId);
+        OptionalParameters.ProposedLeaseId(ProposedLeaseId);
+
+        OperationPayload.SetOptionalParameters(OptionalParameters);
+
+        OperationResponse := BlobAPIWebRequestHelper.PutOperation(OperationPayload, OperationNotSuccessfulErr);
+        exit(OperationResponse);
+    end;
+
+    local procedure TestParameterSpecified("Value": Variant; ParameterName: Text; HeaderIdentifer: Text)
+    begin
+        case true of
+            "Value".IsGuid():
+                if IsNullGuid("Value") then
+                    Error(ParameterMissingErr, ParameterName, HeaderIdentifer);
+        end
     end;
     #endregion
 }

--- a/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
@@ -122,49 +122,49 @@ codeunit 9051 "ABS Client Impl."
         exit(OperationResponse);
     end;
 
-    procedure ContainerLeaseAcquire(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure ContainerAcquireLease(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         Operation: Enum "ABS Operation";
     begin
         OperationPayload.SetOperation(Operation::LeaseContainer);
         OperationPayload.SetContainerName(ContainerName);
-        exit(LeaseAcquire(OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseAcquireLbl, ContainerLbl, OperationPayload.GetContainerName())));
+        exit(AcquireLease(OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseAcquireLbl, ContainerLbl, OperationPayload.GetContainerName())));
     end;
 
-    procedure ContainerLeaseRelease(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure ContainerReleaseLease(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         Operation: Enum "ABS Operation";
     begin
         OperationPayload.SetOperation(Operation::LeaseContainer);
         OperationPayload.SetContainerName(ContainerName);
-        exit(LeaseRelease(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseReleaseLbl, ContainerLbl, OperationPayload.GetContainerName())));
+        exit(ReleaseLease(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseReleaseLbl, ContainerLbl, OperationPayload.GetContainerName())));
     end;
 
-    procedure ContainerLeaseRenew(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure ContainerRenewLease(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         Operation: Enum "ABS Operation";
     begin
         OperationPayload.SetOperation(Operation::LeaseContainer);
         OperationPayload.SetContainerName(ContainerName);
-        exit(LeaseRenew(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseRenewLbl, ContainerLbl, OperationPayload.GetContainerName())));
+        exit(RenewLease(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseRenewLbl, ContainerLbl, OperationPayload.GetContainerName())));
     end;
 
-    procedure ContainerLeaseBreak(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure ContainerBreakLease(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         Operation: Enum "ABS Operation";
     begin
         OperationPayload.SetOperation(Operation::LeaseContainer);
         OperationPayload.SetContainerName(ContainerName);
-        exit(LeaseBreak(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseBreakLbl, ContainerLbl, OperationPayload.GetContainerName())));
+        exit(BreakLease(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseBreakLbl, ContainerLbl, OperationPayload.GetContainerName())));
     end;
 
-    procedure ContainerLeaseChange(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure ContainerChangeLease(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
     var
         Operation: Enum "ABS Operation";
     begin
         OperationPayload.SetOperation(Operation::LeaseContainer);
         OperationPayload.SetContainerName(ContainerName);
-        exit(LeaseChange(OptionalParameters, LeaseId, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseChangeLbl, ContainerLbl, OperationPayload.GetContainerName())));
+        exit(ChangeLease(OptionalParameters, LeaseId, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseChangeLbl, ContainerLbl, OperationPayload.GetContainerName())));
     end;
     #endregion
 
@@ -695,54 +695,54 @@ codeunit 9051 "ABS Client Impl."
         exit(OperationResponse);
     end;
 
-    procedure BlobLeaseAcquire(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure BlobAcquireLease(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         Operation: Enum "ABS Operation";
     begin
         OperationPayload.SetOperation(Operation::LeaseBlob);
         OperationPayload.SetBlobName(BlobName);
-        exit(LeaseAcquire(OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseAcquireLbl, BlobLbl, OperationPayload.GetBlobName())));
+        exit(AcquireLease(OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseAcquireLbl, BlobLbl, OperationPayload.GetBlobName())));
     end;
 
-    procedure BlobLeaseRelease(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure BlobReleaseLease(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         Operation: Enum "ABS Operation";
     begin
         OperationPayload.SetOperation(Operation::LeaseBlob);
         OperationPayload.SetBlobName(BlobName);
-        exit(LeaseRelease(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseReleaseLbl, BlobLbl, OperationPayload.GetBlobName())));
+        exit(ReleaseLease(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseReleaseLbl, BlobLbl, OperationPayload.GetBlobName())));
     end;
 
-    procedure BlobLeaseRenew(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure BlobRenewLease(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         Operation: Enum "ABS Operation";
     begin
         OperationPayload.SetOperation(Operation::LeaseBlob);
         OperationPayload.SetBlobName(BlobName);
-        exit(LeaseRenew(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseRenewLbl, BlobLbl, OperationPayload.GetBlobName())));
+        exit(RenewLease(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseRenewLbl, BlobLbl, OperationPayload.GetBlobName())));
     end;
 
-    procedure BlobLeaseBreak(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure BlobBreakLease(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         Operation: Enum "ABS Operation";
     begin
         OperationPayload.SetOperation(Operation::LeaseBlob);
         OperationPayload.SetBlobName(BlobName);
-        exit(LeaseBreak(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseBreakLbl, BlobLbl, OperationPayload.GetBlobName())));
+        exit(BreakLease(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseBreakLbl, BlobLbl, OperationPayload.GetBlobName())));
     end;
 
-    procedure BlobLeaseChange(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure BlobChangeLease(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
     var
         Operation: Enum "ABS Operation";
     begin
         OperationPayload.SetOperation(Operation::LeaseBlob);
         OperationPayload.SetBlobName(BlobName);
-        exit(LeaseChange(OptionalParameters, LeaseId, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseChangeLbl, BlobLbl, OperationPayload.GetBlobName())));
+        exit(ChangeLease(OptionalParameters, LeaseId, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseChangeLbl, BlobLbl, OperationPayload.GetBlobName())));
     end;
     #endregion
 
     #region Private Lease-functions
-    local procedure LeaseAcquire(OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid; var LeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
+    local procedure AcquireLease(OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid; var LeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
     var
         OperationResponse: Codeunit "ABS Operation Response";
         FormatHelper: Codeunit "ABS Format Helper";
@@ -766,7 +766,7 @@ codeunit 9051 "ABS Client Impl."
         exit(OperationResponse);
     end;
 
-    local procedure LeaseRelease(OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
+    local procedure ReleaseLease(OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
     var
         OperationResponse: Codeunit "ABS Operation Response";
         LeaseAction: Enum "ABS Lease Action";
@@ -783,7 +783,7 @@ codeunit 9051 "ABS Client Impl."
         exit(OperationResponse);
     end;
 
-    local procedure LeaseRenew(OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
+    local procedure RenewLease(OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
     var
         OperationResponse: Codeunit "ABS Operation Response";
         LeaseAction: Enum "ABS Lease Action";
@@ -800,7 +800,7 @@ codeunit 9051 "ABS Client Impl."
         exit(OperationResponse);
     end;
 
-    local procedure LeaseBreak(OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
+    local procedure BreakLease(OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
     var
         OperationResponse: Codeunit "ABS Operation Response";
         LeaseAction: Enum "ABS Lease Action";
@@ -817,7 +817,7 @@ codeunit 9051 "ABS Client Impl."
         exit(OperationResponse);
     end;
 
-    local procedure LeaseChange(OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid; ProposedLeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
+    local procedure ChangeLease(OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid; ProposedLeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
     var
         OperationResponse: Codeunit "ABS Operation Response";
         FormatHelper: Codeunit "ABS Format Helper";

--- a/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
@@ -33,7 +33,15 @@ codeunit 9051 "ABS Client Impl."
         LeaseOperationNotSuccessfulErr: Label 'Could not %1 lease for %2 %3.', Comment = '%1 = Lease Action, %2 = Type (Container or Blob), %3 = Name';
         ParameterDurationErr: Label 'Duration can be -1 (for infinite) or between 15 and 60 seconds. Parameter Value: %1', Comment = '%1 = Current Value';
         ParameterMissingErr: Label 'You need to specify %1 (%2)', Comment = '%1 = Parameter Name, %2 = Header Identifer';
-    #endregion
+        LeaseAcquireLbl: Label 'acquire';
+        LeaseBreakLbl: Label 'break';
+        LeaseChangeLbl: Label 'change';
+        LeaseReleaseLbl: Label 'release';
+        LeaseRenewLbl: Label 'renew';
+        BlobLbl: Label 'Blob';
+        ContainerLbl: Label 'Container';
+
+    #endregion 
 
     [NonDebuggable]
     procedure Initialize(StorageAccountName: Text; ContainerName: Text; BlobName: Text; Authorization: Interface "Storage Service Authorization"; ApiVersion: Enum "Storage Service API Version")
@@ -120,7 +128,7 @@ codeunit 9051 "ABS Client Impl."
     begin
         OperationPayload.SetOperation(Operation::LeaseContainer);
         OperationPayload.SetContainerName(ContainerName);
-        exit(LeaseAcquire(OptionalParameters, DurationSeconds, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'acquire', 'Container', OperationPayload.GetContainerName())));
+        exit(LeaseAcquire(OptionalParameters, DurationSeconds, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseAcquireLbl, ContainerLbl, OperationPayload.GetContainerName())));
     end;
 
     procedure ContainerLeaseRelease(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
@@ -129,7 +137,7 @@ codeunit 9051 "ABS Client Impl."
     begin
         OperationPayload.SetOperation(Operation::LeaseContainer);
         OperationPayload.SetContainerName(ContainerName);
-        exit(LeaseRelease(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'release', 'Container', OperationPayload.GetContainerName())));
+        exit(LeaseRelease(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseReleaseLbl, ContainerLbl, OperationPayload.GetContainerName())));
     end;
 
     procedure ContainerLeaseRenew(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
@@ -138,7 +146,7 @@ codeunit 9051 "ABS Client Impl."
     begin
         OperationPayload.SetOperation(Operation::LeaseContainer);
         OperationPayload.SetContainerName(ContainerName);
-        exit(LeaseRenew(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'renew', 'Container', OperationPayload.GetContainerName())));
+        exit(LeaseRenew(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseRenewLbl, ContainerLbl, OperationPayload.GetContainerName())));
     end;
 
     procedure ContainerLeaseBreak(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
@@ -147,7 +155,7 @@ codeunit 9051 "ABS Client Impl."
     begin
         OperationPayload.SetOperation(Operation::LeaseContainer);
         OperationPayload.SetContainerName(ContainerName);
-        exit(LeaseBreak(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'break', 'Container', OperationPayload.GetContainerName())));
+        exit(LeaseBreak(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseBreakLbl, ContainerLbl, OperationPayload.GetContainerName())));
     end;
 
     procedure ContainerLeaseChange(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
@@ -156,7 +164,7 @@ codeunit 9051 "ABS Client Impl."
     begin
         OperationPayload.SetOperation(Operation::LeaseContainer);
         OperationPayload.SetContainerName(ContainerName);
-        exit(LeaseChange(OptionalParameters, LeaseId, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'change', 'Container', OperationPayload.GetContainerName())));
+        exit(LeaseChange(OptionalParameters, LeaseId, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseChangeLbl, ContainerLbl, OperationPayload.GetContainerName())));
     end;
     #endregion
 
@@ -458,7 +466,7 @@ codeunit 9051 "ABS Client Impl."
         OperationPayload.SetOptionalParameters(OptionalParameters);
         OperationPayload.SetBlobName(BlobName);
 
-        OperationResponse := BlobAPIWebRequestHelper.GetOperationAsText(OperationPayload, ResponseText, StrSubstNo(TagsOperationNotSuccessfulErr, 'get', 'Blob'));
+        OperationResponse := BlobAPIWebRequestHelper.GetOperationAsText(OperationPayload, ResponseText, StrSubstNo(TagsOperationNotSuccessfulErr, 'get', BlobLbl));
         BlobTags := FormatHelper.TextToXmlDocument(ResponseText);
         exit(OperationResponse);
     end;
@@ -484,7 +492,7 @@ codeunit 9051 "ABS Client Impl."
         OperationPayload.SetBlobName(BlobName);
 
         BlobAPIHttpContentHelper.AddTagsContent(Content, OperationPayload, Tags);
-        OperationResponse := BlobAPIWebRequestHelper.PutOperation(OperationPayload, Content, StrSubstNo(TagsOperationNotSuccessfulErr, 'set', 'Blob'));
+        OperationResponse := BlobAPIWebRequestHelper.PutOperation(OperationPayload, Content, StrSubstNo(TagsOperationNotSuccessfulErr, 'set', BlobLbl));
         exit(OperationResponse);
     end;
 
@@ -693,7 +701,7 @@ codeunit 9051 "ABS Client Impl."
     begin
         OperationPayload.SetOperation(Operation::LeaseBlob);
         OperationPayload.SetBlobName(BlobName);
-        exit(LeaseAcquire(OptionalParameters, DurationSeconds, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'acquire', 'Blob', OperationPayload.GetBlobName())));
+        exit(LeaseAcquire(OptionalParameters, DurationSeconds, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseAcquireLbl, BlobLbl, OperationPayload.GetBlobName())));
     end;
 
     procedure BlobLeaseRelease(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
@@ -702,7 +710,7 @@ codeunit 9051 "ABS Client Impl."
     begin
         OperationPayload.SetOperation(Operation::LeaseBlob);
         OperationPayload.SetBlobName(BlobName);
-        exit(LeaseRelease(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'release', 'Blob', OperationPayload.GetBlobName())));
+        exit(LeaseRelease(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseReleaseLbl, BlobLbl, OperationPayload.GetBlobName())));
     end;
 
     procedure BlobLeaseRenew(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
@@ -711,7 +719,7 @@ codeunit 9051 "ABS Client Impl."
     begin
         OperationPayload.SetOperation(Operation::LeaseBlob);
         OperationPayload.SetBlobName(BlobName);
-        exit(LeaseRenew(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'renew', 'Blob', OperationPayload.GetBlobName())));
+        exit(LeaseRenew(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseRenewLbl, BlobLbl, OperationPayload.GetBlobName())));
     end;
 
     procedure BlobLeaseBreak(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
@@ -720,7 +728,7 @@ codeunit 9051 "ABS Client Impl."
     begin
         OperationPayload.SetOperation(Operation::LeaseBlob);
         OperationPayload.SetBlobName(BlobName);
-        exit(LeaseBreak(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'break', 'Blob', OperationPayload.GetBlobName())));
+        exit(LeaseBreak(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseBreakLbl, BlobLbl, OperationPayload.GetBlobName())));
     end;
 
     procedure BlobLeaseChange(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
@@ -729,7 +737,7 @@ codeunit 9051 "ABS Client Impl."
     begin
         OperationPayload.SetOperation(Operation::LeaseBlob);
         OperationPayload.SetBlobName(BlobName);
-        exit(LeaseChange(OptionalParameters, LeaseId, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, 'change', 'Blob', OperationPayload.GetBlobName())));
+        exit(LeaseChange(OptionalParameters, LeaseId, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseChangeLbl, BlobLbl, OperationPayload.GetBlobName())));
     end;
     #endregion
 

--- a/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
@@ -750,7 +750,7 @@ codeunit 9051 "ABS Client Impl."
         // Duration can be:
         //   between 15 and 60 seconds
         //   -1 (= infinite)
-        if ((DurationSeconds > 0) and ((DurationSeconds < 15) or (DurationSeconds > 60))) xor (not (DurationSeconds <> -1)) then
+        if ((((DurationSeconds < 15) or (DurationSeconds > 60))) and (DurationSeconds <> -1)) then
             Error(ParameterDurationErr, DurationSeconds);
 
         OptionalParameters.LeaseAction(LeaseAction::acquire);

--- a/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
@@ -122,13 +122,13 @@ codeunit 9051 "ABS Client Impl."
         exit(OperationResponse);
     end;
 
-    procedure ContainerLeaseAcquire(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure ContainerLeaseAcquire(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         Operation: Enum "ABS Operation";
     begin
         OperationPayload.SetOperation(Operation::LeaseContainer);
         OperationPayload.SetContainerName(ContainerName);
-        exit(LeaseAcquire(OptionalParameters, DurationSeconds, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseAcquireLbl, ContainerLbl, OperationPayload.GetContainerName())));
+        exit(LeaseAcquire(OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseAcquireLbl, ContainerLbl, OperationPayload.GetContainerName())));
     end;
 
     procedure ContainerLeaseRelease(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
@@ -695,13 +695,13 @@ codeunit 9051 "ABS Client Impl."
         exit(OperationResponse);
     end;
 
-    procedure BlobLeaseAcquire(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure BlobLeaseAcquire(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         Operation: Enum "ABS Operation";
     begin
         OperationPayload.SetOperation(Operation::LeaseBlob);
         OperationPayload.SetBlobName(BlobName);
-        exit(LeaseAcquire(OptionalParameters, DurationSeconds, ProposedLeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseAcquireLbl, BlobLbl, OperationPayload.GetBlobName())));
+        exit(LeaseAcquire(OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseAcquireLbl, BlobLbl, OperationPayload.GetBlobName())));
     end;
 
     procedure BlobLeaseRelease(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid): Codeunit "ABS Operation Response"
@@ -742,7 +742,7 @@ codeunit 9051 "ABS Client Impl."
     #endregion
 
     #region Private Lease-functions
-    local procedure LeaseAcquire(OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
+    local procedure LeaseAcquire(OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid; var LeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
     var
         OperationResponse: Codeunit "ABS Operation Response";
         LeaseAction: Enum "ABS Lease Action";
@@ -761,6 +761,7 @@ codeunit 9051 "ABS Client Impl."
         OperationPayload.SetOptionalParameters(OptionalParameters);
 
         OperationResponse := BlobAPIWebRequestHelper.PutOperation(OperationPayload, OperationNotSuccessfulErr);
+        LeaseId := OperationResponse.GetHeaderValueFromResponseHeaders('x-ms-lease-id');
         exit(OperationResponse);
     end;
 

--- a/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
@@ -754,7 +754,7 @@ codeunit 9051 "ABS Client Impl."
         if ((((DurationSeconds < 15) or (DurationSeconds > 60))) and (DurationSeconds <> -1)) then
             Error(ParameterDurationErr, DurationSeconds);
 
-        OptionalParameters.LeaseAction(LeaseAction::acquire);
+        OptionalParameters.LeaseAction(LeaseAction::Acquire);
         OptionalParameters.LeaseDuration(DurationSeconds);
         if not IsNullGuid(ProposedLeaseId) then
             OptionalParameters.ProposedLeaseId(ProposedLeaseId);
@@ -771,7 +771,7 @@ codeunit 9051 "ABS Client Impl."
         OperationResponse: Codeunit "ABS Operation Response";
         LeaseAction: Enum "ABS Lease Action";
     begin
-        OptionalParameters.LeaseAction(LeaseAction::release);
+        OptionalParameters.LeaseAction(LeaseAction::Release);
 
         TestParameterSpecified(LeaseId, 'LeaseId', 'x-ms-lease-id');
 
@@ -788,7 +788,7 @@ codeunit 9051 "ABS Client Impl."
         OperationResponse: Codeunit "ABS Operation Response";
         LeaseAction: Enum "ABS Lease Action";
     begin
-        OptionalParameters.LeaseAction(LeaseAction::renew);
+        OptionalParameters.LeaseAction(LeaseAction::Renew);
 
         TestParameterSpecified(LeaseId, 'LeaseId', 'x-ms-lease-id');
 
@@ -805,7 +805,7 @@ codeunit 9051 "ABS Client Impl."
         OperationResponse: Codeunit "ABS Operation Response";
         LeaseAction: Enum "ABS Lease Action";
     begin
-        OptionalParameters.LeaseAction(LeaseAction::break);
+        OptionalParameters.LeaseAction(LeaseAction::Break);
 
         TestParameterSpecified(LeaseId, 'LeaseId', 'x-ms-lease-id');
 
@@ -823,7 +823,7 @@ codeunit 9051 "ABS Client Impl."
         FormatHelper: Codeunit "ABS Format Helper";
         LeaseAction: Enum "ABS Lease Action";
     begin
-        OptionalParameters.LeaseAction(LeaseAction::change);
+        OptionalParameters.LeaseAction(LeaseAction::Change);
 
         TestParameterSpecified(LeaseId, 'LeaseId', 'x-ms-lease-id');
         TestParameterSpecified(ProposedLeaseId, 'ProposedLeaseId', 'x-ms-proposed-lease-id');

--- a/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
@@ -158,7 +158,7 @@ codeunit 9051 "ABS Client Impl."
         exit(LeaseBreak(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseBreakLbl, ContainerLbl, OperationPayload.GetContainerName())));
     end;
 
-    procedure ContainerLeaseChange(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure ContainerLeaseChange(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
     var
         Operation: Enum "ABS Operation";
     begin
@@ -731,7 +731,7 @@ codeunit 9051 "ABS Client Impl."
         exit(LeaseBreak(OptionalParameters, LeaseId, StrSubstNo(LeaseOperationNotSuccessfulErr, LeaseBreakLbl, BlobLbl, OperationPayload.GetBlobName())));
     end;
 
-    procedure BlobLeaseChange(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure BlobLeaseChange(BlobName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
     var
         Operation: Enum "ABS Operation";
     begin
@@ -745,6 +745,7 @@ codeunit 9051 "ABS Client Impl."
     local procedure LeaseAcquire(OptionalParameters: Codeunit "ABS Optional Parameters"; DurationSeconds: Integer; ProposedLeaseId: Guid; var LeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
     var
         OperationResponse: Codeunit "ABS Operation Response";
+        FormatHelper: Codeunit "ABS Format Helper";
         LeaseAction: Enum "ABS Lease Action";
     begin
         // Duration can be:
@@ -761,7 +762,7 @@ codeunit 9051 "ABS Client Impl."
         OperationPayload.SetOptionalParameters(OptionalParameters);
 
         OperationResponse := BlobAPIWebRequestHelper.PutOperation(OperationPayload, OperationNotSuccessfulErr);
-        LeaseId := OperationResponse.GetHeaderValueFromResponseHeaders('x-ms-lease-id');
+        LeaseId := FormatHelper.RemoveCurlyBracketsFromString(OperationResponse.GetHeaderValueFromResponseHeaders('x-ms-lease-id'));
         exit(OperationResponse);
     end;
 
@@ -816,9 +817,10 @@ codeunit 9051 "ABS Client Impl."
         exit(OperationResponse);
     end;
 
-    local procedure LeaseChange(OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseId: Guid; ProposedLeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
+    local procedure LeaseChange(OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid; ProposedLeaseId: Guid; OperationNotSuccessfulErr: Text): Codeunit "ABS Operation Response"
     var
         OperationResponse: Codeunit "ABS Operation Response";
+        FormatHelper: Codeunit "ABS Format Helper";
         LeaseAction: Enum "ABS Lease Action";
     begin
         OptionalParameters.LeaseAction(LeaseAction::change);
@@ -832,6 +834,7 @@ codeunit 9051 "ABS Client Impl."
         OperationPayload.SetOptionalParameters(OptionalParameters);
 
         OperationResponse := BlobAPIWebRequestHelper.PutOperation(OperationPayload, OperationNotSuccessfulErr);
+        LeaseId := FormatHelper.RemoveCurlyBracketsFromString(OperationResponse.GetHeaderValueFromResponseHeaders('x-ms-lease-id'));
         exit(OperationResponse);
     end;
 

--- a/Modules/System/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
@@ -120,6 +120,201 @@ codeunit 9052 "ABS Container Client"
         exit(BlobServicesApiImpl.DeleteContainer(ContainerName, OptionalParameters));
     end;
 
+    /// <summary>
+    /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseAcquire(ContainerName: Text): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+        ProposedLeaseId: Guid;
+    begin
+        exit(LeaseAcquire(ContainerName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, null Guid
+    end;
+
+    /// <summary>
+    /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseAcquire(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    var
+        ProposedLeaseId: Guid;
+    begin
+        exit(LeaseAcquire(ContainerName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, null Guid
+    end;
+
+    /// <summary>
+    /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>    
+    /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseAcquire(ContainerName: Text; DurationSeconds: Integer): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+        ProposedLeaseId: Guid;
+    begin
+        exit(LeaseAcquire(ContainerName, DurationSeconds, ProposedLeaseId, OptionalParameters)); // Custom duration, null Guid
+    end;
+
+    /// <summary>
+    /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>    
+    /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseAcquire(ContainerName: Text; DurationSeconds: Integer; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    var
+        ProposedLeaseId: Guid;
+    begin
+        exit(LeaseAcquire(ContainerName, DurationSeconds, ProposedLeaseId, OptionalParameters)); // Custom duration, null Guid
+    end;
+
+    /// <summary>
+    /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>
+    /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseAcquire(ContainerName: Text; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(LeaseAcquire(ContainerName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, custom Guid
+    end;
+
+    /// <summary>
+    /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>
+    /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseAcquire(ContainerName: Text; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(LeaseAcquire(ContainerName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, custom Guid
+    end;
+
+    /// <summary>
+    /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>    
+    /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
+    /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseAcquire(ContainerName: Text; DurationSeconds: Integer; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId));
+    end;
+
+    /// <summary>
+    /// Releases a lease on a container if it is no longer needed so that another client may immediately acquire a lease against the blob
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be released</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseRelease(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(LeaseRelease(ContainerName, LeaseId, OptionalParameters));
+    end;
+
+    /// <summary>
+    /// Releases a lease on a container if it is no longer needed so that another client may immediately acquire a lease against the blob
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be released</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseRelease(ContainerName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(BlobServicesApiImpl.ContainerLeaseRelease(ContainerName, OptionalParameters, LeaseId));
+    end;
+
+    /// <summary>
+    /// Renews a lease on a container to keep it locked again for the same amount of time as before
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseRenew(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(LeaseRenew(ContainerName, LeaseId, OptionalParameters));
+    end;
+
+    /// <summary>
+    /// Renews a lease on a container to keep it locked again for the same amount of time as before
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseRenew(ContainerName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(BlobServicesApiImpl.ContainerLeaseRenew(ContainerName, OptionalParameters, LeaseId));
+    end;
+
+
+    /// <summary>
+    /// Breaks a lease on a container but ensures that another client cannot acquire a new lease until the current lease period has expired
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be broken</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseBreak(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(LeaseBreak(ContainerName, LeaseId, OptionalParameters));
+    end;
+
+    /// <summary>
+    /// Breaks a lease on a container but ensures that another client cannot acquire a new lease until the current lease period has expired
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be broken</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseBreak(ContainerName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(BlobServicesApiImpl.ContainerLeaseBreak(ContainerName, OptionalParameters, LeaseId));
+    end;
+
+    /// <summary>
+    /// Changes the lease ID of an active lease
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be changed</param>
+    /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseChange(ContainerName: Text; LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(LeaseChange(ContainerName, LeaseId, ProposedLeaseId, OptionalParameters));
+    end;
+
+    /// <summary>
+    /// Changes the lease ID of an active lease
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>
+    /// <param name="LeaseId">The Guid for the lease that should be changed</param>
+    /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure LeaseChange(ContainerName: Text; LeaseId: Guid; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(BlobServicesApiImpl.ContainerLeaseChange(ContainerName, OptionalParameters, LeaseId, ProposedLeaseId));
+    end;
+
     var
         BlobServicesApiImpl: Codeunit "ABS Client Impl.";
 }

--- a/Modules/System/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
@@ -124,7 +124,7 @@ codeunit 9052 "ABS Container Client"
     /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
-    /// <param name="ContainerName">The name of the container to delete.</param>
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
     procedure AcquireLease(ContainerName: Text; var LeaseId: Guid): Codeunit "ABS Operation Response"
@@ -139,7 +139,7 @@ codeunit 9052 "ABS Container Client"
     /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
-    /// <param name="ContainerName">The name of the container to delete.</param>
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
@@ -154,7 +154,7 @@ codeunit 9052 "ABS Container Client"
     /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>    
-    /// <param name="ContainerName">The name of the container to delete.</param>
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
@@ -170,7 +170,7 @@ codeunit 9052 "ABS Container Client"
     /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>    
-    /// <param name="ContainerName">The name of the container to delete.</param>
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
@@ -186,7 +186,7 @@ codeunit 9052 "ABS Container Client"
     /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
-    /// <param name="ContainerName">The name of the container to delete.</param>
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
@@ -201,7 +201,7 @@ codeunit 9052 "ABS Container Client"
     /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
-    /// <param name="ContainerName">The name of the container to delete.</param>
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
@@ -214,8 +214,8 @@ codeunit 9052 "ABS Container Client"
     /// <summary>
     /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
-    /// </summary> 
-    /// <param name="ContainerName">The name of the container to delete.</param>
+    /// </summary>     
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
@@ -230,6 +230,7 @@ codeunit 9052 "ABS Container Client"
     /// Releases a lease on a container if it is no longer needed so that another client may immediately acquire a lease against the blob
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be released</param>
     /// <returns>An operation reponse object</returns>
     procedure ReleaseLease(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
@@ -243,6 +244,7 @@ codeunit 9052 "ABS Container Client"
     /// Releases a lease on a container if it is no longer needed so that another client may immediately acquire a lease against the blob
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be released</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
@@ -255,6 +257,7 @@ codeunit 9052 "ABS Container Client"
     /// Renews a lease on a container to keep it locked again for the same amount of time as before
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
     /// <returns>An operation reponse object</returns>
     procedure RenewLease(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
@@ -268,6 +271,7 @@ codeunit 9052 "ABS Container Client"
     /// Renews a lease on a container to keep it locked again for the same amount of time as before
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
@@ -276,36 +280,67 @@ codeunit 9052 "ABS Container Client"
         exit(BlobServicesApiImpl.ContainerRenewLease(ContainerName, OptionalParameters, LeaseId));
     end;
 
-
     /// <summary>
     /// Breaks a lease on a container but ensures that another client cannot acquire a new lease until the current lease period has expired
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
     /// <returns>An operation reponse object</returns>
     procedure BreakLease(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(BlobServicesApiImpl.ContainerBreakLease(ContainerName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.ContainerBreakLease(ContainerName, OptionalParameters, LeaseId, 0));
     end;
 
     /// <summary>
     /// Breaks a lease on a container but ensures that another client cannot acquire a new lease until the current lease period has expired
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
+    /// <param name="ContainerName">The name of the container.</param>
+    /// <param name="LeaseId">The Guid for the lease that should be broken</param>
+    /// <param name="LeaseBreakPeriod">The proposed duration the lease should continue before it is broken, in seconds, between 0 and 60.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure BreakLease(ContainerName: Text; LeaseId: Guid; LeaseBreakPeriod: Integer): Codeunit "ABS Operation Response"
+    var
+        OptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(BlobServicesApiImpl.ContainerBreakLease(ContainerName, OptionalParameters, LeaseId, LeaseBreakPeriod));
+    end;
+
+    /// <summary>
+    /// Breaks a lease on a container but ensures that another client cannot acquire a new lease until the current lease period has expired
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
     procedure BreakLease(ContainerName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.ContainerBreakLease(ContainerName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.ContainerBreakLease(ContainerName, OptionalParameters, LeaseId, 0));
+    end;
+
+    /// <summary>
+    /// Breaks a lease on a container but ensures that another client cannot acquire a new lease until the current lease period has expired
+    /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
+    /// </summary>
+    /// <param name="ContainerName">The name of the container.</param>
+    /// <param name="LeaseId">The Guid for the lease that should be broken</param>
+    /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <param name="LeaseBreakPeriod">The proposed duration the lease should continue before it is broken, in seconds, between 0 and 60.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure BreakLease(ContainerName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"; LeaseBreakPeriod: Integer): Codeunit "ABS Operation Response"
+    begin
+        exit(BlobServicesApiImpl.ContainerBreakLease(ContainerName, OptionalParameters, LeaseId, LeaseBreakPeriod));
     end;
 
     /// <summary>
     /// Changes the lease ID of an active lease
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be changed. Will contain the updated Guid after successful operation.</param>
     /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
     /// <returns>An operation reponse object</returns>
@@ -320,6 +355,7 @@ codeunit 9052 "ABS Container Client"
     /// Changes the lease ID of an active lease
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
+    /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be changed</param>
     /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>

--- a/Modules/System/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
@@ -127,12 +127,12 @@ codeunit 9052 "ABS Container Client"
     /// <param name="ContainerName">The name of the container to delete.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(ContainerName: Text; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure AcquireLease(ContainerName: Text; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, null Guid
+        exit(BlobServicesApiImpl.ContainerAcquireLease(ContainerName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, null Guid
     end;
 
     /// <summary>
@@ -143,11 +143,11 @@ codeunit 9052 "ABS Container Client"
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure AcquireLease(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, null Guid
+        exit(BlobServicesApiImpl.ContainerAcquireLease(ContainerName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, null Guid
     end;
 
     /// <summary>
@@ -158,12 +158,12 @@ codeunit 9052 "ABS Container Client"
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(ContainerName: Text; DurationSeconds: Integer; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure AcquireLease(ContainerName: Text; DurationSeconds: Integer; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId)); // Custom duration, null Guid
+        exit(BlobServicesApiImpl.ContainerAcquireLease(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId)); // Custom duration, null Guid
     end;
 
     /// <summary>
@@ -175,11 +175,11 @@ codeunit 9052 "ABS Container Client"
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(ContainerName: Text; DurationSeconds: Integer; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure AcquireLease(ContainerName: Text; DurationSeconds: Integer; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId)); // Custom duration, null Guid
+        exit(BlobServicesApiImpl.ContainerAcquireLease(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId)); // Custom duration, null Guid
     end;
 
     /// <summary>
@@ -190,11 +190,11 @@ codeunit 9052 "ABS Container Client"
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(ContainerName: Text; ProposedLeaseId: Guid; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure AcquireLease(ContainerName: Text; ProposedLeaseId: Guid; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, custom Guid
+        exit(BlobServicesApiImpl.ContainerAcquireLease(ContainerName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, custom Guid
     end;
 
     /// <summary>
@@ -206,9 +206,9 @@ codeunit 9052 "ABS Container Client"
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(ContainerName: Text; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure AcquireLease(ContainerName: Text; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, custom Guid
+        exit(BlobServicesApiImpl.ContainerAcquireLease(ContainerName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, custom Guid
     end;
 
     /// <summary>
@@ -221,9 +221,9 @@ codeunit 9052 "ABS Container Client"
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(ContainerName: Text; DurationSeconds: Integer; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure AcquireLease(ContainerName: Text; DurationSeconds: Integer; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId));
+        exit(BlobServicesApiImpl.ContainerAcquireLease(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId));
     end;
 
     /// <summary>
@@ -232,11 +232,11 @@ codeunit 9052 "ABS Container Client"
     /// </summary>
     /// <param name="LeaseId">The Guid for the lease that should be released</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseRelease(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure ReleaseLease(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseRelease(ContainerName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.ContainerReleaseLease(ContainerName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -246,9 +246,9 @@ codeunit 9052 "ABS Container Client"
     /// <param name="LeaseId">The Guid for the lease that should be released</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseRelease(ContainerName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure ReleaseLease(ContainerName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseRelease(ContainerName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.ContainerReleaseLease(ContainerName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -257,11 +257,11 @@ codeunit 9052 "ABS Container Client"
     /// </summary>
     /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseRenew(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure RenewLease(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseRenew(ContainerName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.ContainerRenewLease(ContainerName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -271,9 +271,9 @@ codeunit 9052 "ABS Container Client"
     /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseRenew(ContainerName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure RenewLease(ContainerName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseRenew(ContainerName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.ContainerRenewLease(ContainerName, OptionalParameters, LeaseId));
     end;
 
 
@@ -283,11 +283,11 @@ codeunit 9052 "ABS Container Client"
     /// </summary>
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseBreak(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure BreakLease(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseBreak(ContainerName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.ContainerBreakLease(ContainerName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -297,9 +297,9 @@ codeunit 9052 "ABS Container Client"
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseBreak(ContainerName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure BreakLease(ContainerName: Text; LeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseBreak(ContainerName, OptionalParameters, LeaseId));
+        exit(BlobServicesApiImpl.ContainerBreakLease(ContainerName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -309,11 +309,11 @@ codeunit 9052 "ABS Container Client"
     /// <param name="LeaseId">The Guid for the lease that should be changed. Will contain the updated Guid after successful operation.</param>
     /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseChange(ContainerName: Text; var LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure ChangeLease(ContainerName: Text; var LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseChange(ContainerName, OptionalParameters, LeaseId, ProposedLeaseId));
+        exit(BlobServicesApiImpl.ContainerChangeLease(ContainerName, OptionalParameters, LeaseId, ProposedLeaseId));
     end;
 
     /// <summary>
@@ -324,9 +324,9 @@ codeunit 9052 "ABS Container Client"
     /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseChange(ContainerName: Text; LeaseId: Guid; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure ChangeLease(ContainerName: Text; LeaseId: Guid; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseChange(ContainerName, OptionalParameters, LeaseId, ProposedLeaseId));
+        exit(BlobServicesApiImpl.ContainerChangeLease(ContainerName, OptionalParameters, LeaseId, ProposedLeaseId));
     end;
 
     var

--- a/Modules/System/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
@@ -130,7 +130,7 @@ codeunit 9052 "ABS Container Client"
         OptionalParameters: Codeunit "ABS Optional Parameters";
         ProposedLeaseId: Guid;
     begin
-        exit(LeaseAcquire(ContainerName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, null Guid
+        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, null Guid
     end;
 
     /// <summary>
@@ -143,7 +143,7 @@ codeunit 9052 "ABS Container Client"
     var
         ProposedLeaseId: Guid;
     begin
-        exit(LeaseAcquire(ContainerName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, null Guid
+        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, null Guid
     end;
 
     /// <summary>
@@ -157,7 +157,7 @@ codeunit 9052 "ABS Container Client"
         OptionalParameters: Codeunit "ABS Optional Parameters";
         ProposedLeaseId: Guid;
     begin
-        exit(LeaseAcquire(ContainerName, DurationSeconds, ProposedLeaseId, OptionalParameters)); // Custom duration, null Guid
+        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId)); // Custom duration, null Guid
     end;
 
     /// <summary>
@@ -171,7 +171,7 @@ codeunit 9052 "ABS Container Client"
     var
         ProposedLeaseId: Guid;
     begin
-        exit(LeaseAcquire(ContainerName, DurationSeconds, ProposedLeaseId, OptionalParameters)); // Custom duration, null Guid
+        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId)); // Custom duration, null Guid
     end;
 
     /// <summary>
@@ -184,7 +184,7 @@ codeunit 9052 "ABS Container Client"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(LeaseAcquire(ContainerName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, custom Guid
+        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, custom Guid
     end;
 
     /// <summary>
@@ -196,7 +196,7 @@ codeunit 9052 "ABS Container Client"
     /// <returns>An operation reponse object</returns>
     procedure LeaseAcquire(ContainerName: Text; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(LeaseAcquire(ContainerName, -1, ProposedLeaseId, OptionalParameters)); // Infinite duration, custom Guid
+        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, custom Guid
     end;
 
     /// <summary>
@@ -222,7 +222,7 @@ codeunit 9052 "ABS Container Client"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(LeaseRelease(ContainerName, LeaseId, OptionalParameters));
+        exit(BlobServicesApiImpl.ContainerLeaseRelease(ContainerName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -247,7 +247,7 @@ codeunit 9052 "ABS Container Client"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(LeaseRenew(ContainerName, LeaseId, OptionalParameters));
+        exit(BlobServicesApiImpl.ContainerLeaseRenew(ContainerName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -273,7 +273,7 @@ codeunit 9052 "ABS Container Client"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(LeaseBreak(ContainerName, LeaseId, OptionalParameters));
+        exit(BlobServicesApiImpl.ContainerLeaseBreak(ContainerName, OptionalParameters, LeaseId));
     end;
 
     /// <summary>
@@ -299,7 +299,7 @@ codeunit 9052 "ABS Container Client"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(LeaseChange(ContainerName, LeaseId, ProposedLeaseId, OptionalParameters));
+        exit(BlobServicesApiImpl.ContainerLeaseChange(ContainerName, OptionalParameters, LeaseId, ProposedLeaseId));
     end;
 
     /// <summary>

--- a/Modules/System/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
@@ -306,10 +306,10 @@ codeunit 9052 "ABS Container Client"
     /// Changes the lease ID of an active lease
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
-    /// <param name="LeaseId">The Guid for the lease that should be changed</param>
+    /// <param name="LeaseId">The Guid for the lease that should be changed. Will contain the updated Guid after successful operation.</param>
     /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseChange(ContainerName: Text; LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure LeaseChange(ContainerName: Text; var LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin

--- a/Modules/System/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
@@ -124,92 +124,106 @@ codeunit 9052 "ABS Container Client"
     /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
+    /// <param name="ContainerName">The name of the container to delete.</param>
+    /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(ContainerName: Text): Codeunit "ABS Operation Response"
+    procedure LeaseAcquire(ContainerName: Text; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, null Guid
+        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, null Guid
     end;
 
     /// <summary>
     /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
+    /// <param name="ContainerName">The name of the container to delete.</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure LeaseAcquire(ContainerName: Text; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, null Guid
+        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, null Guid
     end;
 
     /// <summary>
     /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>    
+    /// <param name="ContainerName">The name of the container to delete.</param>
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
+    /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(ContainerName: Text; DurationSeconds: Integer): Codeunit "ABS Operation Response"
+    procedure LeaseAcquire(ContainerName: Text; DurationSeconds: Integer; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId)); // Custom duration, null Guid
+        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId)); // Custom duration, null Guid
     end;
 
     /// <summary>
     /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>    
+    /// <param name="ContainerName">The name of the container to delete.</param>
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(ContainerName: Text; DurationSeconds: Integer; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure LeaseAcquire(ContainerName: Text; DurationSeconds: Integer; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ProposedLeaseId: Guid;
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId)); // Custom duration, null Guid
+        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId)); // Custom duration, null Guid
     end;
 
     /// <summary>
     /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
+    /// <param name="ContainerName">The name of the container to delete.</param>
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
+    /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(ContainerName: Text; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
+    procedure LeaseAcquire(ContainerName: Text; ProposedLeaseId: Guid; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, custom Guid
+        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, custom Guid
     end;
 
     /// <summary>
     /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
     /// </summary>
+    /// <param name="ContainerName">The name of the container to delete.</param>
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(ContainerName: Text; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure LeaseAcquire(ContainerName: Text; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId)); // Infinite duration, custom Guid
+        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, custom Guid
     end;
 
     /// <summary>
     /// Requests a new lease. If the container does not have an active lease, the blob service creates a lease on the container. The lease duration can be 15 to 60 seconds or can be infinite
     /// see: https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container
-    /// </summary>    
+    /// </summary> 
+    /// <param name="ContainerName">The name of the container to delete.</param>
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param>
+    /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
     /// <returns>An operation reponse object</returns>
-    procedure LeaseAcquire(ContainerName: Text; DurationSeconds: Integer; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure LeaseAcquire(ContainerName: Text; DurationSeconds: Integer; ProposedLeaseId: Guid; OptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     begin
-        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId));
+        exit(BlobServicesApiImpl.ContainerLeaseAcquire(ContainerName, OptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId));
     end;
 
     /// <summary>

--- a/Modules/System/Azure Blob Services API/src/ABSOperationResponse.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSOperationResponse.Codeunit.al
@@ -61,16 +61,6 @@ codeunit 9050 "ABS Operation Response"
         Response := NewResponse;
     end;
 
-    procedure GetLeaseId(): Guid
-    var
-        LeaseId: Guid;
-        LeaseIdAsText: Text;
-    begin
-        LeaseIdAsText := GetHeaderValueFromResponseHeaders('x-ms-lease-id');
-        LeaseId := LeaseIdAsText;
-        exit(LeaseId);
-    end;
-
     [NonDebuggable]
     internal procedure GetHeaderValueFromResponseHeaders(HeaderName: Text): Text
     var

--- a/Modules/System/Azure Blob Services API/src/ABSOperationResponse.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSOperationResponse.Codeunit.al
@@ -61,6 +61,29 @@ codeunit 9050 "ABS Operation Response"
         Response := NewResponse;
     end;
 
+    procedure GetLeaseId(): Guid
+    var
+        LeaseId: Guid;
+        LeaseIdAsText: Text;
+    begin
+        LeaseIdAsText := GetHeaderValueFromResponseHeaders('x-ms-lease-id');
+        LeaseId := LeaseIdAsText;
+        exit(LeaseId);
+    end;
+
+    [NonDebuggable]
+    internal procedure GetHeaderValueFromResponseHeaders(HeaderName: Text): Text
+    var
+        Headers: HttpHeaders;
+        Values: array[100] of Text;
+        HeaderKeys: List of [Text];
+    begin
+        Headers := Response.Headers;
+        if not Headers.GetValues(HeaderName, Values) then
+            exit('');
+        exit(Values[1]);
+    end;
+
     var
         [NonDebuggable]
         Response: HttpResponseMessage;

--- a/Modules/System/Azure Blob Services API/src/API Enums/ABSLeaseAction.Enum.al
+++ b/Modules/System/Azure Blob Services API/src/API Enums/ABSLeaseAction.Enum.al
@@ -1,0 +1,54 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+/// <summary>
+/// The types of allowed lease operations
+/// See: https://docs.microsoft.com/en-us/rest/api/storageservices/blob-service-rest-api
+/// </summary>
+enum 9049 "ABS Lease Action"
+{
+    Access = Internal;
+    Extensible = false;
+
+    /// <summary>
+    /// Requests a new lease.
+    /// </summary>
+    value(0; acquire)
+    {
+        Caption = 'acquire', Locked = true;
+    }
+
+    /// <summary>
+    /// Renews the lease.
+    /// </summary>
+    value(1; renew)
+    {
+        Caption = 'renew', Locked = true;
+    }
+
+    /// <summary>
+    /// Changes the lease ID of an active lease.
+    /// </summary>
+    value(2; change)
+    {
+        Caption = 'change', Locked = true;
+    }
+
+    /// <summary>
+    /// Releases the lease
+    /// </summary>
+    value(3; release)
+    {
+        Caption = 'release', Locked = true;
+    }
+
+    /// <summary>
+    /// Breaks the lease, if the blob has an active lease
+    /// </summary>
+    value(4; break)
+    {
+        Caption = 'break', Locked = true;
+    }
+}

--- a/Modules/System/Azure Blob Services API/src/API Enums/ABSLeaseAction.Enum.al
+++ b/Modules/System/Azure Blob Services API/src/API Enums/ABSLeaseAction.Enum.al
@@ -15,7 +15,7 @@ enum 9049 "ABS Lease Action"
     /// <summary>
     /// Requests a new lease.
     /// </summary>
-    value(0; acquire)
+    value(0; Acquire)
     {
         Caption = 'acquire', Locked = true;
     }
@@ -23,7 +23,7 @@ enum 9049 "ABS Lease Action"
     /// <summary>
     /// Renews the lease.
     /// </summary>
-    value(1; renew)
+    value(1; Renew)
     {
         Caption = 'renew', Locked = true;
     }
@@ -31,7 +31,7 @@ enum 9049 "ABS Lease Action"
     /// <summary>
     /// Changes the lease ID of an active lease.
     /// </summary>
-    value(2; change)
+    value(2; Change)
     {
         Caption = 'change', Locked = true;
     }
@@ -39,7 +39,7 @@ enum 9049 "ABS Lease Action"
     /// <summary>
     /// Releases the lease
     /// </summary>
-    value(3; release)
+    value(3; Release)
     {
         Caption = 'release', Locked = true;
     }
@@ -47,7 +47,7 @@ enum 9049 "ABS Lease Action"
     /// <summary>
     /// Breaks the lease, if the blob has an active lease
     /// </summary>
-    value(4; break)
+    value(4; Break)
     {
         Caption = 'break', Locked = true;
     }

--- a/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
@@ -240,8 +240,6 @@ codeunit 9047 "ABS Optional Parameters"
     /// </summary>
     /// <param name="Value">Integer value specifying the HttpHeader value.</param>
     internal procedure LeaseBreakPeriod("Value": Integer)
-    var
-        LeaseAction: Enum "ABS Lease Action";
     begin
         SetRequestHeader('x-ms-lease-break-period', Format("Value"));
     end;
@@ -251,8 +249,6 @@ codeunit 9047 "ABS Optional Parameters"
     /// </summary>
     /// <param name="Value">Integer value specifying the HttpHeader value.</param>
     internal procedure LeaseDuration("Value": Integer)
-    var
-        LeaseAction: Enum "ABS Lease Action";
     begin
         SetRequestHeader('x-ms-lease-duration', Format("Value"));
     end;
@@ -261,13 +257,8 @@ codeunit 9047 "ABS Optional Parameters"
     /// Sets the value for 'x-ms-proposed-lease-id' HttpHeader for a request.
     /// </summary>
     /// <param name="Value">Guid value specifying the HttpHeader value.</param>
-    procedure ProposedLeaseId("Value": Guid)
-    var
-        LeaseAction: Enum "ABS Lease Action";
+    internal procedure ProposedLeaseId("Value": Guid)
     begin
-        LeaseAction := GetLeaseActionFromRequestHeader();
-        if not (LeaseAction in [LeaseAction::Acquire, LeaseAction::Change]) then
-            Error(HeaderCanOnlyBeSetOnTwoConditionsErr, 'x-ms-proposed-lease-id', 'x-ms-lease-action', 'acquire', 'change');
         SetRequestHeader('x-ms-proposed-lease-id', "Value");
     end;
 

--- a/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
@@ -227,15 +227,6 @@ codeunit 9047 "ABS Optional Parameters"
     end;
 
     /// <summary>
-    /// Sets the value for 'x-ms-lease-action' HttpHeader for a request.
-    /// </summary>
-    /// <param name="Value">Enum "ABS Lease Action" value specifying the HttpHeader value</param>
-    procedure LeaseAction("Value": Enum "ABS Lease Action")
-    begin
-        SetRequestHeader('x-ms-lease-action', Format("Value"));
-    end;
-
-    /// <summary>
     /// Sets the value for 'x-ms-lease-break-period' HttpHeader for a request.
     /// </summary>
     /// <param name="Value">Integer value specifying the HttpHeader value.</param>

--- a/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
@@ -239,13 +239,10 @@ codeunit 9047 "ABS Optional Parameters"
     /// Sets the value for 'x-ms-lease-break-period' HttpHeader for a request.
     /// </summary>
     /// <param name="Value">Integer value specifying the HttpHeader value.</param>
-    procedure LeaseBreakPeriod("Value": Integer)
+    internal procedure LeaseBreakPeriod("Value": Integer)
     var
         LeaseAction: Enum "ABS Lease Action";
     begin
-        LeaseAction := GetLeaseActionFromRequestHeader();
-        if not (LeaseAction in [LeaseAction::Break]) then
-            Error(HeaderCanOnlyBeSetOnConditionErr, 'x-ms-lease-break-period', 'x-ms-lease-action', 'break');
         SetRequestHeader('x-ms-lease-break-period', Format("Value"));
     end;
 

--- a/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
@@ -250,13 +250,10 @@ codeunit 9047 "ABS Optional Parameters"
     /// Sets the value for 'x-ms-lease-duration' HttpHeader for a request.
     /// </summary>
     /// <param name="Value">Integer value specifying the HttpHeader value.</param>
-    procedure LeaseDuration("Value": Integer)
+    internal procedure LeaseDuration("Value": Integer)
     var
         LeaseAction: Enum "ABS Lease Action";
     begin
-        LeaseAction := GetLeaseActionFromRequestHeader();
-        if not (LeaseAction in [LeaseAction::Acquire]) then
-            Error(HeaderCanOnlyBeSetOnConditionErr, 'x-ms-lease-duration', 'x-ms-lease-action', 'acquire');
         SetRequestHeader('x-ms-lease-duration', Format("Value"));
     end;
 

--- a/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
@@ -262,15 +262,6 @@ codeunit 9047 "ABS Optional Parameters"
         SetRequestHeader('x-ms-proposed-lease-id', "Value");
     end;
 
-    internal procedure GetLeaseActionFromRequestHeader(): Enum "ABS Lease Action"
-    var
-        LeaseActionAsText: Text;
-    begin
-        if not RequestHeaders.Get('x-ms-lease-action', LeaseActionAsText) then
-            Error(NeedToSpecifyHeaderErr, 'x-ms-lease-action');
-        exit(Enum::"ABS Lease Action".FromInteger(Enum::"ABS Lease Action".Ordinals.Get(Enum::"ABS Lease Action".Names.IndexOf(UpperCase(LeaseActionAsText[1]) + CopyStr(LeaseActionAsText, 2))))); // Make first Char Uppercase
-    end;
-
     local procedure SetRequestHeader(Header: Text; HeaderValue: Text)
     begin
         RequestHeaders.Remove(Header);

--- a/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
@@ -227,6 +227,15 @@ codeunit 9047 "ABS Optional Parameters"
     end;
 
     /// <summary>
+    /// Sets the value for 'x-ms-lease-action' HttpHeader for a request.
+    /// </summary>
+    /// <param name="Value">Enum "ABS Lease Action" value specifying the HttpHeader value</param>    
+    internal procedure LeaseAction("Value": Enum "ABS Lease Action")
+    begin
+        SetRequestHeader('x-ms-lease-action', Format("Value"));
+    end;
+
+    /// <summary>
     /// Sets the value for 'x-ms-lease-break-period' HttpHeader for a request.
     /// </summary>
     /// <param name="Value">Integer value specifying the HttpHeader value.</param>

--- a/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
@@ -244,7 +244,7 @@ codeunit 9047 "ABS Optional Parameters"
         LeaseAction: Enum "ABS Lease Action";
     begin
         LeaseAction := GetLeaseActionFromRequestHeader();
-        if not (LeaseAction in [LeaseAction::break]) then
+        if not (LeaseAction in [LeaseAction::Break]) then
             Error(HeaderCanOnlyBeSetOnConditionErr, 'x-ms-lease-break-period', 'x-ms-lease-action', 'break');
         SetRequestHeader('x-ms-lease-break-period', Format("Value"));
     end;
@@ -258,7 +258,7 @@ codeunit 9047 "ABS Optional Parameters"
         LeaseAction: Enum "ABS Lease Action";
     begin
         LeaseAction := GetLeaseActionFromRequestHeader();
-        if not (LeaseAction in [LeaseAction::acquire]) then
+        if not (LeaseAction in [LeaseAction::Acquire]) then
             Error(HeaderCanOnlyBeSetOnConditionErr, 'x-ms-lease-duration', 'x-ms-lease-action', 'acquire');
         SetRequestHeader('x-ms-lease-duration', Format("Value"));
     end;
@@ -272,7 +272,7 @@ codeunit 9047 "ABS Optional Parameters"
         LeaseAction: Enum "ABS Lease Action";
     begin
         LeaseAction := GetLeaseActionFromRequestHeader();
-        if not (LeaseAction in [LeaseAction::acquire, LeaseAction::change]) then
+        if not (LeaseAction in [LeaseAction::Acquire, LeaseAction::Change]) then
             Error(HeaderCanOnlyBeSetOnTwoConditionsErr, 'x-ms-proposed-lease-id', 'x-ms-lease-action', 'acquire', 'change');
         SetRequestHeader('x-ms-proposed-lease-id', "Value");
     end;

--- a/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
@@ -283,7 +283,7 @@ codeunit 9047 "ABS Optional Parameters"
     begin
         if not RequestHeaders.Get('x-ms-lease-action', LeaseActionAsText) then
             Error(NeedToSpecifyHeaderErr, 'x-ms-lease-action');
-        exit(Enum::"ABS Lease Action".FromInteger(Enum::"ABS Lease Action".Ordinals.Get(Enum::"ABS Lease Action".Names.IndexOf(LeaseActionAsText))));
+        exit(Enum::"ABS Lease Action".FromInteger(Enum::"ABS Lease Action".Ordinals.Get(Enum::"ABS Lease Action".Names.IndexOf(UpperCase(LeaseActionAsText[1]) + CopyStr(LeaseActionAsText, 2))))); // Make first Char Uppercase
     end;
 
     local procedure SetRequestHeader(Header: Text; HeaderValue: Text)


### PR DESCRIPTION
This PR adds support for [Lease Blob](https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob)- and [Lease Container](https://docs.microsoft.com/en-us/rest/api/storageservices/lease-container)-operations for the "Azure Blob Services API".

The tests contain one deactivated part, because the operation ("Lease Change") works against a "real" Azure Storage Account, but not against the Azurite emulator (I'll try to create a PR for the bug in Azurite as well).