### PR TITLE
New SetFormat in module Image

### DIFF
--- a/Modules/System Tests/Image/src/ImageTests.Codeunit.al
+++ b/Modules/System Tests/Image/src/ImageTests.Codeunit.al
@@ -119,6 +119,7 @@ codeunit 135135 "Image Tests"
         // [Given] base64 encoded data, create image
         Image.FromBase64(ImageAsBase64Txt);
 
+        // [When] change the format to Jpeg without any errors
         Image.SetFormat(Format::Jpeg);
 
         // [Then] verify format

--- a/Modules/System Tests/Image/src/ImageTests.Codeunit.al
+++ b/Modules/System Tests/Image/src/ImageTests.Codeunit.al
@@ -111,6 +111,21 @@ codeunit 135135 "Image Tests"
     end;
 
     [Test]
+    procedure SetFormatTest()
+    var
+        Image: Codeunit Image;
+        Format: Enum "Image Format";
+    begin
+        // [Given] base64 encoded data, create image
+        Image.FromBase64(ImageAsBase64Txt);
+
+        Image.SetFormat(Format::Jpeg);
+
+        // [Then] verify format
+        Assert.AreEqual(Format::Jpeg, Image.GetFormat(), 'Changing format failed');
+    end;
+
+    [Test]
     procedure GetFormatAsTextTest()
     var
         Image: Codeunit Image;

--- a/Modules/System/Image/README.md
+++ b/Modules/System/Image/README.md
@@ -56,6 +56,31 @@ begin
 
 end;
 ```
+
+##### Save an image in a new format
+```
+procedure Example()
+var
+    TempBlob:Codeunit "Temp Blob";
+    Image: Codeunit Image;
+    InStream: InStream;
+    OutStream: OutStream;
+    FileName: Text;
+begin
+    UploadIntoStream('', '', '', FileName, InStream);
+
+    Image.FromStream(InStream);
+    Image.SetFormat(Enum::"Image Format"::Png);
+
+    TempBlob.CreateOutStream(OutStream);
+    Image.Save(OutStream);	
+
+    TempBlob.CreateInStream(InStream);
+    FileName := FileName + '.png';
+    DownloadFromStream(InStream, '', '', '', FileName);
+end;
+```
+
 # Public Objects
 ## Image (Codeunit 3971)
 
@@ -121,6 +146,15 @@ procedure GetFormat(): Enum "Image Format"
 *[Enum "Image Format"]()*
 
 The enum value.
+### SetFormat (Method) <a name="SetFormat"></a> 
+
+ Sets the image format from an Enum "Image Format".
+ 
+
+#### Syntax
+```
+procedure SetFormat(ImageFormat: Enum "Image Format")
+```
 ### FromBase64 (Method) <a name="FromBase64"></a> 
 
  Creates an Image from base64 encoding.

--- a/Modules/System/Image/README.md
+++ b/Modules/System/Image/README.md
@@ -61,7 +61,7 @@ end;
 ```
 procedure Example()
 var
-    TempBlob:Codeunit "Temp Blob";
+    TempBlob: Codeunit "Temp Blob";
     Image: Codeunit Image;
     InStream: InStream;
     OutStream: OutStream;

--- a/Modules/System/Image/src/Image.Codeunit.al
+++ b/Modules/System/Image/src/Image.Codeunit.al
@@ -73,6 +73,14 @@ codeunit 3971 Image
     end;
 
     /// <summary>
+    /// Sets the image format from an Enum "Image Format".
+    /// </summary>
+    procedure SetFormat(ImageFormat: Enum "Image Format")
+    begin
+        ImageImpl.SetFormat(ImageFormat);
+    end;
+
+    /// <summary>
     /// Creates an Image from base64 encoding.
     /// </summary>
     /// <param name="Base64Text">A base64 encoded string the contains the image.</param>

--- a/Modules/System/Image/src/Image.Codeunit.al
+++ b/Modules/System/Image/src/Image.Codeunit.al
@@ -75,6 +75,7 @@ codeunit 3971 Image
     /// <summary>
     /// Sets the image format from an Enum "Image Format".
     /// </summary>
+    /// <remarks>Depending on the format selected, calling this method may result in loss of image quality.</remarks>
     procedure SetFormat(ImageFormat: Enum "Image Format")
     begin
         ImageImpl.SetFormat(ImageFormat);

--- a/Modules/System/Image/src/ImageImpl.Codeunit.al
+++ b/Modules/System/Image/src/ImageImpl.Codeunit.al
@@ -296,7 +296,7 @@ codeunit 3970 "Image Impl."
             Error(FormatErr);
         end;
 
-        SetCodec(Image.RawFormat, ImageCodec);
+        SetCodec(Image, ImageCodec);
 
         Size := TempBlob.Length();
         Width := GetWidth();
@@ -316,14 +316,14 @@ codeunit 3970 "Image Impl."
         Image := Image.FromStream(ImageInStream);
     end;
 
-    local procedure SetCodec(ImageFormat: DotNet ImageFormat; var LocalImageCodec: DotNet ImageCodecInfo)
+    local procedure SetCodec(Image: DotNet Image; var LocalImageCodec: DotNet ImageCodecInfo)
     var
         Codecs: DotNet ArrayList;
         Codec: DotNet ImageCodecInfo;
     begin
         Codecs := Codec.GetImageEncoders();
         foreach Codec in Codecs do
-            if ImageFormat.Guid() = Codec.FormatID then
+            if Image.RawFormat.Guid() = Codec.FormatID then
                 LocalImageCodec := Codec;
     end;
 

--- a/Modules/System/Image/src/ImageImpl.Codeunit.al
+++ b/Modules/System/Image/src/ImageImpl.Codeunit.al
@@ -190,6 +190,45 @@ codeunit 3970 "Image Impl."
         Error(UnsupportedFormatErr);
     end;
 
+    procedure SetFormat(Format: Enum "Image Format")
+    var
+        DstTempBlob: Codeunit "Temp Blob";
+        Image: DotNet Image;
+        ImageFormat: DotNet ImageFormat;
+        OutStream: OutStream;
+    begin
+        case Format of 
+            Enum::"Image Format"::Bmp:
+                ImageFormat := ImageFormat.Bmp();
+            Enum::"Image Format"::Emf:
+                ImageFormat := ImageFormat.Emf();
+            Enum::"Image Format"::Exif:
+                ImageFormat := ImageFormat.Exif();
+            Enum::"Image Format"::Gif:
+                ImageFormat := ImageFormat.Gif();
+            Enum::"Image Format"::Icon:
+                ImageFormat := ImageFormat.Icon();
+            Enum::"Image Format"::Jpeg:
+                ImageFormat := ImageFormat.Jpeg();
+            Enum::"Image Format"::Png:
+                ImageFormat := ImageFormat.Png();
+            Enum::"Image Format"::Tiff:
+                ImageFormat := ImageFormat.Tiff();
+            Enum::"Image Format"::Wmf:
+                ImageFormat := ImageFormat.Wmf();
+        end;
+
+        LoadImage(Image);
+
+        DstTempBlob.CreateOutStream(OutStream);
+        Image.Save(OutStream, ImageFormat);
+        Image.Dispose();
+
+        TempBlob := DstTempBlob;
+        
+        CreateAndVerifyImage();
+    end;
+
     procedure GetFormatAsString(): Text
     var
         FormatConverter: DotNet ImageFormatConverter;
@@ -257,7 +296,7 @@ codeunit 3970 "Image Impl."
             Error(FormatErr);
         end;
 
-        SetCodec(Image, ImageCodec);
+        SetCodec(Image.RawFormat, ImageCodec);
 
         Size := TempBlob.Length();
         Width := GetWidth();
@@ -277,14 +316,14 @@ codeunit 3970 "Image Impl."
         Image := Image.FromStream(ImageInStream);
     end;
 
-    local procedure SetCodec(Image: DotNet Image; var LocalImageCodec: DotNet ImageCodecInfo)
+    local procedure SetCodec(ImageFormat: DotNet ImageFormat; var LocalImageCodec: DotNet ImageCodecInfo)
     var
         Codecs: DotNet ArrayList;
         Codec: DotNet ImageCodecInfo;
     begin
         Codecs := Codec.GetImageEncoders();
         foreach Codec in Codecs do
-            if Image.RawFormat.Guid() = Codec.FormatID then
+            if ImageFormat.Guid() = Codec.FormatID then
                 LocalImageCodec := Codec;
     end;
 


### PR DESCRIPTION
This PR is related to issue #15162. It adds a new procedure called SetFormat in the module Image.
This procedure allows the user to change the format of the image typically to re-encode a BMP to PNG or PNG to JPEG.
