### PR TITLE
Remove "Internal" from Codeunit 9060

### DIFF
--- a/Modules/System/Azure Storage Services Authorization/src/AuthFormatHelper.Codeunit.al
+++ b/Modules/System/Azure Storage Services Authorization/src/AuthFormatHelper.Codeunit.al
@@ -5,6 +5,7 @@
 
 codeunit 9060 "Auth. Format Helper"
 {
+    Access = Internal;
 
     procedure NewLine(): Text
     var
@@ -41,5 +42,4 @@ codeunit 9060 "Auth. Format Helper"
     begin
         exit(CryptographyManagement.GenerateBase64KeyedHashAsBase64String(StringToSign, AccessKey, HashAlgorithmType::HMACSHA256));
     end;
-
 }

--- a/Modules/System/Azure Storage Services Authorization/src/AuthFormatHelper.Codeunit.al
+++ b/Modules/System/Azure Storage Services Authorization/src/AuthFormatHelper.Codeunit.al
@@ -5,7 +5,6 @@
 
 codeunit 9060 "Auth. Format Helper"
 {
-    Access = Internal;
 
     procedure NewLine(): Text
     var
@@ -42,4 +41,5 @@ codeunit 9060 "Auth. Format Helper"
     begin
         exit(CryptographyManagement.GenerateBase64KeyedHashAsBase64String(StringToSign, AccessKey, HashAlgorithmType::HMACSHA256));
     end;
+
 }

--- a/Modules/System/Azure Storage Services Authorization/src/StorageServiceAuthorization.Codeunit.al
+++ b/Modules/System/Azure Storage Services Authorization/src/StorageServiceAuthorization.Codeunit.al
@@ -100,7 +100,7 @@ codeunit 9062 "Storage Service Authorization"
     var
         AuthHelper: Codeunit "Auth. Format Helper";
     begin
-        AuthHelper.GetRfc1123DateTime(dt);
+        exit(AuthHelper.GetRfc1123DateTime(dt));
     end;
 
     /// <summary>
@@ -112,7 +112,7 @@ codeunit 9062 "Storage Service Authorization"
     var
         AuthHelper: Codeunit "Auth. Format Helper";
     begin
-        AuthHelper.GetIso8601DateTime(dt);
+        exit(AuthHelper.GetIso8601DateTime(dt));
     end;
 
 }

--- a/Modules/System/Azure Storage Services Authorization/src/StorageServiceAuthorization.Codeunit.al
+++ b/Modules/System/Azure Storage Services Authorization/src/StorageServiceAuthorization.Codeunit.al
@@ -90,4 +90,29 @@ codeunit 9062 "Storage Service Authorization"
     begin
         exit(StorServAuthImpl.GetDefaultAPIVersion());
     end;
+
+    /// <summary>
+    /// Formats the given datetime in RFC 1123.
+    /// </summary>
+    /// <param name="dt">The datetime to be formatted.</param>
+    /// <returns>The datetime formatted in RFC 1123.</returns>
+    procedure FormatRfc1123DateTime(dt: DateTime): Text;
+    var
+        AuthHelper: Codeunit "Auth. Format Helper";
+    begin
+        AuthHelper.GetRfc1123DateTime(dt);
+    end;
+
+    /// <summary>
+    /// Formats the given datetime in ISO 8601.
+    /// </summary>
+    /// <param name="dt">The datetime to be formatted.</param>
+    /// <returns>The datetime formatted in ISO 8601.</returns>
+    procedure FormatIso8601DateTime(dt: DateTime): Text
+    var
+        AuthHelper: Codeunit "Auth. Format Helper";
+    begin
+        AuthHelper.GetIso8601DateTime(dt);
+    end;
+
 }


### PR DESCRIPTION
I propose to remove the "Internal" access modifier from Codeunit 9060. This Codeunit does not seem to handle any sensitive data and/or security related stuff, so I do not see a real need for it to be internal.

On the other hand, it provides two important format functions that allows us to format dates according to ISO8601 and RFC1123. This are just a few examples of formats required when interfacing with external web services. Without the .NET DateTime we are just left to reinvent the wheel on this, messing around with strings - which is cumbersome and error-prone (especially with non-english languages). The wrapper Codeunit DotNet_DateTime does not really help here.

Exposing this codeunit would give us easy access to these formats.