### PR TITLE
Add the ability to set the From Name and From Address on Email via the SMTP Connector

### DIFF
--- a/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPIHelper.Codeunit.al
+++ b/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPIHelper.Codeunit.al
@@ -47,8 +47,14 @@ codeunit 4509 "Email - Outlook API Helper"
         EmailAddressJson: JsonObject;
         FromJson: JsonObject;
     begin
-        EmailAddressJson.Add('address', Account."Email Address");
-        EmailAddressJson.Add('name', Account."Name");
+        if EmailMessage.GetFromAddress() <> '' then
+            EmailAddressJson.Add('address', EmailMessage.GetFromAddress())
+        else
+            EmailAddressJson.Add('address', Account."Email Address");
+        if EmailMessage.GetFromName() <> '' then
+            EmailAddressJson.Add('name', EmailMessage.GetFromName())
+        else
+            EmailAddressJson.Add('name', Account."Name");
 
         FromJson.Add('emailAddress', EmailAddressJson);
         EmailMessageJson.Add('from', FromJson);

--- a/Apps/W1/Email - SMTP Connector/app/src/SMTPConnectorImpl.Codeunit.al
+++ b/Apps/W1/Email - SMTP Connector/app/src/SMTPConnectorImpl.Codeunit.al
@@ -183,7 +183,17 @@ codeunit 4513 "SMTP Connector Impl." implements "Email Connector"
         AttachmentInStream: InStream;
     begin
         // From name/email address
-        SMTPMessage.AddFrom(SMTPAccount."Sender Name", SMTPAccount."Email Address");
+        if EmailMessage.GetFromAddress() <> '' then
+            FromAddress := EmailMessage.GetFromAddress()
+        else
+            FromAddress := SMTPAccount."Email Address";
+
+        if EmailMessage.GetFromName() <> '' then
+            FromName := EmailMessage.GetFromName()
+        else
+            FromName := SMTPAccount."Sender Name";
+
+        SMTPMessage.AddFrom(FromName, FromAddress);
 
         // To, Cc and Bcc Recipients
         EmailMessage.GetRecipients("Email Recipient Type"::"To", Recipients);

--- a/Modules/System Tests/Email/src/EmailE2ETests.Codeunit.al
+++ b/Modules/System Tests/Email/src/EmailE2ETests.Codeunit.al
@@ -51,7 +51,8 @@ codeunit 134692 "Email E2E Tests"
 
         EmailMessage.Create(Recipient, Subject, Body, true);
         EmailMessage.AddAttachment('Attachment1', 'text/plain', Base64Convert.ToBase64('Content'));
-        EmailMessage.SetFrom(FromName, FromAddress);
+        EmailMessage.SetFromName(FromName);
+        EmailMessage.SetFromAddress(FromAddress);
 
         // Save to Outbox
         Email.SaveAsDraft(EmailMessage);

--- a/Modules/System/Email/src/Email/EmailImpl.Codeunit.al
+++ b/Modules/System/Email/src/Email/EmailImpl.Codeunit.al
@@ -228,7 +228,11 @@ codeunit 8900 "Email Impl"
         EmailOutbox."Account Id" := AccountId;
         EmailOutbox.Description := CopyStr(EmailMessageImpl.GetSubject(), 1, MaxStrLen(EmailOutbox.Description));
         EmailOutbox."User Security Id" := UserSecurityId();
-        EmailOutbox."Send From" := CopyStr(SentFrom, 1, MaxStrLen(EmailOutbox."Send From"));
+        if EmailMessage.GetFromName() <> '' then
+            EmailOutbox."Send From" := CopyStr(EmailMessage.GetFromName(), 1, MaxStrLen(EmailOutbox."Send From"))
+        else
+            EmailOutbox."Send From" := CopyStr(SentFrom, 1, MaxStrLen(EmailOutbox."Send From"));
+        EmailOutbox."Send From Address" := EmailMessage.GetFromAddress();
         EmailOutbox.Status := Status;
         if Status = Enum::"Email Status"::Queued then begin
             EmailOutbox."Date Queued" := CurrentDateTime();

--- a/Modules/System/Email/src/Email/Outbox/EmailOutbox.Table.al
+++ b/Modules/System/Email/src/Email/Outbox/EmailOutbox.Table.al
@@ -111,6 +111,13 @@ table 8888 "Email Outbox"
             DataClassification = SystemMetadata;
             Description = 'The field is marked as internal in order to prevent modifying it from code.';
         }
+
+        field(16; "Send From Address"; Text[250])
+        {
+            Access = Internal;
+            DataClassification = EndUserIdentifiableInformation;
+            Description = 'The field is marked as internal in order to prevent modifying it from code.';
+        }
     }
 
     keys

--- a/Modules/System/Email/src/Email/Sent/SentEmail.Table.al
+++ b/Modules/System/Email/src/Email/Sent/SentEmail.Table.al
@@ -75,6 +75,13 @@ table 8889 "Sent Email"
             DataClassification = CustomerContent;
             Description = 'The field is marked as internal in order to prevent modifying it from code.';
         }
+
+        field(15; "Sent From Address"; Text[250])
+        {
+            Access = Internal;
+            DataClassification = EndUserIdentifiableInformation;
+            Description = 'The field is marked as internal in order to prevent modifying it from code.';
+        }
     }
 
     keys

--- a/Modules/System/Email/src/Message/EmailMessage.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessage.Codeunit.al
@@ -60,6 +60,16 @@ codeunit 8904 "Email Message"
     end;
 
     /// <summary>
+    /// Adds the mailbox that this email is being sent from.
+    /// </summary>
+    /// <param name="FromName">The name of the email sender</param>
+    /// <param name="FromAddress">The address of the email sender</param>
+    procedure SetFrom(FromName: Text[250]; FromAddress: Text[250])
+    begin
+        EmailMessageImpl.SetFrom(FromName, FromAddress);
+    end;
+
+    /// <summary>
     /// Gets the email message with the given ID.
     /// </summary>
     /// <param name="MessageId">The ID of the email message to get.</param>
@@ -76,6 +86,24 @@ codeunit 8904 "Email Message"
     procedure GetBody(): Text
     begin
         exit(EmailMessageImpl.GetBody());
+    end;
+
+    /// <summary>
+    /// Gets the sender address of the email message.
+    /// </summary>
+    /// <returns>The sender address of the email.</returns>
+    procedure GetFromAddress(): Text[250]
+    begin
+        exit(EmailMessageImpl.GetFromAddress());
+    end;
+
+    /// <summary>
+    /// Gets the sender name of the email message.
+    /// </summary>
+    /// <returns>The sender name of the email.</returns>
+    procedure GetFromName(): Text[250]
+    begin
+        exit(EmailMessageImpl.GetFromName());
     end;
 
     /// <summary>

--- a/Modules/System/Email/src/Message/EmailMessage.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessage.Codeunit.al
@@ -63,10 +63,18 @@ codeunit 8904 "Email Message"
     /// Adds the mailbox that this email is being sent from.
     /// </summary>
     /// <param name="FromName">The name of the email sender</param>
-    /// <param name="FromAddress">The address of the email sender</param>
-    procedure SetFrom(FromName: Text[250]; FromAddress: Text[250])
+    procedure SetFromName(FromName: Text[250])
     begin
-        EmailMessageImpl.SetFrom(FromName, FromAddress);
+        EmailMessageImpl.SetFromName(FromName);
+    end;
+
+    /// <summary>
+    /// Adds the mailbox that this email is being sent from.
+    /// </summary>
+    /// <param name="FromAddress">The address of the email sender</param>
+    procedure SetFromAddress(FromAddress: Text[250])
+    begin
+        EmailMessageImpl.SetFromAddress(FromAddress);
     end;
 
     /// <summary>

--- a/Modules/System/Email/src/Message/EmailMessage.Table.al
+++ b/Modules/System/Email/src/Message/EmailMessage.Table.al
@@ -37,6 +37,16 @@ table 8900 "Email Message"
             DataClassification = SystemMetadata;
             InitValue = True;
         }
+        field(6; "From Address"; Text[250])
+        {
+            Access = Internal;
+            DataClassification = SystemMetadata;
+        }
+        field(7; "From Name"; Text[250])
+        {
+            Access = Internal;
+            DataClassification = SystemMetadata;
+        }
     }
 
     keys

--- a/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -175,9 +175,14 @@ codeunit 8905 "Email Message Impl."
         Modify();
     end;
 
-    procedure SetFrom(FromName: Text[250]; FromAddress: Text[250])
+    procedure SetFromName(FromName: Text[250])
     begin
         EmailMessageRec."From Name" := FromName;
+        EmailMessageRec.Modify();
+    end;
+
+    procedure SetFromAddress(FromAddress: Text[250])
+    begin
         EmailMessageRec."From Address" := FromAddress;
         EmailMessageRec.Modify();
     end;

--- a/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -143,6 +143,16 @@ codeunit 8905 "Email Message Impl."
         EmailMessageRec.Subject := CopyStr(Subject, 1, MaxStrLen(EmailMessageRec.Subject));
     end;
 
+    procedure GetFromAddress(): Text[250]
+    begin
+        exit(EmailMessageRec."From Address");
+    end;
+
+    procedure GetFromName(): Text[250]
+    begin
+        exit(EmailMessageRec."From Name");
+    end;
+
     procedure SetSubject(Subject: Text)
     begin
         SetSubjectValue(Subject);
@@ -163,6 +173,13 @@ codeunit 8905 "Email Message Impl."
     begin
         SetBodyHTMLFormattedValue(Value);
         Modify();
+    end;
+
+    procedure SetFrom(FromName: Text[250]; FromAddress: Text[250])
+    begin
+        EmailMessageRec."From Name" := FromName;
+        EmailMessageRec."From Address" := FromAddress;
+        EmailMessageRec.Modify();
     end;
 
     procedure IsRead(): Boolean


### PR DESCRIPTION
These updates allow the use of the "From Name" and "From Address" fields on the "Email Item" record when sending email using the "Email - SMTP Connector" extension.

The updated name and address, if used, are reflected in the "Sent Email" records.