### PR TITLE
Add 'SetDefaultSeed'

### DIFF
--- a/Modules/DevTools/TestFramework/TestLibraries/Any/src/Any.Codeunit.al
+++ b/Modules/DevTools/TestFramework/TestLibraries/Any/src/Any.Codeunit.al
@@ -12,6 +12,7 @@ codeunit 130500 "Any"
 {
     var
         Seed: Integer;
+        SeedSet: Boolean;
 
     /// <summary>
     /// Provides an integer between 1 and the given value
@@ -220,7 +221,18 @@ codeunit 130500 "Any"
     procedure SetSeed(NewSeed: Integer)
     begin
         Seed := NewSeed;
+        SeedSet := true;
         Randomize(Seed);
+    end;
+
+    /// <summary>.
+    /// Sets the default Seed for Pseudo-random number generation (no. of milliseconds since midnight of today).
+    /// Setting this value will change the numbers returned.
+    /// </summary>
+    procedure SetDefaultSeed()
+    begin
+        SeedSet := true;
+        Randomize();
     end;
 
     /// <summary>.
@@ -231,7 +243,7 @@ codeunit 130500 "Any"
     /// <returns>Pseudo-random integer value</returns>
     local procedure GetNextValue(MaxValue: Integer): Integer
     begin
-        if Seed = 0 then
+        if (not SeedSet) then
             SetSeed(1);
 
         exit(Random(MaxValue));


### PR DESCRIPTION
Added 'SetDefaultSeed' that allows to initialize the instance with the same seed that a call to the system function `Randomize` would. This allows to generate non-predictable random numbers - without explicitly specifying a seed.