### PR TITLE
Add setter functions for email message

### DIFF
--- a/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
+++ b/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
@@ -531,9 +531,9 @@ codeunit 134689 "Email Message Unit Test"
     begin
         // Initialize
         PermissionsMock.Set('Email Edit');
+        Message.Create(Recipients, 'Test subject', 'Test body', true);
 
         // Exercise
-        Message.Create(Recipients, 'Test subject', 'Test body', true);
         Message.SetBody('Changed test body');
         // Verify
         Assert.AreEqual('Changed test body', Message.GetBody(), 'A different body was expected');

--- a/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
+++ b/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
@@ -619,7 +619,9 @@ codeunit 134689 "Email Message Unit Test"
     var
         Message: Codeunit "Email Message";
         Recipients: List of [Text];
-        Result: List of [Text];
+        ResultTo: List of [Text];
+        ResultCc: List of [Text];
+        ResultBCc: List of [Text];
         Index: Integer;
     begin
         // Initialize
@@ -631,61 +633,157 @@ codeunit 134689 "Email Message Unit Test"
         Recipients.Add('recipient2@test.com');
         Recipients.Add('recipient3@test.com');
         Message.SetRecipients(Enum::"Email Recipient Type"::"To", Recipients);
-        Message.GetRecipients(Enum::"Email Recipient Type"::"To", Result);
-
+        Message.GetRecipients(Enum::"Email Recipient Type"::"To", ResultTo);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"Cc", ResultCc);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"BCc", ResultBCc);
         // Verify
-        for Index := 1 to Result.Count() do
-            Assert.AreEqual(StrSubstNo(RecipientLbl, Index), Result.Get(Index), 'A different recipient was expected');
+        for Index := 1 to ResultTo.Count() do
+            Assert.AreEqual(StrSubstNo(RecipientLbl, Index), ResultTo.Get(Index), 'A different recipient was expected');
+        Assert.AreEqual(ResultCc.Count, 0, 'Zero CC recipients were expected');
+        Assert.AreEqual(ResultBCc.Count, 0, 'Zero CC recipients were expected');
     end;
 
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
-    procedure SetRecipientsCCTest()
+    procedure SetRecipientsCcTest()
     var
         Message: Codeunit "Email Message";
         Recipients: List of [Text];
-        Result: List of [Text];
+        ResultTo: List of [Text];
+        ResultCc: List of [Text];
+        ResultBCc: List of [Text];
         Index: Integer;
     begin
         // Initialize
         PermissionsMock.Set('Email Edit');
 
         // Exercise
-        Message.Create(Recipients, 'Test subject', 'Test body', true);
+        Message.Create(Recipients, 'Test subject', 'Test body', true, Recipients, Recipients);
         Recipients.Add('recipient1@test.com');
         Recipients.Add('recipient2@test.com');
         Recipients.Add('recipient3@test.com');
         Message.SetRecipients(Enum::"Email Recipient Type"::"Cc", Recipients);
-        Message.GetRecipients(Enum::"Email Recipient Type"::"Cc", Result);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"To", ResultTo);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"Cc", ResultCc);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"BCc", ResultBCc);
 
         // Verify
-        for Index := 1 to Result.Count() do
-            Assert.AreEqual(StrSubstNo(RecipientLbl, Index), Result.Get(Index), 'A different recipient was expected');
+        Assert.AreEqual(ResultTo.Count, 0, 'Zero To recipients were expected');
+        for Index := 1 to ResultCc.Count() do
+            Assert.AreEqual(StrSubstNo(RecipientLbl, Index), ResultCc.Get(Index), 'A different recipient was expected');
+        Assert.AreEqual(ResultBCc.Count, 0, 'Zero CC recipients were expected');
     end;
 
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
-    procedure SetRecipientsBCCTest()
+    procedure SetRecipientsBCcTest()
     var
         Message: Codeunit "Email Message";
         Recipients: List of [Text];
-        Result: List of [Text];
+        ResultTo: List of [Text];
+        ResultCc: List of [Text];
+        ResultBCc: List of [Text];
         Index: Integer;
     begin
         // Initialize
         PermissionsMock.Set('Email Edit');
 
         // Exercise
-        Message.Create(Recipients, 'Test subject', 'Test body', true);
+        Message.Create(Recipients, 'Test subject', 'Test body', true, Recipients, Recipients);
         Recipients.Add('recipient1@test.com');
         Recipients.Add('recipient2@test.com');
         Recipients.Add('recipient3@test.com');
         Message.SetRecipients(Enum::"Email Recipient Type"::"BCc", Recipients);
-        Message.GetRecipients(Enum::"Email Recipient Type"::"BCc", Result);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"To", ResultTo);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"Cc", ResultCc);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"BCc", ResultBCc);
 
         // Verify
-        for Index := 1 to Result.Count() do
-            Assert.AreEqual(StrSubstNo(RecipientLbl, Index), Result.Get(Index), 'A different recipient was expected');
+        Assert.AreEqual(ResultTo.Count, 0, 'Zero To recipients were expected');
+        Assert.AreEqual(ResultCc.Count, 0, 'Zero CC recipients were expected');
+        for Index := 1 to ResultBCc.Count() do
+            Assert.AreEqual(StrSubstNo(RecipientLbl, Index), ResultBCc.Get(Index), 'A different recipient was expected');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure AddRecipientToTest()
+    var
+        Message: Codeunit "Email Message";
+        Recipient: Text;
+        ResultTo: List of [Text];
+        ResultCc: List of [Text];
+        ResultBCc: List of [Text];
+    begin
+        // Initialize
+        PermissionsMock.Set('Email Edit');
+
+        // Exercise
+        Message.Create(ResultTo, 'Test subject', 'Test body', true, ResultCc, ResultBCc);
+        Recipient := 'recipient1@test.com';
+        Message.AddRecipient(Enum::"Email Recipient Type"::"To", Recipient);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"To", ResultTo);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"Cc", ResultCc);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"BCc", ResultBCc);
+
+        // Verify
+        Assert.AreEqual(Recipient, ResultTo.Get(0), 'A different recipient was expected');
+        Assert.AreEqual(ResultCc.Count, 0, 'Zero Cc recipients were expected');
+        Assert.AreEqual(ResultBCc.Count, 0, 'Zero BCc recipients were expected');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure AddRecipientCcTest()
+    var
+        Message: Codeunit "Email Message";
+        Recipient: Text;
+        ResultTo: List of [Text];
+        ResultCc: List of [Text];
+        ResultBCc: List of [Text];
+    begin
+        // Initialize
+        PermissionsMock.Set('Email Edit');
+
+        // Exercise
+        Message.Create(ResultTo, 'Test subject', 'Test body', true, ResultCc, ResultBCc);
+        Recipient := 'recipient1@test.com';
+        Message.AddRecipient(Enum::"Email Recipient Type"::"Cc", Recipient);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"To", ResultTo);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"Cc", ResultCc);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"BCc", ResultBCc);
+
+        // Verify
+        Assert.AreEqual(ResultTo.Count, 0, 'Zero To recipients were expected');
+        Assert.AreEqual(Recipient, ResultCc.Get(0), 'A different recipient was expected');
+        Assert.AreEqual(ResultBCc.Count, 0, 'Zero BCc recipients were expected');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure AddRecipientBCcTest()
+    var
+        Message: Codeunit "Email Message";
+        Recipient: Text;
+        ResultTo: List of [Text];
+        ResultCc: List of [Text];
+        ResultBCc: List of [Text];
+    begin
+        // Initialize
+        PermissionsMock.Set('Email Edit');
+
+        // Exercise
+        Message.Create(ResultTo, 'Test subject', 'Test body', true, ResultCc, ResultBCc);
+        Recipient := 'recipient1@test.com';
+        Message.AddRecipient(Enum::"Email Recipient Type"::"BCc", Recipient);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"To", ResultTo);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"Cc", ResultCc);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"BCc", ResultBCc);
+
+        // Verify
+        Assert.AreEqual(ResultTo.Count, 0, 'Zero To recipients were expected');
+        Assert.AreEqual(ResultCc.Count, 0, 'Zero Cc recipients were expected');
+        Assert.AreEqual(Recipient, ResultBCc.Get(0), 'A different recipient was expected');
     end;
 
     [StrMenuHandler]

--- a/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
+++ b/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
@@ -711,6 +711,7 @@ codeunit 134689 "Email Message Unit Test"
     var
         Message: Codeunit "Email Message";
         Recipient: Text;
+        Recipient2: Text;
         ResultTo: List of [Text];
         ResultCc: List of [Text];
         ResultBCc: List of [Text];
@@ -721,13 +722,15 @@ codeunit 134689 "Email Message Unit Test"
         // Exercise
         Message.Create(ResultTo, 'Test subject', 'Test body', true, ResultCc, ResultBCc);
         Recipient := 'recipient1@test.com';
+        Recipient2 := 'recipient2@test.com';
         Message.AddRecipient(Enum::"Email Recipient Type"::"To", Recipient);
         Message.GetRecipients(Enum::"Email Recipient Type"::"To", ResultTo);
         Message.GetRecipients(Enum::"Email Recipient Type"::"Cc", ResultCc);
         Message.GetRecipients(Enum::"Email Recipient Type"::"BCc", ResultBCc);
 
         // Verify
-        Assert.AreEqual(Recipient, ResultTo.Get(0), 'A different recipient was expected');
+        Assert.AreEqual(Recipient, ResultTo.Get(1), 'A different recipient was expected');
+        Assert.AreEqual(Recipient2, ResultTo.Get(2), 'A different recipient was expected');
         Assert.AreEqual(ResultCc.Count, 0, 'Zero Cc recipients were expected');
         Assert.AreEqual(ResultBCc.Count, 0, 'Zero BCc recipients were expected');
     end;
@@ -739,6 +742,7 @@ codeunit 134689 "Email Message Unit Test"
         Message: Codeunit "Email Message";
         Recipient: Text;
         ResultTo: List of [Text];
+        Recipient2: Text;
         ResultCc: List of [Text];
         ResultBCc: List of [Text];
     begin
@@ -749,13 +753,15 @@ codeunit 134689 "Email Message Unit Test"
         Message.Create(ResultTo, 'Test subject', 'Test body', true, ResultCc, ResultBCc);
         Recipient := 'recipient1@test.com';
         Message.AddRecipient(Enum::"Email Recipient Type"::"Cc", Recipient);
+        Recipient2 := 'recipient2@test.com';
         Message.GetRecipients(Enum::"Email Recipient Type"::"To", ResultTo);
         Message.GetRecipients(Enum::"Email Recipient Type"::"Cc", ResultCc);
         Message.GetRecipients(Enum::"Email Recipient Type"::"BCc", ResultBCc);
 
         // Verify
         Assert.AreEqual(ResultTo.Count, 0, 'Zero To recipients were expected');
-        Assert.AreEqual(Recipient, ResultCc.Get(0), 'A different recipient was expected');
+        Assert.AreEqual(Recipient, ResultCc.Get(1), 'A different recipient was expected');
+        Assert.AreEqual(Recipient2, ResultCc.Get(2), 'A different recipient was expected');
         Assert.AreEqual(ResultBCc.Count, 0, 'Zero BCc recipients were expected');
     end;
 
@@ -765,6 +771,7 @@ codeunit 134689 "Email Message Unit Test"
     var
         Message: Codeunit "Email Message";
         Recipient: Text;
+        Recipient2: Text;
         ResultTo: List of [Text];
         ResultCc: List of [Text];
         ResultBCc: List of [Text];
@@ -776,6 +783,7 @@ codeunit 134689 "Email Message Unit Test"
         Message.Create(ResultTo, 'Test subject', 'Test body', true, ResultCc, ResultBCc);
         Recipient := 'recipient1@test.com';
         Message.AddRecipient(Enum::"Email Recipient Type"::"BCc", Recipient);
+        Recipient2 := 'recipient2@test.com';
         Message.GetRecipients(Enum::"Email Recipient Type"::"To", ResultTo);
         Message.GetRecipients(Enum::"Email Recipient Type"::"Cc", ResultCc);
         Message.GetRecipients(Enum::"Email Recipient Type"::"BCc", ResultBCc);
@@ -783,7 +791,8 @@ codeunit 134689 "Email Message Unit Test"
         // Verify
         Assert.AreEqual(ResultTo.Count, 0, 'Zero To recipients were expected');
         Assert.AreEqual(ResultCc.Count, 0, 'Zero Cc recipients were expected');
-        Assert.AreEqual(Recipient, ResultBCc.Get(0), 'A different recipient was expected');
+        Assert.AreEqual(Recipient, ResultBCc.Get(1), 'A different recipient was expected');
+        Assert.AreEqual(Recipient2, ResultBCc.Get(2), 'A different recipient was expected');
     end;
 
     [StrMenuHandler]

--- a/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
+++ b/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
@@ -559,6 +559,24 @@ codeunit 134689 "Email Message Unit Test"
 
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
+    procedure AppendToBodyTestEmptyString()
+    var
+        Message: Codeunit "Email Message";
+        Recipients: List of [Text];
+        Index: Integer;
+    begin
+        // Initialize
+        PermissionsMock.Set('Email Edit');
+
+        // Exercise
+        Message.Create(Recipients, 'Test subject', 'Test body', true);
+        Message.AppendToBody('');
+        // Verify
+        Assert.AreEqual('Test body', Message.GetBody(), 'A different body was expected');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
     procedure SetSubjectTest()
     var
         Message: Codeunit "Email Message";

--- a/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
+++ b/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
@@ -522,6 +522,157 @@ codeunit 134689 "Email Message Unit Test"
         Assert.ExpectedError(EmailMessageSentCannotDeleteRecipientErr);
     end;
 
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure SetBodyTest()
+    var
+        Message: Codeunit "Email Message";
+        Recipients: List of [Text];
+        Result: List of [Text];
+        Index: Integer;
+    begin
+        // Initialize
+        PermissionsMock.Set('Email Edit');
+
+        // Exercise
+        Message.Create(Recipients, 'Test subject', 'Test body', true);
+        Message.SetBody('Changed test body');
+        // Verify
+        Assert.AreEqual('Changed test body', Message.GetBody(), 'A different body was expected');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure AppendToBodyTest()
+    var
+        Message: Codeunit "Email Message";
+        Recipients: List of [Text];
+        Result: List of [Text];
+        Index: Integer;
+    begin
+        // Initialize
+        PermissionsMock.Set('Email Edit');
+
+        // Exercise
+        Message.Create(Recipients, 'Test subject', 'Test body', true);
+        Message.AppendToBody(' extended');
+        // Verify
+        Assert.AreEqual('Test body extended', Message.GetBody(), 'A different body was expected');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure SetSubjectTest()
+    var
+        Message: Codeunit "Email Message";
+        Recipients: List of [Text];
+        Result: List of [Text];
+        Index: Integer;
+    begin
+        // Initialize
+        PermissionsMock.Set('Email Edit');
+
+        // Exercise
+        Message.Create(Recipients, 'Test subject', 'Test body', true);
+        Message.SetSubject('Changed test subject');
+        // Verify
+        Assert.AreEqual('Changed test subject', Message.GetSubject(), 'A different subject was expected');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure SetBodyHTMLFormattedTest()
+    var
+        Message: Codeunit "Email Message";
+        Recipients: List of [Text];
+        Result: List of [Text];
+        Index: Integer;
+    begin
+        // Initialize
+        PermissionsMock.Set('Email Edit');
+
+        // Exercise
+        Message.Create(Recipients, 'Test subject', 'Test body', true);
+        Message.SetBodyHTMLFormatted(false);
+        // Verify
+        Assert.IsFalse(Message.IsBodyHTMLFormatted(), 'Body was expected not to be HTML formatted');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure SetRecipientsToTest()
+    var
+        Message: Codeunit "Email Message";
+        Recipients: List of [Text];
+        Result: List of [Text];
+        Index: Integer;
+    begin
+        // Initialize
+        PermissionsMock.Set('Email Edit');
+
+        // Exercise
+        Message.Create(Recipients, 'Test subject', 'Test body', true);
+        Recipients.Add('recipient1@test.com');
+        Recipients.Add('recipient2@test.com');
+        Recipients.Add('recipient3@test.com');
+        Message.SetRecipients(Enum::"Email Recipient Type"::"To", Recipients);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"To", Result);
+
+        // Verify
+        for Index := 1 to Result.Count() do
+            Assert.AreEqual(StrSubstNo(RecipientLbl, Index), Result.Get(Index), 'A different recipient was expected');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure SetRecipientsCCTest()
+    var
+        Message: Codeunit "Email Message";
+        Recipients: List of [Text];
+        Result: List of [Text];
+        Index: Integer;
+    begin
+        // Initialize
+        PermissionsMock.Set('Email Edit');
+
+        // Exercise
+        Message.Create(Recipients, 'Test subject', 'Test body', true);
+        Recipients.Add('recipient1@test.com');
+        Recipients.Add('recipient2@test.com');
+        Recipients.Add('recipient3@test.com');
+        Message.SetRecipients(Enum::"Email Recipient Type"::"Cc", Recipients);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"Cc", Result);
+
+        // Verify
+        for Index := 1 to Result.Count() do
+            Assert.AreEqual(StrSubstNo(RecipientLbl, Index), Result.Get(Index), 'A different recipient was expected');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure SetRecipientsBCCTest()
+    var
+        Message: Codeunit "Email Message";
+        Recipients: List of [Text];
+        Result: List of [Text];
+        Index: Integer;
+    begin
+        // Initialize
+        PermissionsMock.Set('Email Edit');
+
+        // Exercise
+        Message.Create(Recipients, 'Test subject', 'Test body', true);
+        Recipients.Add('recipient1@test.com');
+        Recipients.Add('recipient2@test.com');
+        Recipients.Add('recipient3@test.com');
+        Message.SetRecipients(Enum::"Email Recipient Type"::"BCc", Recipients);
+        Message.GetRecipients(Enum::"Email Recipient Type"::"BCc", Result);
+
+        // Verify
+        for Index := 1 to Result.Count() do
+            Assert.AreEqual(StrSubstNo(RecipientLbl, Index), Result.Get(Index), 'A different recipient was expected');
+    end;
+
     [StrMenuHandler]
     [Scope('OnPrem')]
     procedure CloseEmailEditorHandler(Options: Text[1024]; var Choice: Integer; Instruction: Text[1024])

--- a/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
+++ b/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
@@ -528,8 +528,6 @@ codeunit 134689 "Email Message Unit Test"
     var
         Message: Codeunit "Email Message";
         Recipients: List of [Text];
-        Result: List of [Text];
-        Index: Integer;
     begin
         // Initialize
         PermissionsMock.Set('Email Edit');

--- a/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
+++ b/Modules/System Tests/Email/src/EmailMessageUnitTest.Codeunit.al
@@ -545,7 +545,6 @@ codeunit 134689 "Email Message Unit Test"
     var
         Message: Codeunit "Email Message";
         Recipients: List of [Text];
-        Result: List of [Text];
         Index: Integer;
     begin
         // Initialize

--- a/Modules/System/Email/src/Message/EmailMessage.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessage.Codeunit.al
@@ -80,7 +80,7 @@ codeunit 8904 "Email Message"
 
     /// <summary>
     /// Sets the body of the email message.
-    /// /// <param name="Body">The body to set to the email message.</param>
+    /// <param name="Body">The body to set to the email message.</param>
     /// </summary>
     procedure SetBody(Body: Text)
     begin
@@ -156,7 +156,7 @@ codeunit 8904 "Email Message"
     /// </summary>
     /// <param name="RecipientType">Specifies the type of the recipients.</param>
     /// <param name="Recipients">Specifies the list of the recipients' email addresses as a semicolon (;) separated list.</param>
-    procedure SetRecipients(RecipientType: Enum "Email Recipient Type"; var Recipients: Text)
+    procedure SetRecipients(RecipientType: Enum "Email Recipient Type"; Recipients: Text)
     begin
         EmailMessageImpl.SetRecipients(RecipientType, Recipients);
     end;
@@ -166,7 +166,7 @@ codeunit 8904 "Email Message"
     /// </summary>
     /// <param name="RecipientType">Specifies the type of the recipients.</param>
     /// <param name="Recipients">Specifies the list of the recipients' email addresses.</param>
-    procedure SetRecipients(RecipientType: Enum "Email Recipient Type"; var Recipients: list of [Text])
+    procedure SetRecipients(RecipientType: Enum "Email Recipient Type"; Recipients: list of [Text])
     begin
         EmailMessageImpl.SetRecipients(RecipientType, Recipients);
     end;

--- a/Modules/System/Email/src/Message/EmailMessage.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessage.Codeunit.al
@@ -79,6 +79,24 @@ codeunit 8904 "Email Message"
     end;
 
     /// <summary>
+    /// Sets the body of the email message.
+    /// /// <param name="Body">The body to set to the email message.</param>
+    /// </summary>
+    procedure SetBody(Body: Text)
+    begin
+        EmailMessageImpl.SetBody(Body);
+    end;
+
+    /// <summary>
+    /// Appends to the body of the email message.
+    /// /// <param name="Value">The value to append to the body of the email message.</param>
+    /// </summary>
+    procedure AppendToBody(Value: Text)
+    begin
+        EmailMessageImpl.AppendToBody(Value);
+    end;
+
+    /// <summary>
     /// Gets the subject of the email message.
     /// </summary>
     /// <returns>The subject of the email.</returns>
@@ -88,12 +106,30 @@ codeunit 8904 "Email Message"
     end;
 
     /// <summary>
+    /// Sets the subject of the email message.
+    /// /// <param name="Subbject">The subject to set to the email message.</param>
+    /// </summary>
+    procedure SetSubject(Subject: Text)
+    begin
+        EmailMessageImpl.SetSubject(Subject);
+    end;
+
+    /// <summary>
     /// Checks if the email body is formatted in HTML.
     /// </summary>
     /// <returns>True if the email body is formatted in HTML; otherwise - false.</returns>
     procedure IsBodyHTMLFormatted(): Boolean
     begin
         exit(EmailMessageImpl.IsBodyHTMLFormatted());
+    end;
+
+    /// <summary>
+    /// Sets whether the email body is formatted in HTML.
+    /// /// <param name="Value">True if the email body is formatted in HTML; otherwise - false.</param>
+    /// </summary>
+    procedure SetBodyHTMLFormatted(Value: Boolean)
+    begin
+        EmailMessageImpl.SetBodyHTMLFormatted(Value);
     end;
 
     /// <summary>
@@ -113,6 +149,26 @@ codeunit 8904 "Email Message"
     procedure GetRecipients(RecipientType: Enum "Email Recipient Type"; var Recipients: list of [Text])
     begin
         Recipients := EmailMessageImpl.GetRecipients(RecipientType);
+    end;
+
+    /// <summary>
+    /// Sets the recipents of a certain type of the email message.
+    /// </summary>
+    /// <param name="RecipientType">Specifies the type of the recipients.</param>
+    /// <param name="Recipients">Specifies the list of the recipients' email addresses as a semicolon (;) separated list.</param>
+    procedure SetRecipients(RecipientType: Enum "Email Recipient Type"; var Recipients: Text)
+    begin
+        EmailMessageImpl.SetRecipients(RecipientType, Recipients);
+    end;
+
+    /// <summary>
+    /// Sets the recipents of a certain type of the email message.
+    /// </summary>
+    /// <param name="RecipientType">Specifies the type of the recipients.</param>
+    /// <param name="Recipients">Specifies the list of the recipients' email addresses as a list.</param>
+    procedure SetRecipients(RecipientType: Enum "Email Recipient Type"; var Recipients: list of [Text])
+    begin
+        EmailMessageImpl.SetRecipients(RecipientType, Recipients);
     end;
 
     /// <summary>

--- a/Modules/System/Email/src/Message/EmailMessage.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessage.Codeunit.al
@@ -162,6 +162,16 @@ codeunit 8904 "Email Message"
     end;
 
     /// <summary>
+    /// Adds a recipent of a certain type to the email message.
+    /// </summary>
+    /// <param name="RecipientType">Specifies the type of the recipient.</param>
+    /// <param name="Recipient">Specifies the recipient's email address.</param>
+    procedure AddRecipient(RecipientType: Enum "Email Recipient Type"; Recipient: Text)
+    begin
+        EmailMessageImpl.AddRecipient(RecipientType, Recipient);
+    end;
+
+    /// <summary>
     /// Sets the recipents of a certain type of the email message.
     /// </summary>
     /// <param name="RecipientType">Specifies the type of the recipients.</param>

--- a/Modules/System/Email/src/Message/EmailMessage.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessage.Codeunit.al
@@ -107,7 +107,7 @@ codeunit 8904 "Email Message"
 
     /// <summary>
     /// Sets the subject of the email message.
-    /// /// <param name="Subbject">The subject to set to the email message.</param>
+    /// /// <param name="Subject">The subject to set to the email message.</param>
     /// </summary>
     procedure SetSubject(Subject: Text)
     begin
@@ -165,7 +165,7 @@ codeunit 8904 "Email Message"
     /// Sets the recipents of a certain type of the email message.
     /// </summary>
     /// <param name="RecipientType">Specifies the type of the recipients.</param>
-    /// <param name="Recipients">Specifies the list of the recipients' email addresses as a list.</param>
+    /// <param name="Recipients">Specifies the list of the recipients' email addresses.</param>
     procedure SetRecipients(RecipientType: Enum "Email Recipient Type"; var Recipients: list of [Text])
     begin
         EmailMessageImpl.SetRecipients(RecipientType, Recipients);

--- a/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -365,7 +365,7 @@ codeunit 8905 "Email Message Impl."
         Recipients: List of [Text];
         tmpRecipient: Text;
     begin
-        if Recipient <> '' then
+        if Recipient = '' then
             exit;
         EmailRecipientRecord.SetRange("Email Message Id", Message.Id);
         EmailRecipientRecord.SetRange("Email Recipient Type", RecipientType);

--- a/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -73,9 +73,9 @@ codeunit 8905 "Email Message Impl."
 
     procedure UpdateMessage(ToRecipients: List of [Text]; Subject: Text; Body: Text; HtmlFormatted: Boolean; CCRecipients: List of [Text]; BCCRecipients: List of [Text])
     begin
-        SetBody(Body);
-        SetSubject(Subject);
-        SetBodyHTMLFormatted(HtmlFormatted);
+        SetBodyValue(Body);
+        SetSubjectValue(Subject);
+        SetBodyHTMLFormattedValue(HtmlFormatted);
         Modify();
 
         SetRecipients(Enum::"Email Recipient Type"::"To", ToRecipients);
@@ -97,7 +97,7 @@ codeunit 8905 "Email Message Impl."
         BodyInStream.Read(BodyText);
     end;
 
-    procedure SetBody(BodyText: Text)
+    procedure SetBodyValue(BodyText: Text)
     var
         BodyOutStream: OutStream;
     begin
@@ -111,14 +111,39 @@ codeunit 8905 "Email Message Impl."
         BodyOutStream.Write(BodyText);
     end;
 
+    procedure SetBody(BodyText: Text)
+    begin
+        SetBodyValue(BodyText);
+        Modify();
+    end;
+
+    procedure AppendToBody(BodyText: Text)
+    var
+        BodyOutStream: OutStream;
+    begin
+        if BodyText = '' then
+            exit;
+
+        ReplaceRgbaColorsWithRgb(BodyText);
+        Message.Body.CreateOutStream(BodyOutStream, TextEncoding::UTF8);
+        BodyOutStream.Write(BodyText);
+        Modify();
+    end;
+
     procedure GetSubject(): Text[2048]
     begin
         exit(Message.Subject);
     end;
 
-    procedure SetSubject(Subject: Text)
+    procedure SetSubjectValue(Subject: Text)
     begin
         Message.Subject := CopyStr(Subject, 1, MaxStrLen(Message.Subject));
+    end;
+
+    procedure SetSubject(Subject: Text)
+    begin
+        SetSubjectValue(Subject);
+        Modify();
     end;
 
     procedure IsBodyHTMLFormatted(): Boolean
@@ -126,9 +151,15 @@ codeunit 8905 "Email Message Impl."
         exit(Message."HTML Formatted Body");
     end;
 
-    procedure SetBodyHTMLFormatted(Value: Boolean)
+    procedure SetBodyHTMLFormattedValue(Value: Boolean)
     begin
         Message."HTML Formatted Body" := Value;
+    end;
+
+    procedure SetBodyHTMLFormatted(Value: Boolean)
+    begin
+        SetBodyHTMLFormattedValue(Value);
+        Modify();
     end;
 
     procedure IsRead(): Boolean

--- a/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -355,6 +355,36 @@ codeunit 8905 "Email Message Impl."
         end;
     end;
 
+    procedure AddRecipient(RecipientType: Enum "Email Recipient Type"; Recipient: Text)
+    var
+        EmailRecipientRecord: Record "Email Recipient";
+        UniqueRecipients: Dictionary of [Text, Text];
+        Recipients: List of [Text];
+        tmpRecipient: Text;
+    begin
+        if Recipient <> '' then
+            exit;
+        EmailRecipientRecord.SetRange("Email Message Id", Message.Id);
+        EmailRecipientRecord.SetRange("Email Recipient Type", RecipientType);
+
+        if not EmailRecipientRecord.IsEmpty() then
+            EmailRecipientRecord.DeleteAll();
+
+        Recipient := DelChr(Recipient, '<>'); // trim the whitespaces around
+        Recipients := GetRecipients(RecipientType);
+        foreach tmpRecipient in Recipients do
+            if UniqueRecipients.Add(tmpRecipient.ToLower(), tmpRecipient) then;
+
+        if UniqueRecipients.Add(Recipient.ToLower(), Recipient) then begin // Set the recipient key to lowercase to prevent duplicates
+            EmailRecipientRecord.Init();
+            EmailRecipientRecord."Email Message Id" := Message.Id;
+            EmailRecipientRecord."Email Recipient Type" := RecipientType;
+            EmailRecipientRecord."Email Address" := CopyStr(Recipient, 1, MaxStrLen(EmailRecipientRecord."Email Address"));
+
+            EmailRecipientRecord.Insert();
+        end;
+    end;
+
     procedure Attachments_DeleteContent(): Boolean
     var
         MediaId: Guid;

--- a/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -367,11 +367,6 @@ codeunit 8905 "Email Message Impl."
     begin
         if Recipient = '' then
             exit;
-        EmailRecipientRecord.SetRange("Email Message Id", Message.Id);
-        EmailRecipientRecord.SetRange("Email Recipient Type", RecipientType);
-
-        if not EmailRecipientRecord.IsEmpty() then
-            EmailRecipientRecord.DeleteAll();
 
         Recipient := DelChr(Recipient, '<>'); // trim the whitespaces around
         Recipients := GetRecipients(RecipientType);

--- a/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
+++ b/Modules/System/Email/src/Message/EmailMessageImpl.Codeunit.al
@@ -120,12 +120,15 @@ codeunit 8905 "Email Message Impl."
     procedure AppendToBody(BodyText: Text)
     var
         BodyOutStream: OutStream;
+        Body: Text;
     begin
         if BodyText = '' then
             exit;
 
         ReplaceRgbaColorsWithRgb(BodyText);
+        Body := GetBody();
         Message.Body.CreateOutStream(BodyOutStream, TextEncoding::UTF8);
+        BodyOutStream.Write(Body);
         BodyOutStream.Write(BodyText);
         Modify();
     end;


### PR DESCRIPTION
per #16149

Adding the following setter functions to the email message codeunit.
- SetBody
- AppendToBody
- SetSubject
- SetBodyHTMLFormatted
- SetRecipients (Both List of Text and Text)

Also renaming the previous setter functions in the codeunit "email message impl" to for example setBodyValue to not have conflicts with the naming in the "email message" codeunit
