### PR TITLE
TempBlob Create*Stream with a stream as return

### DIFF
--- a/Modules/System Tests/BLOB Storage/src/TempBlobTest.Codeunit.al
+++ b/Modules/System Tests/BLOB Storage/src/TempBlobTest.Codeunit.al
@@ -28,6 +28,20 @@ codeunit 135030 "Temp Blob Test"
     end;
 
     [Test]
+    procedure CreateStreamReturnTest()
+    var
+        TempBlob: Codeunit "Temp Blob";
+    begin
+        // [SCENARIO] Streams (InStream and OutStream) can be created and used.
+
+        // Verify the module highest permission level is sufficient ignore non Tables
+        PermissionsMock.Set('Blob Storage Exec');
+
+        WriteSampleTextToBlob(TempBlob);
+        Assert.IsTrue(BlobContentIsEqualToSampleTextReturn(TempBlob), 'Same text was expected.');
+    end;
+
+    [Test]
     procedure CreateStreamWithEncodingTest()
     var
         TempBlob: Codeunit "Temp Blob";
@@ -56,6 +70,37 @@ codeunit 135030 "Temp Blob Test"
         // [THEN] Incorrect result.
         Assert.AreNotEqual(SampleTxt, OutputText, 'Different text was expected.');
     end;
+
+    [Test]
+    procedure CreateStreamReturnWithEncodingTest()
+    var
+        TempBlob: Codeunit "Temp Blob";
+        BlobOutStream: OutStream;
+        BlobInStream: InStream;
+        OutputText: Text;
+    begin
+        // [SCENARIO] Streams with encoding (InStream and OutStream) can be created and used.
+
+        // Verify the module highest permission level is sufficient ignore non Tables
+        PermissionsMock.Set('Blob Storage Exec');
+
+        // [GIVEN] Some value in TempBlob.
+        BlobOutStream := TempBlob.CreateOutStream(TextEncoding::Windows);
+        BlobOutStream.WriteText(SampleTxt);
+
+        // [WHEN] The correct encoding is used.
+        BlobInStream := TempBlob.CreateInStream(TextEncoding::Windows);
+        BlobInStream.ReadText(OutputText);
+        // [THEN] Correct result.
+        Assert.AreEqual(SampleTxt, OutputText, 'Same text was expected.');
+
+        // [WHEN] The wrong encoding is used.
+        BlobInStream := TempBlob.CreateInStream(TextEncoding::UTF16);
+        BlobInStream.ReadText(OutputText);
+        // [THEN] Incorrect result.
+        Assert.AreNotEqual(SampleTxt, OutputText, 'Different text was expected.');
+    end;
+
 
     [Test]
     procedure ReadFromRecordTest()
@@ -102,7 +147,7 @@ codeunit 135030 "Temp Blob Test"
 
         // Verify the module highest permission level is sufficient ignore non Tables
         PermissionsMock.Set('Blob Storage Exec');
-        
+
         IntegerFieldNo := 5; // Height
         BlobFieldNo := 3; // Content
 
@@ -270,6 +315,16 @@ codeunit 135030 "Temp Blob Test"
         OutputText: Text;
     begin
         TempBlob.CreateInStream(BlobInStream);
+        BlobInStream.ReadText(OutputText);
+        exit(SampleTxt = OutputText);
+    end;
+
+    local procedure BlobContentIsEqualToSampleTextReturn(TempBlob: Codeunit "Temp Blob"): Boolean
+    var
+        BlobInStream: InStream;
+        OutputText: Text;
+    begin
+        BlobInStream := TempBlob.CreateInStream();
         BlobInStream.ReadText(OutputText);
         exit(SampleTxt = OutputText);
     end;

--- a/Modules/System/BLOB Storage/src/TempBlob.Codeunit.al
+++ b/Modules/System/BLOB Storage/src/TempBlob.Codeunit.al
@@ -16,10 +16,29 @@ codeunit 4100 "Temp Blob"
     /// <summary>
     /// Creates an InStream object with default encoding for the TempBlob. This enables you to read data from the TempBlob.
     /// </summary>
+    /// <returns>The InStream variable with the BLOB content attached.</returns>
+    procedure CreateInStream() InStream: InStream
+    begin
+        TempBlobImpl.CreateInStream(InStream);
+    end;
+
+    /// <summary>
+    /// Creates an InStream object with default encoding for the TempBlob. This enables you to read data from the TempBlob.
+    /// </summary>
     /// <param name="InStream">The InStream variable passed as a VAR to which the BLOB content will be attached.</param>
     procedure CreateInStream(var InStream: InStream)
     begin
         TempBlobImpl.CreateInStream(InStream);
+    end;
+
+    /// <summary>
+    /// Creates an InStream object with default encoding for the TempBlob. This enables you to read data from the TempBlob.
+    /// </summary>
+    /// <param name="Encoding">The text encoding to use.</param>
+    /// <returns>The InStream variable with the BLOB content attached.</returns>
+    procedure CreateInStream(Encoding: TextEncoding) InStream: InStream
+    begin
+        TempBlobImpl.CreateInStream(InStream, Encoding);
     end;
 
     /// <summary>
@@ -35,10 +54,29 @@ codeunit 4100 "Temp Blob"
     /// <summary>
     /// Creates an OutStream object with default encoding for the TempBlob. This enables you to write data to the TempBlob.
     /// </summary>
+    /// <returns>The OutStream variable passed which the BLOB content will be attached.</returns>
+    procedure CreateOutStream() OutStream: OutStream
+    begin
+        TempBlobImpl.CreateOutStream(OutStream);
+    end;
+
+    /// <summary>
+    /// Creates an OutStream object with default encoding for the TempBlob. This enables you to write data to the TempBlob.
+    /// </summary>
     /// <param name="OutStream">The OutStream variable passed as a VAR to which the BLOB content will be attached.</param>
     procedure CreateOutStream(var OutStream: OutStream)
     begin
         TempBlobImpl.CreateOutStream(OutStream);
+    end;
+
+    /// <summary>
+    /// Creates an OutStream object with the specified encoding for the TempBlob. This enables you to write data to the TempBlob.
+    /// </summary>
+    /// <param name="Encoding">The text encoding to use.</param>
+    /// <returns>The OutStream variable with the BLOB content attached.</returns>
+    procedure CreateOutStream(Encoding: TextEncoding) OutStream: OutStream
+    begin
+        TempBlobImpl.CreateOutStream(OutStream, Encoding);
     end;
 
     /// <summary>


### PR DESCRIPTION
It would be useful if the Create*Steam functions returned the stream directly so that it can be passed on directly into a convert function, for example.