### PR TITLE
Table Purchase Header Change to fix bug

### DIFF
--- a/BREAKINGCHANGES.md
+++ b/BREAKINGCHANGES.md
@@ -1,4 +1,4 @@
-# Breaking Changes
+# Breaking ChangesABC
 ### ...and how to resolve them
 This document contains a list of the breaking changes that we know were introduced since 2019 release wave 2. For each breaking change we’ve provided some information about what you need to do to your code so that it will compile again against the latest version of the System Application and Base Application in Business central.
 


### PR DESCRIPTION
field(28; "Location Code"; Code[10])

               if PurchSetup."Use Vendor's Tax Area Code" then begin
                    if "Buy-from Vendor No." <> Vend."No." then
                        Vend.Get("Buy-from Vendor No.");
                    "Tax Area Code" := Vend."Tax Area Code";
                end;
This fails if the Buy-From Vendor becomes blank.
The fix we have in NAV 2017 is:
IF PurchSetup."Use Vendor's Tax Area Code" THEN BEGIN
  IF "Buy-from Vendor No." <> Vend."No." THEN
    IF "Buy-from Vendor No." <>'' THEN//CM001
      Vend.GET("Buy-from Vendor No.");
  "Tax Area Code" := Vend."Tax Area Code";
END;

Since we cannot insert a line like this in an extension, please make the update to base.
This is for a new cloud upgrade, so 19.5 would be fine, but please not later.