### PR TITLE
Migrate GP Vendor Classes

### DIFF
--- a/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
@@ -67,9 +67,11 @@ permissionset 4031 "HybridGP - Edit"
                     tabledata "GP Migration Errors" = IMD,
                     tabledata "GP Segment Name" = IMD,
                     tabledata "GP Company Additional Settings" = IMD,
-                    tabledata "GP SY40100" = RIMD,
-                    tabledata "GP SY40101" = RIMD,
-                    tabledata "GP CM20600" = RIMD,
+                    tabledata "GP SY40100" = IMD,
+                    tabledata "GP SY40101" = IMD,
+                    tabledata "GP CM20600" = IMD,
                     tabledata "GP MC40200" = IMD,
-                    tabledata "GP SY06000" = IMD;
+                    tabledata "GP SY06000" = IMD,
+                    tabledata "GP PM00100" = IMD,
+                    tabledata "GP PM00200" = IMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
@@ -96,5 +96,7 @@ permissionset 4029 "HybridGP - Objects"
                     table "GP SY40101" = X,
                     table "GP CM20600" = X,
                     table "GP MC40200" = X,
-                    table "GP SY06000" = X;
+                    table "GP SY06000" = X,
+                    table "GP PM00100" = X,
+                    table "GP PM00200" = X;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
@@ -71,5 +71,7 @@ permissionset 4032 "HybridGP - Read"
                     tabledata "GP SY40101" = R,
                     tabledata "GP CM20600" = R,
                     tabledata "GP MC40200" = R,
-                    tabledata "GP SY06000" = R;
+                    tabledata "GP SY06000" = R,
+                    tabledata "GP PM00100" = R,
+                    tabledata "GP PM00200" = R;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
@@ -64,5 +64,7 @@ permissionsetextension 4025 "D365 BASIC - HGP" extends "D365 BASIC"
                   tabledata "GP Checkbook MSTR" = RIMD,
                   tabledata "GP Checkbook Transactions" = RIMD,
                   tabledata "GP MC40200" = RIMD,
-                  tabledata "GP SY06000" = RIMD;
+                  tabledata "GP SY06000" = RIMD,
+                  tabledata "GP PM00100" = RIMD,
+                  tabledata "GP PM00200" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
@@ -64,5 +64,7 @@ permissionsetextension 4026 "D365 BASIC ISV - HGP" extends "D365 BASIC ISV"
                   tabledata "GP Checkbook MSTR" = RIMD,
                   tabledata "GP Checkbook Transactions" = RIMD,
                   tabledata "GP MC40200" = RIMD,
-                  tabledata "GP SY06000" = RIMD;
+                  tabledata "GP SY06000" = RIMD,
+                  tabledata "GP PM00100" = RIMD,
+                  tabledata "GP PM00200" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
@@ -64,5 +64,7 @@ permissionsetextension 4027 "D365 TEAM MEMBER - HGP" extends "D365 TEAM MEMBER"
                   tabledata "GP Checkbook MSTR" = RIMD,
                   tabledata "GP Checkbook Transactions" = RIMD,
                   tabledata "GP MC40200" = RIMD,
-                  tabledata "GP SY06000" = RIMD;
+                  tabledata "GP SY06000" = RIMD,
+                  tabledata "GP PM00100" = RIMD,
+                  tabledata "GP PM00200" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/intelligentcloudHGP.permisisonsetextension.al
+++ b/Apps/W1/HybridGP/app/Permissions/intelligentcloudHGP.permisisonsetextension.al
@@ -64,5 +64,7 @@ permissionsetextension 4028 "INTELLIGENT CLOUD - HGP" extends "INTELLIGENT CLOUD
                   tabledata "GP Checkbook MSTR" = RIMD,
                   tabledata "GP Checkbook Transactions" = RIMD,
                   tabledata "GP MC40200" = RIMD,
-                  tabledata "GP SY06000" = RIMD;
+                  tabledata "GP SY06000" = RIMD,
+                  tabledata "GP PM00100" = RIMD,
+                  tabledata "GP PM00200" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Support/GPConfiguration.table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/GPConfiguration.table.al
@@ -74,6 +74,11 @@ table 4024 "GP Configuration"
             DataClassification = SystemMetadata;
             InitValue = false;
         }
+        field(16; "Vendor Classes Created"; Boolean)
+        {
+            DataClassification = SystemMetadata;
+            InitValue = false;
+        }
     }
 
     keys
@@ -91,5 +96,16 @@ table 4024 "GP Configuration"
             Init();
             Insert();
         end;
+    end;
+
+    procedure IsAllPostMigrationDataCreated(): Boolean
+    begin
+        exit(
+                "CheckBooks Created" and
+                "Open Purchase Orders Created" and
+                "Fiscal Periods Created" and
+                "Vendor EFT Bank Acc. Created" and
+                "Vendor Classes Created"
+            );
     end;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
@@ -554,6 +554,11 @@ Codeunit 4037 "Helper Functions"
         CreateVendorEFTBankAccountsImp();
     end;
 
+    procedure CreateVendorClasses()
+    begin
+        CreateVendorClassesImp();
+    end;
+
     procedure CreateSetupRecordsIfNeeded()
     var
         CompanyInformation: Record "Company Information";
@@ -1042,6 +1047,8 @@ Codeunit 4037 "Helper Functions"
         GPSY40101: Record "GP SY40101";
         GPSY06000: Record "GP SY06000";
         GPMC40200: Record "GP MC40200";
+        GPPM00100: Record "GP PM00100";
+        GPPM00200: Record "GP PM00200";
     begin
         GPAccount.DeleteAll();
         GPGLTransactions.DeleteAll();
@@ -1072,6 +1079,9 @@ Codeunit 4037 "Helper Functions"
 
         GPSY06000.DeleteAll();
         GPMC40200.DeleteAll();
+
+        GPPM00100.DeleteAll();
+        GPPM00200.DeleteAll();
 
         Session.LogMessage('00007GH', 'Cleaned up staging tables.', Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', GetTelemetryCategory());
     end;
@@ -1741,6 +1751,15 @@ Codeunit 4037 "Helper Functions"
         SetVendorEFTBankAccountsCreated();
     end;
 
+    local procedure CreateVendorClassesImp()
+    var
+        GPVendorMigrator: CodeUnit "GP Vendor Migrator";
+    begin
+        GPVendorMigrator.MigrateVendorClasses();
+        Session.LogMessage('', 'Created Vendor Classes', Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', GetTelemetryCategory());
+        SetVendorClassesCreated();
+    end;
+
     local procedure SetDimentionsCreated()
     begin
         GPConfiguration.GetSingleInstance();
@@ -1794,6 +1813,13 @@ Codeunit 4037 "Helper Functions"
     begin
         GPConfiguration.GetSingleInstance();
         GPConfiguration."Vendor EFT Bank Acc. Created" := true;
+        GPConfiguration.Modify();
+    end;
+
+    local procedure SetVendorClassesCreated()
+    begin
+        GPConfiguration.GetSingleInstance();
+        GPConfiguration."Vendor Classes Created" := true;
         GPConfiguration.Modify();
     end;
 
@@ -1852,6 +1878,12 @@ Codeunit 4037 "Helper Functions"
         exit(GPConfiguration."Vendor EFT Bank Acc. Created");
     end;
 
+    local procedure VendorClassesCreated(): Boolean
+    begin
+        GPConfiguration.GetSingleInstance();
+        exit(GPConfiguration."Vendor Classes Created");
+    end;
+
     procedure PreMigrationCleanupCompleted(): Boolean
     begin
         GPConfiguration.GetSingleInstance();
@@ -1902,10 +1934,10 @@ Codeunit 4037 "Helper Functions"
         if not VendorEFTBankAccountsCreated() then
             CreateVendorEFTBankAccounts();
 
-        if CheckBooksCreated() and OpenPurchaseOrdersCreated() and FiscalPeriodsCreated() and VendorEFTBankAccountsCreated() then
-            exit(true);
+        if not VendorClassesCreated() then
+            CreateVendorClasses();
 
-        exit(false);
+        exit(GPConfiguration.IsAllPostMigrationDataCreated());
     end;
 
     procedure CheckMigrationStatus()
@@ -1972,5 +2004,29 @@ Codeunit 4037 "Helper Functions"
             OutValue := '';
 
         exit(OutValue);
+    end;
+
+    procedure GetGPAccountNumberByIndex(GPAccountIndex: Integer): Code[20]
+    var
+        GPAccount: Record "GP Account";
+    begin
+        if (GPAccountIndex > 0) then
+            if GPAccount.Get(GPAccountIndex) then
+                exit(CopyStr(GPAccount.AcctNum, 1, 20));
+
+        exit('');
+    end;
+
+    procedure EnsureAccountHasGenProdPostingAccount(AccountNumber: Code[20])
+    var
+        GLAccount: Record "G/L Account";
+    begin
+        if GLAccount.Get(AccountNumber) then begin
+            // Ensure the GLAccount has a Gen. Prod. Posting Group.
+            if GLAccount."Gen. Prod. Posting Group" = '' then begin
+                GLAccount."Gen. Prod. Posting Group" := PostingGroupCodeTxt;
+                GLAccount.Modify(true);
+            end;
+        end;
     end;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPPM00100.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPPM00100.Table.al
@@ -1,0 +1,233 @@
+table 40112 "GP PM00100"
+{
+    Description = 'GP Vendor Class Master';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; VNDCLSID; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; VNDCLDSC; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(3; DEFLTCLS; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(4; MXIAFVND; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(5; MXINVAMT; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(6; WRITEOFF; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(7; CREDTLMT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(8; TEN99TYPE; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(9; PTCSHACF; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(10; MXWOFAMT; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(11; MINORDER; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(12; CRLMTDLR; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(13; PYMNTPRI; Text[3])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(14; SHIPMTHD; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(15; PYMTRMID; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(16; MINPYTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(17; MINPYDLR; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(18; MINPYPCT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(19; CURNCYID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(20; TAXSCHID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(21; KPCALHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(22; KGLDSTHS; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(23; KPERHIST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(24; KPTRXHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(25; TRDDISCT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(26; USERDEF1; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(27; USERDEF2; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(28; PMAPINDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(29; PMCSHIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(30; PMDAVIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(31; PMDTKIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(32; PMFINIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(33; PMMSCHIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(34; PMFRTIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(35; PMTAXIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(36; PMWRTIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(37; PMPRCHIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(38; PMRTNGIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(39; PMTDSCIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(40; ACPURIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(41; PURPVIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(42; CHEKBKID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(43; MODIFDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(44; CREATDDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(45; RATETPID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(46; Revalue_Vendor; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(47; Post_Results_To; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(48; FREEONBOARD; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(49; DISGRPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(50; DUEGRPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(51; TaxInvRecvd; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(52; CBVAT; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(53; ONEPAYPERVENDINV; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(54; DEX_ROW_ID; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+    keys
+    {
+        key(Key1; VNDCLSID)
+        {
+            Clustered = true;
+        }
+    }
+}
+

--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPPM00200.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPPM00200.Table.al
@@ -1,0 +1,449 @@
+table 40113 "GP PM00200"
+{
+    Description = 'GP Vendor Master';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; VENDORID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; VENDNAME; Text[65])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(3; VNDCHKNM; Text[65])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(4; VENDSHNM; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(5; VADDCDPR; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(6; VADCDPAD; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(7; VADCDSFR; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(8; VADCDTRO; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(9; VNDCLSID; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(10; VNDCNTCT; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(11; ADDRESS1; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(12; ADDRESS2; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(13; ADDRESS3; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(14; CITY; Text[35])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(15; STATE; Text[29])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(16; ZIPCODE; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(17; COUNTRY; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(18; PHNUMBR1; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(19; PHNUMBR2; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(20; PHONE3; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(21; FAXNUMBR; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(22; UPSZONE; Text[3])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(23; SHIPMTHD; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(24; TAXSCHID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(25; ACNMVNDR; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(26; TXIDNMBR; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(27; VENDSTTS; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(28; CURNCYID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(29; TXRGNNUM; Text[25])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(30; PARVENID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(31; TRDDISCT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(32; TEN99TYPE; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(33; TEN99BOXNUMBER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(34; MINORDER; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(35; PYMTRMID; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(36; MINPYTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(37; MINPYPCT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(38; MINPYDLR; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(39; MXIAFVND; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(40; MAXINDLR; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(41; COMMENT1; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(42; COMMENT2; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(43; USERDEF1; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(44; USERDEF2; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(45; CRLMTDLR; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(46; PYMNTPRI; Text[3])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(47; KPCALHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(48; KGLDSTHS; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(49; KPERHIST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(50; KPTRXHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(51; HOLD; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(52; PTCSHACF; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(53; CREDTLMT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(54; WRITEOFF; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(55; MXWOFAMT; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(56; SBPPSDED; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(57; PPSTAXRT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(58; DXVARNUM; Text[25])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(59; CRTCOMDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(60; CRTEXPDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(61; RTOBUTKN; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(62; XPDTOBLG; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(63; PRSPAYEE; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(64; PMAPINDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(65; PMCSHIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(66; PMDAVIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(67; PMDTKIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(68; PMFINIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(69; PMMSCHIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(70; PMFRTIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(71; PMTAXIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(72; PMWRTIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(73; PMPRCHIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(74; PMRTNGIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(75; PMTDSCIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(76; ACPURIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(77; PURPVIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(78; NOTEINDX; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(79; CHEKBKID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(80; MODIFDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(81; CREATDDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(82; RATETPID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(83; Revalue_Vendor; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(84; Post_Results_To; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(85; FREEONBOARD; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(86; GOVCRPID; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(87; GOVINDID; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(88; DISGRPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(89; DUEGRPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(90; DOCFMTID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(91; TaxInvRecvd; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(92; USERLANG; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(93; WithholdingType; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(94; WithholdingFormType; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(95; WithholdingEntityType; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(96; TaxFileNumMode; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(97; BRTHDATE; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(98; LaborPmtType; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(99; CCode; Text[7])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(100; DECLID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(101; CBVAT; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(102; Workflow_Approval_Status; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(103; Workflow_Priority; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(104; Workflow_Status; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(105; VADCD1099; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(106; ONEPAYPERVENDINV; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(107; DEX_ROW_TS; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(108; DEX_ROW_ID; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+    keys
+    {
+        key(Key1; VENDORID)
+        {
+            Clustered = true;
+        }
+    }
+}
+

--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
@@ -468,9 +468,11 @@ codeunit 4022 "GP Vendor Migrator"
         AccountNumber: Code[20];
         MigrateVendorClasses: Boolean;
     begin
-        MigrateVendorClasses := GPCompanyAdditionalSettings.GetMigrateVendorClasses();
+        if not GPPM00200.FindSet() then
+            exit;
 
-        if not MigrateVendorClasses or not GPPM00200.FindSet() then
+        MigrateVendorClasses := GPCompanyAdditionalSettings.GetMigrateVendorClasses();
+        if not MigrateVendorClasses then
             exit;
 
         repeat

--- a/Apps/W1/HybridGP/app/src/codeunits/GPCloudMigration.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/codeunits/GPCloudMigration.codeunit.al
@@ -46,6 +46,8 @@ codeunit 4025 "GP Cloud Migration"
         GPCM20600Lbl: Label 'CM20600', Locked = true;
         GPMC40200Lbl: Label 'MC40200', Locked = true;
         GPSY06000Lbl: Label 'SY06000', Locked = true;
+        GPPM00100Lbl: Label 'PM00100', Locked = true;
+        GPPM00200Lbl: Label 'PM00200', Locked = true;
 
     local procedure InitiateGPMigration()
     var
@@ -148,6 +150,8 @@ codeunit 4025 "GP Cloud Migration"
         UpdateOrInsertRecord(Database::"GP CM20600", GPCM20600Lbl);
         UpdateOrInsertRecord(Database::"GP MC40200", GPMC40200Lbl);
         UpdateOrInsertRecord(Database::"GP SY06000", GPSY06000Lbl);
+        UpdateOrInsertRecord(Database::"GP PM00100", GPPM00100Lbl);
+        UpdateOrInsertRecord(Database::"GP PM00200", GPPM00200Lbl);
     end;
 
     local procedure UpdateOrInsertRecord(TableID: Integer; SourceTableName: Text[128])

--- a/Apps/W1/HybridGP/app/src/pages/GPMigrationSettingsList.page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPMigrationSettingsList.page.al
@@ -73,6 +73,27 @@ page 4021 "GP Migration Settings List"
                         end;
                     end;
                 }
+                field("Migrate Vendor Classes"; MigrateVendorClasses)
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Migrate Vendor Classes';
+                    ToolTip = 'Specifies whether to migrate Vendor Classes.';
+                    Width = 8;
+
+                    trigger OnValidate()
+                    var
+                        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+                    begin
+                        if not GPCompanyAdditionalSettings.Get(Rec.Name) then begin
+                            GPCompanyAdditionalSettings.Name := Rec.Name;
+                            GPCompanyAdditionalSettings."Migrate Vendor Classes" := MigrateVendorClasses;
+                            GPCompanyAdditionalSettings.Insert();
+                        end else begin
+                            GPCompanyAdditionalSettings."Migrate Vendor Classes" := MigrateVendorClasses;
+                            GPCompanyAdditionalSettings.Modify();
+                        end;
+                    end;
+                }
             }
         }
     }
@@ -94,9 +115,16 @@ page 4021 "GP Migration Settings List"
 
         Rec.Modify();
 
-        MigrateInactiveCheckbooks := GPCompanyAdditionalSettings.GetMigrateInactiveCheckbooks();
+        MigrateInactiveCheckbooks := true;
+        MigrateVendorClasses := true;
+
+        if GPCompanyAdditionalSettings.Get(CompanyName()) then begin
+            MigrateInactiveCheckbooks := GPCompanyAdditionalSettings."Migrate Inactive Checkbooks";
+            MigrateVendorClasses := GPCompanyAdditionalSettings."Migrate Vendor Classes";
+        end;
     end;
 
     var
         MigrateInactiveCheckbooks: Boolean;
+        MigrateVendorClasses: Boolean;
 }

--- a/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
+++ b/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
@@ -2,7 +2,6 @@ table 40105 "GP Company Additional Settings"
 {
     ReplicateData = false;
     DataPerCompany = false;
-    Extensible = false;
 
     fields
     {
@@ -13,6 +12,11 @@ table 40105 "GP Company Additional Settings"
         }
 
         field(10; "Migrate Inactive Checkbooks"; Boolean)
+        {
+            InitValue = true;
+            DataClassification = SystemMetadata;
+        }
+        field(11; "Migrate Vendor Classes"; Boolean)
         {
             InitValue = true;
             DataClassification = SystemMetadata;
@@ -36,5 +40,16 @@ table 40105 "GP Company Additional Settings"
             MigrateInactiveCheckbooks := Rec."Migrate Inactive Checkbooks";
 
         exit(MigrateInactiveCheckbooks);
+    end;
+
+    procedure GetMigrateVendorClasses(): Boolean
+    var
+        MigrateVendorClasses: Boolean;
+    begin
+        MigrateVendorClasses := true;
+        if Rec.Get(CompanyName()) then
+            MigrateVendorClasses := Rec."Migrate Vendor Classes";
+
+        exit(MigrateVendorClasses);
     end;
 }

--- a/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
+++ b/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
@@ -18,7 +18,7 @@ table 40105 "GP Company Additional Settings"
         }
         field(11; "Migrate Vendor Classes"; Boolean)
         {
-            InitValue = true;
+            InitValue = false;
             DataClassification = SystemMetadata;
         }
     }
@@ -46,7 +46,6 @@ table 40105 "GP Company Additional Settings"
     var
         MigrateVendorClasses: Boolean;
     begin
-        MigrateVendorClasses := true;
         if Rec.Get(CompanyName()) then
             MigrateVendorClasses := Rec."Migrate Vendor Classes";
 


### PR DESCRIPTION
This change enhances the GP cloud migration to include migrating GP Vendor Classes to BC Vendor Posting Groups.

- For each GP vendor class that has related accounts a new Vendor Posting Group will be created in BC.
- Any vendor migrated from GP that is part of a vendor class will have the related Vendor Posting Group assigned.
- A configuration option has been added to give the ability to not migrate Vendor Classes, disabled by default.