### PR TITLE
Update pull_request_target Branch Name to main

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   pull_request_target:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   SystemApplication:


### PR DESCRIPTION
My Latest PR didn't trigger the CI.
I updated PR Branch Name from old name master to main.

This change will only be used for new PR, as soon as this change is merged to the main branch.