### PR TITLE
Migrate GP Customer Classes

### DIFF
--- a/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
@@ -73,5 +73,7 @@ permissionset 4031 "HybridGP - Edit"
                     tabledata "GP MC40200" = IMD,
                     tabledata "GP SY06000" = IMD,
                     tabledata "GP PM00100" = IMD,
-                    tabledata "GP PM00200" = IMD;
+                    tabledata "GP PM00200" = IMD,
+                    tabledata "GP RM00101" = IMD,
+                    tabledata "GP RM00201" = IMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
@@ -98,5 +98,7 @@ permissionset 4029 "HybridGP - Objects"
                     table "GP MC40200" = X,
                     table "GP SY06000" = X,
                     table "GP PM00100" = X,
-                    table "GP PM00200" = X;
+                    table "GP PM00200" = X,
+                    table "GP RM00101" = X,
+                    table "GP RM00201" = X;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
@@ -73,5 +73,7 @@ permissionset 4032 "HybridGP - Read"
                     tabledata "GP MC40200" = R,
                     tabledata "GP SY06000" = R,
                     tabledata "GP PM00100" = R,
-                    tabledata "GP PM00200" = R;
+                    tabledata "GP PM00200" = R,
+                    tabledata "GP RM00101" = R,
+                    tabledata "GP RM00201" = R;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
@@ -66,5 +66,7 @@ permissionsetextension 4025 "D365 BASIC - HGP" extends "D365 BASIC"
                   tabledata "GP MC40200" = RIMD,
                   tabledata "GP SY06000" = RIMD,
                   tabledata "GP PM00100" = RIMD,
-                  tabledata "GP PM00200" = RIMD;
+                  tabledata "GP PM00200" = RIMD,
+                  tabledata "GP RM00101" = RIMD,
+                  tabledata "GP RM00201" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
@@ -66,5 +66,7 @@ permissionsetextension 4026 "D365 BASIC ISV - HGP" extends "D365 BASIC ISV"
                   tabledata "GP MC40200" = RIMD,
                   tabledata "GP SY06000" = RIMD,
                   tabledata "GP PM00100" = RIMD,
-                  tabledata "GP PM00200" = RIMD;
+                  tabledata "GP PM00200" = RIMD,
+                  tabledata "GP RM00101" = RIMD,
+                  tabledata "GP RM00201" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
@@ -66,5 +66,7 @@ permissionsetextension 4027 "D365 TEAM MEMBER - HGP" extends "D365 TEAM MEMBER"
                   tabledata "GP MC40200" = RIMD,
                   tabledata "GP SY06000" = RIMD,
                   tabledata "GP PM00100" = RIMD,
-                  tabledata "GP PM00200" = RIMD;
+                  tabledata "GP PM00200" = RIMD,
+                  tabledata "GP RM00101" = RIMD,
+                  tabledata "GP RM00201" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/intelligentcloudHGP.permisisonsetextension.al
+++ b/Apps/W1/HybridGP/app/Permissions/intelligentcloudHGP.permisisonsetextension.al
@@ -66,5 +66,7 @@ permissionsetextension 4028 "INTELLIGENT CLOUD - HGP" extends "INTELLIGENT CLOUD
                   tabledata "GP MC40200" = RIMD,
                   tabledata "GP SY06000" = RIMD,
                   tabledata "GP PM00100" = RIMD,
-                  tabledata "GP PM00200" = RIMD;
+                  tabledata "GP PM00200" = RIMD,
+                  tabledata "GP RM00101" = RIMD,
+                  tabledata "GP RM00201" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
@@ -390,62 +390,68 @@ codeunit 4018 "GP Customer Migrator"
         if not GPRM00101.FindSet() then
             exit;
 
+        if not GPRM00201.FindSet() then
+            exit;
+
         MigrateCustomerClasses := GPCompanyAdditionalSettings.GetMigrateCustomerClasses();
         if not MigrateCustomerClasses then
             exit;
 
+        // Create the Customer Posting Groups
         repeat
-            Clear(GPRM00201);
             Clear(CustomerPostingGroup);
+            ClassId := GPRM00201.CLASSID.Trim();
+            if ClassId <> '' then
+                if not CustomerPostingGroup.Get(ClassId) then begin
+                    CustomerPostingGroup.Validate("Code", ClassId);
+                    CustomerPostingGroup.Validate("Description", GPRM00201.CLASDSCR);
 
+                    // Receivables Account
+                    AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMARACC);
+                    if AccountNumber <> '' then begin
+                        HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
+                        CustomerPostingGroup.Validate("Receivables Account", AccountNumber);
+                    end;
+
+                    // Payment Disc. Debit Acc.
+                    AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMTAKACC);
+                    if AccountNumber <> '' then begin
+                        HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
+                        CustomerPostingGroup.Validate("Payment Disc. Debit Acc.", AccountNumber);
+                    end;
+
+                    // Additional Fee Account
+                    AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMFCGACC);
+                    if AccountNumber <> '' then begin
+                        HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
+                        CustomerPostingGroup.Validate("Additional Fee Account", AccountNumber);
+                    end;
+
+                    // Payment Disc. Credit Acc.
+                    AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMAVACC);
+                    if AccountNumber <> '' then begin
+                        HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
+                        CustomerPostingGroup.Validate("Payment Disc. Credit Acc.", AccountNumber);
+                    end;
+
+                    // Payment Tolerance Debit Acc.
+                    // Payment Tolerance Credit Acc.
+                    AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMWRACC);
+                    if AccountNumber <> '' then begin
+                        HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
+                        CustomerPostingGroup.Validate("Payment Tolerance Debit Acc.", AccountNumber);
+                        CustomerPostingGroup.Validate("Payment Tolerance Credit Acc.", AccountNumber);
+                    end;
+
+                    CustomerPostingGroup.Insert();
+                end;
+        until GPRM00201.Next() = 0;
+
+        // Assign the Customer Posting Groups to the Customers
+        repeat
             ClassId := GPRM00101.CUSTCLAS.Trim();
             if ClassId <> '' then
                 if Customer.Get(GPRM00101.CUSTNMBR) then begin
-                    if not CustomerPostingGroup.Get(ClassId) then
-                        if GPRM00201.Get(ClassId) then begin
-                            CustomerPostingGroup.Validate("Code", ClassId);
-                            CustomerPostingGroup.Validate("Description", GPRM00201.CLASDSCR);
-
-                            // Receivables Account
-                            AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMARACC);
-                            if AccountNumber <> '' then begin
-                                HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
-                                CustomerPostingGroup.Validate("Receivables Account", AccountNumber);
-                            end;
-
-                            // Payment Disc. Debit Acc.
-                            AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMTAKACC);
-                            if AccountNumber <> '' then begin
-                                HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
-                                CustomerPostingGroup.Validate("Payment Disc. Debit Acc.", AccountNumber);
-                            end;
-
-                            // Additional Fee Account
-                            AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMFCGACC);
-                            if AccountNumber <> '' then begin
-                                HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
-                                CustomerPostingGroup.Validate("Additional Fee Account", AccountNumber);
-                            end;
-
-                            // Payment Disc. Credit Acc.
-                            AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMAVACC);
-                            if AccountNumber <> '' then begin
-                                HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
-                                CustomerPostingGroup.Validate("Payment Disc. Credit Acc.", AccountNumber);
-                            end;
-
-                            // Payment Tolerance Debit Acc.
-                            // Payment Tolerance Credit Acc.
-                            AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMWRACC);
-                            if AccountNumber <> '' then begin
-                                HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
-                                CustomerPostingGroup.Validate("Payment Tolerance Debit Acc.", AccountNumber);
-                                CustomerPostingGroup.Validate("Payment Tolerance Credit Acc.", AccountNumber);
-                            end;
-
-                            CustomerPostingGroup.Insert();
-                        end;
-
                     Customer.Validate("Customer Posting Group", ClassId);
                     Customer.Modify(true);
                 end;

--- a/Apps/W1/HybridGP/app/src/Migration/Customers/GPRM00101.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Customers/GPRM00101.Table.al
@@ -1,0 +1,429 @@
+table 40114 "GP RM00101"
+{
+    Description = 'RM Customer Master';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; CUSTNMBR; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; CUSTNAME; Text[65])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(3; CUSTCLAS; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(4; CPRCSTNM; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(5; CNTCPRSN; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(6; STMTNAME; Text[65])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(7; SHRTNAME; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(8; ADRSCODE; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(9; UPSZONE; Text[3])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(10; SHIPMTHD; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(11; TAXSCHID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(12; ADDRESS1; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(13; ADDRESS2; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(14; ADDRESS3; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(15; COUNTRY; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(16; CITY; Text[35])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(17; STATE; Text[29])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(18; ZIP; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(19; PHONE1; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(20; PHONE2; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(21; PHONE3; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(22; FAX; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(23; PRBTADCD; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(24; PRSTADCD; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(25; STADDRCD; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(26; SLPRSNID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(27; CHEKBKID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(28; PYMTRMID; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(29; CRLMTTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(30; CRLMTAMT; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(31; CRLMTPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(32; CRLMTPAM; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(33; CURNCYID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(34; RATETPID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(35; CUSTDISC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(36; PRCLEVEL; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(37; MINPYTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(38; MINPYDLR; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(39; MINPYPCT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(40; FNCHATYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(41; FNCHPCNT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(42; FINCHDLR; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(43; MXWOFTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(44; MXWROFAM; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(45; COMMENT1; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(46; COMMENT2; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(47; USERDEF1; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(48; USERDEF2; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(49; TAXEXMT1; Text[25])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(50; TAXEXMT2; Text[25])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(51; TXRGNNUM; Text[25])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(52; BALNCTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(53; STMTCYCL; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(54; BANKNAME; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(55; BNKBRNCH; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(56; SALSTERR; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(57; DEFCACTY; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(58; RMCSHACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(59; RMARACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(60; RMSLSACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(61; RMIVACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(62; RMCOSACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(63; RMTAKACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(64; RMAVACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(65; RMFCGACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(66; RMWRACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(67; RMSORACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(68; FRSTINDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(69; INACTIVE; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(70; HOLD; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(71; CRCARDID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(72; CRCRDNUM; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(73; CCRDXPDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(74; KPDSTHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(75; KPCALHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(76; KPERHIST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(77; KPTRXHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(78; NOTEINDX; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(79; CREATDDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(80; MODIFDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(81; Revalue_Customer; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(82; Post_Results_To; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(83; FINCHID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(84; GOVCRPID; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(85; GOVINDID; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(86; DISGRPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(87; DUEGRPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(88; DOCFMTID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(89; Send_Email_Statements; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(90; USERLANG; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(91; GPSFOINTEGRATIONID; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(92; INTEGRATIONSOURCE; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(93; INTEGRATIONID; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(94; ORDERFULFILLDEFAULT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(95; CUSTPRIORITY; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(96; CCode; Text[7])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(97; DECLID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(98; RMOvrpymtWrtoffAcctIdx; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(99; SHIPCOMPLETE; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(100; CBVAT; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(101; INCLUDEINDP; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(102; DEX_ROW_TS; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(103; DEX_ROW_ID; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+    keys
+    {
+        key(Key1; CUSTNMBR)
+        {
+            Clustered = true;
+        }
+    }
+}
+

--- a/Apps/W1/HybridGP/app/src/Migration/Customers/GPRM00201.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Customers/GPRM00201.Table.al
@@ -1,0 +1,257 @@
+table 40115 "GP RM00201"
+{
+    Description = 'RM Class Master';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; CLASSID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; CLASDSCR; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(3; CRLMTTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(4; CRLMTAMT; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(5; CRLMTPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(6; CRLMTPAM; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(7; DEFLTCLS; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(8; BALNCTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(9; CHEKBKID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(10; BANKNAME; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(11; TAXSCHID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(12; SHIPMTHD; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(13; PYMTRMID; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(14; CUSTDISC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(15; CSTPRLVL; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(16; MINPYTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(17; MINPYDLR; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(18; MINPYPCT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(19; MXWOFTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(20; MXWROFAM; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(21; FINCHARG; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(22; FNCHATYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(23; FINCHDLR; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(24; FNCHPCNT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(25; PRCLEVEL; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(26; CURNCYID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(27; RATETPID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(28; DEFCACTY; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(29; RMCSHACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(30; RMARACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(31; RMCOSACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(32; RMIVACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(33; RMSLSACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(34; RMAVACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(35; RMTAKACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(36; RMFCGACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(37; RMWRACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(38; RMSORACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(39; SALSTERR; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(40; SLPRSNID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(41; STMTCYCL; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(42; SNDSTMNT; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(43; INACTIVE; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(44; KPCALHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(45; KPDSTHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(46; KPERHIST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(47; KPTRXHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(48; NOTEINDX; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(49; MODIFDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(50; CREATDDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(51; Revalue_Customer; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(52; Post_Results_To; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(53; DISGRPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(54; DUEGRPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(55; ORDERFULFILLDEFAULT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(56; CUSTPRIORITY; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(57; RMOvrpymtWrtoffAcctIdx; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(58; CBVAT; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(59; INCLUDEINDP; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(60; DEX_ROW_ID; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+    keys
+    {
+        key(Key1; CLASSID)
+        {
+            Clustered = true;
+        }
+    }
+}
+

--- a/Apps/W1/HybridGP/app/src/Migration/Support/GPConfiguration.table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/GPConfiguration.table.al
@@ -79,6 +79,11 @@ table 4024 "GP Configuration"
             DataClassification = SystemMetadata;
             InitValue = false;
         }
+        field(17; "Customer Classes Created"; Boolean)
+        {
+            DataClassification = SystemMetadata;
+            InitValue = false;
+        }
     }
 
     keys
@@ -105,7 +110,8 @@ table 4024 "GP Configuration"
                 "Open Purchase Orders Created" and
                 "Fiscal Periods Created" and
                 "Vendor EFT Bank Acc. Created" and
-                "Vendor Classes Created"
+                "Vendor Classes Created" and
+                "Customer Classes Created"
             );
     end;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
@@ -558,6 +558,11 @@ Codeunit 4037 "Helper Functions"
         CreateVendorClassesImp();
     end;
 
+    procedure CreateCustomerClasses()
+    begin
+        CreateCustomerClassesImp();
+    end;
+
     procedure CreateSetupRecordsIfNeeded()
     var
         CompanyInformation: Record "Company Information";
@@ -1048,6 +1053,8 @@ Codeunit 4037 "Helper Functions"
         GPMC40200: Record "GP MC40200";
         GPPM00100: Record "GP PM00100";
         GPPM00200: Record "GP PM00200";
+        GPRM00101: Record "GP RM00101";
+        GPRM00201: Record "GP RM00201";
     begin
         GPAccount.DeleteAll();
         GPGLTransactions.DeleteAll();
@@ -1081,6 +1088,9 @@ Codeunit 4037 "Helper Functions"
 
         GPPM00100.DeleteAll();
         GPPM00200.DeleteAll();
+
+        GPRM00101.DeleteAll();
+        GPRM00201.DeleteAll();
 
         Session.LogMessage('00007GH', 'Cleaned up staging tables.', Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', GetTelemetryCategory());
     end;
@@ -1759,6 +1769,15 @@ Codeunit 4037 "Helper Functions"
         SetVendorClassesCreated();
     end;
 
+    local procedure CreateCustomerClassesImp()
+    var
+        GPCustomerMigrator: CodeUnit "GP Customer Migrator";
+    begin
+        GPCustomerMigrator.MigrateCustomerClasses();
+        Session.LogMessage('', 'Created Customer Classes', Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', GetTelemetryCategory());
+        SetCustomerClassesCreated();
+    end;
+
     local procedure SetDimentionsCreated()
     begin
         GPConfiguration.GetSingleInstance();
@@ -1819,6 +1838,13 @@ Codeunit 4037 "Helper Functions"
     begin
         GPConfiguration.GetSingleInstance();
         GPConfiguration."Vendor Classes Created" := true;
+        GPConfiguration.Modify();
+    end;
+
+    local procedure SetCustomerClassesCreated()
+    begin
+        GPConfiguration.GetSingleInstance();
+        GPConfiguration."Customer Classes Created" := true;
         GPConfiguration.Modify();
     end;
 
@@ -1883,6 +1909,12 @@ Codeunit 4037 "Helper Functions"
         exit(GPConfiguration."Vendor Classes Created");
     end;
 
+    local procedure CustomerClassesCreated(): Boolean
+    begin
+        GPConfiguration.GetSingleInstance();
+        exit(GPConfiguration."Customer Classes Created");
+    end;
+
     procedure PreMigrationCleanupCompleted(): Boolean
     begin
         GPConfiguration.GetSingleInstance();
@@ -1935,6 +1967,9 @@ Codeunit 4037 "Helper Functions"
 
         if not VendorClassesCreated() then
             CreateVendorClasses();
+
+        if not CustomerClassesCreated() then
+            CreateCustomerClasses();
 
         exit(GPConfiguration.IsAllPostMigrationDataCreated());
     end;

--- a/Apps/W1/HybridGP/app/src/codeunits/GPCloudMigration.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/codeunits/GPCloudMigration.codeunit.al
@@ -48,6 +48,8 @@ codeunit 4025 "GP Cloud Migration"
         GPSY06000Lbl: Label 'SY06000', Locked = true;
         GPPM00100Lbl: Label 'PM00100', Locked = true;
         GPPM00200Lbl: Label 'PM00200', Locked = true;
+        GPRM00101Lbl: Label 'RM00101', Locked = true;
+        GPRM00201Lbl: Label 'RM00201', Locked = true;
 
     local procedure InitiateGPMigration()
     var
@@ -152,6 +154,8 @@ codeunit 4025 "GP Cloud Migration"
         UpdateOrInsertRecord(Database::"GP SY06000", GPSY06000Lbl);
         UpdateOrInsertRecord(Database::"GP PM00100", GPPM00100Lbl);
         UpdateOrInsertRecord(Database::"GP PM00200", GPPM00200Lbl);
+        UpdateOrInsertRecord(Database::"GP RM00101", GPRM00101Lbl);
+        UpdateOrInsertRecord(Database::"GP RM00201", GPRM00201Lbl);
     end;
 
     local procedure UpdateOrInsertRecord(TableID: Integer; SourceTableName: Text[128])

--- a/Apps/W1/HybridGP/app/src/pages/GPMigrationSettingsList.page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPMigrationSettingsList.page.al
@@ -94,6 +94,27 @@ page 4021 "GP Migration Settings List"
                         end;
                     end;
                 }
+                field("Migrate Customer Classes"; MigrateCustomerClasses)
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Migrate Customer Classes';
+                    ToolTip = 'Specifies whether to migrate Customer Classes.';
+                    Width = 8;
+
+                    trigger OnValidate()
+                    var
+                        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+                    begin
+                        if not GPCompanyAdditionalSettings.Get(Rec.Name) then begin
+                            GPCompanyAdditionalSettings.Name := Rec.Name;
+                            GPCompanyAdditionalSettings."Migrate Customer Classes" := MigrateCustomerClasses;
+                            GPCompanyAdditionalSettings.Insert();
+                        end else begin
+                            GPCompanyAdditionalSettings."Migrate Customer Classes" := MigrateCustomerClasses;
+                            GPCompanyAdditionalSettings.Modify();
+                        end;
+                    end;
+                }
             }
         }
     }
@@ -116,15 +137,16 @@ page 4021 "GP Migration Settings List"
         Rec.Modify();
 
         MigrateInactiveCheckbooks := true;
-        MigrateVendorClasses := true;
 
         if GPCompanyAdditionalSettings.Get(CompanyName()) then begin
             MigrateInactiveCheckbooks := GPCompanyAdditionalSettings."Migrate Inactive Checkbooks";
             MigrateVendorClasses := GPCompanyAdditionalSettings."Migrate Vendor Classes";
+            MigrateCustomerClasses := GPCompanyAdditionalSettings."Migrate Customer Classes";
         end;
     end;
 
     var
         MigrateInactiveCheckbooks: Boolean;
         MigrateVendorClasses: Boolean;
+        MigrateCustomerClasses: Boolean;
 }

--- a/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
+++ b/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
@@ -21,6 +21,11 @@ table 40105 "GP Company Additional Settings"
             InitValue = false;
             DataClassification = SystemMetadata;
         }
+        field(12; "Migrate Customer Classes"; Boolean)
+        {
+            InitValue = false;
+            DataClassification = SystemMetadata;
+        }
     }
 
     keys
@@ -50,5 +55,15 @@ table 40105 "GP Company Additional Settings"
             MigrateVendorClasses := Rec."Migrate Vendor Classes";
 
         exit(MigrateVendorClasses);
+    end;
+
+    procedure GetMigrateCustomerClasses(): Boolean
+    var
+        MigrateCustomerClasses: Boolean;
+    begin
+        if Rec.Get(CompanyName()) then
+            MigrateCustomerClasses := Rec."Migrate Customer Classes";
+
+        exit(MigrateCustomerClasses);
     end;
 }


### PR DESCRIPTION
This change enhances the GP cloud migration to include migrating GP Customer Classes to BC Customer Posting Groups.

- For each GP customer class that has related accounts a new Customer Posting Group will be created in BC.
- Any customer migrated from GP that is part of a customer class will have the related Customer Posting Group assigned.
- A configuration option has been added to give the ability to not migrate Customer Classes, disabled by default.