### PR TITLE
Add VerifyData procedure with SignatureKey as PrivateKey to Cryptography Management

### DIFF
--- a/Modules/System/Cryptography Management/src/CryptographyManagement.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/CryptographyManagement.Codeunit.al
@@ -329,6 +329,33 @@ codeunit 1266 "Cryptography Management"
     begin
         exit(CryptographyManagementImpl.VerifyData(DataInStream, XmlString, HashAlgorithm, SignatureInStream));
     end;
+    
+    /// <summary>
+    /// Verifies that a digital signature is valid.
+    /// </summary>
+    /// <param name="InputString">Input string.</param>
+    /// <param name="SignatureKey">The private key to use in the hash algorithm.</param>    
+    /// <param name="HashAlgorithm">The available hash algorithms are MD5, SHA1, SHA256, SHA384, and SHA512.</param>
+    /// <param name="SignatureInStream">The stream of signature.</param>
+    /// <returns>True if the signature is valid; otherwise, false.</returns>
+    procedure VerifyData(InputString: Text; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureInStream: InStream): Boolean
+    begin
+        exit(CryptographyManagementImpl.VerifyData(InputString, SignatureKey, HashAlgorithm, SignatureInStream));
+    end;
+
+    /// <summary>
+    /// Verifies that a digital signature is valid.
+    /// </summary>
+    /// <param name="DataInStream">The stream of input data.</param>
+    /// <param name="SignatureKey">The private key to use in the hash algorithm.</param>    
+    /// <param name="HashAlgorithm">The available hash algorithms are MD5, SHA1, SHA256, SHA384, and SHA512.</param>
+    /// <param name="SignatureInStream">The stream of signature.</param>
+    /// <returns>True if the signature is valid; otherwise, false.</returns>
+    procedure VerifyData(DataInStream: InStream; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureInStream: InStream): Boolean
+    begin
+        exit(CryptographyManagementImpl.VerifyData(DataInStream, SignatureKey, HashAlgorithm, SignatureInStream));
+    end;
+
 
 #if not CLEAN19
 #pragma warning disable AL0432

--- a/Modules/System/Cryptography Management/src/CryptographyManagementImpl.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/CryptographyManagementImpl.Codeunit.al
@@ -471,9 +471,9 @@ codeunit 1279 "Cryptography Management Impl."
         exit(VerifyData(DataInStream, XmlString, HashAlgorithm, SignatureInStream));
     end;
     
-    procedure VerifyData(InputString: Text; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureInStream: InStream)
+    procedure VerifyData(InputString: Text; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureInStream: InStream): Boolean
     begin
-        VerifyData(InputString, SignatureKey.ToXmlString(), HashAlgorithm, SignatureInStream);
+        exit(VerifyData(InputString, SignatureKey.ToXmlString(), HashAlgorithm, SignatureInStream));
     end;
 
 #if not CLEAN19
@@ -521,9 +521,9 @@ codeunit 1279 "Cryptography Management Impl."
         exit(ISignatureAlgorithm.VerifyData(DataInStream, HashAlgorithm, SignatureInStream));
     end;
     
-    procedure VerifyData(DataInStream: InStream; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureInStream: InStream)
+    procedure VerifyData(DataInStream: InStream; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureInStream: InStream): Boolean
     begin
-        VerifyData(DataInStream, SignatureKey.ToXmlString(), HashAlgorithm, SignatureInStream);
+        exit(VerifyData(DataInStream, SignatureKey.ToXmlString(), HashAlgorithm, SignatureInStream));
     end;
 
 #if not CLEAN19

--- a/Modules/System/Cryptography Management/src/CryptographyManagementImpl.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/CryptographyManagementImpl.Codeunit.al
@@ -470,6 +470,11 @@ codeunit 1279 "Cryptography Management Impl."
         DataOutStream.WriteText(InputString);
         exit(VerifyData(DataInStream, XmlString, HashAlgorithm, SignatureInStream));
     end;
+    
+    procedure VerifyData(InputString: Text; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureInStream: InStream)
+    begin
+        VerifyData(InputString, SignatureKey.ToXmlString(), HashAlgorithm, SignatureInStream);
+    end;
 
 #if not CLEAN19
 #pragma warning disable AL0432
@@ -514,6 +519,11 @@ codeunit 1279 "Cryptography Management Impl."
         ISignatureAlgorithm := Enum::SignatureAlgorithm::RSA;
         ISignatureAlgorithm.FromXmlString(XmlString);
         exit(ISignatureAlgorithm.VerifyData(DataInStream, HashAlgorithm, SignatureInStream));
+    end;
+    
+    procedure VerifyData(DataInStream: InStream; SignatureKey: Codeunit "Signature Key"; HashAlgorithm: Enum "Hash Algorithm"; SignatureInStream: InStream)
+    begin
+        VerifyData(DataInStream, SignatureKey.ToXmlString(), HashAlgorithm, SignatureInStream);
     end;
 
 #if not CLEAN19


### PR DESCRIPTION
In Cryptography Management the option for using Signature Key(codeunit) as the private key exists for the SignData procedure which takes both xml string and Signature key. But not for VerifyData it only has a xml string option but i don´t see why it should not also be possible to use Signature Key(codeunit) for VerifyData. Since the only Cloud friendly way to retrieve a Privatekey from Certificates is via 
Certificate Management.GetCertPrivateKey(IsolatedCertificate: Record "Isolated Certificate"; var SignatureKey: Codeunit "Signature Key") 

This is a step towards making the LS Central app universal code compliant.
