### PR TITLE
License information

### DIFF
--- a/Modules/System Tests/Environment Information/src/EnvironmentInformationTest.Codeunit.al
+++ b/Modules/System Tests/Environment Information/src/EnvironmentInformationTest.Codeunit.al
@@ -12,6 +12,7 @@ codeunit 135091 "Environment Information Test"
         Assert: Codeunit "Library Assert";
         EnvironmentInformation: Codeunit "Environment Information";
         EnvironmentInfoTestLibrary: Codeunit "Environment Info Test Library";
+        LicenseInformation: Codeunit "License Information";
 
     [Test]
     [Scope('OnPrem')]
@@ -77,6 +78,40 @@ codeunit 135091 "Environment Information Test"
         // [When] Poll for IsSaaS
         // [Then] Should return false
         Assert.IsFalse(EnvironmentInformation.IsSaaS(), 'Testability should have dictacted a non- SaaS environment');
+    end;
+
+    [Test]
+    procedure TestGetLicenseErrorWhenTestabilitySaaSIsSet()
+    var
+        LicenseDetails: text;
+    begin
+        // [SCENARIO] Set the SaaS testability to true. GetLicenseDetails returns error, only for OnPrem.
+
+        // [Given] Environment is SaaS
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(true);
+
+        // [When] Get license details
+        asserterror LicenseDetails := LicenseInformation.GetLicenseDetails();
+
+        // [Then] Expected Error
+        Assert.ExpectedError('Only for OnPrem environments. In SaaS environments use Entitlements.');
+    end;
+
+    [Test]
+    procedure TestGetLicenseDetails()
+    var
+        LicenseDetails: text;
+    begin
+        // [SCENARIO] Set the SaaS testability to false. GetLicense returns the license details.
+
+        // [Given] Environment is OnPrem
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(false);
+
+        // [When] Get license details
+        LicenseDetails := LicenseInformation.GetLicenseDetails();
+
+        // [Then] Should return true
+        Assert.IsTrue(LicenseDetails <> '', 'License details should not be empty.');
     end;
 }
 

--- a/Modules/System/Environment Information/permissions/EnvironmentInfoObjects.PermissionSet.al
+++ b/Modules/System/Environment Information/permissions/EnvironmentInfoObjects.PermissionSet.al
@@ -12,5 +12,7 @@ permissionset 417 "Environment Info. - Objects"
     Permissions = Codeunit "Environment Information Impl." = X,
                   Codeunit "Environment Information" = X,
                   Codeunit "Tenant Information Impl." = X,
-                  Codeunit "Tenant Information" = X;
+                  Codeunit "Tenant Information" = X,
+                  codeunit "License Information Impl." = X,
+                  codeunit "License Information" = X;
 }

--- a/Modules/System/Environment Information/src/LicenseInformation.Codeunit.al
+++ b/Modules/System/Environment Information/src/LicenseInformation.Codeunit.al
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+/// <summary>
+/// Exposes functionality to fetch details from the license uploaded to an OnPrem instance.
+/// </summary>
+codeunit 50000 "License Information"
+{
+    Access = Public;
+
+    var
+        LicenseInformationImpl: Codeunit "License Information Impl.";
+
+    /// <summary>
+    /// Gets the OnPrem license details from License Information table.
+    /// </summary>
+    /// <returns>If Environment is not OnPrem, an error is returned. Otherwise a text with the license details is returned.</returns>
+    procedure GetLicenseDetails(): Text
+    begin
+        exit(LicenseInformationImpl.GetLicenseDetails());
+    end;
+}
+

--- a/Modules/System/Environment Information/src/LicenseInformationImpl.Codeunit.al
+++ b/Modules/System/Environment Information/src/LicenseInformationImpl.Codeunit.al
@@ -1,0 +1,30 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+codeunit 50001 "License Information Impl."
+{
+    Access = Internal;
+
+    var
+        LicenseInformation: Record "License Information";
+        EnvironmentInformation: Codeunit "Environment Information";
+        OnSaaSError: Label 'Only for OnPrem environments. In SaaS environments use Entitlements.';
+
+    procedure GetLicenseDetails(): Text
+    var
+        LicenseDetailsBuilder: TextBuilder;
+    begin
+        if EnvironmentInformation.IsSaaS() then
+            Error(OnSaaSError);
+
+        LicenseInformation.FindSet();
+        repeat
+            LicenseDetailsBuilder.Append(LicenseInformation.Text);
+        until LicenseInformation.Next() = 0;
+
+        exit(LicenseDetailsBuilder.ToText());
+    end;
+}
+


### PR DESCRIPTION
We need a way of getting the license details stored on the License Information table while making our App universal code compliant.
This table is not accessible on SaaS, hence we propose this changes to be able to get license details for OnPrem environments.
It should be possible to reference this new codeunit on Apps where target = cloud, but it will only provide the details if the environment is OnPrem.