### PR TITLE
Update ApplicationUserSettings.Table.al

### DIFF
--- a/Modules/System/User Settings/src/ApplicationUserSettings.Table.al
+++ b/Modules/System/User Settings/src/ApplicationUserSettings.Table.al
@@ -8,7 +8,7 @@
 /// </summary>
 table 9222 "Application User Settings"
 {
-    Access = Internal;
+    Access = Public;
     DataPerCompany = false;
     ReplicateData = false;
 


### PR DESCRIPTION
Following the question on Yammer (https://www.yammer.com/dynamicsnavdev/#/threads/show?threadId=1796797239181312), we would like to be able to 'mass' update the 'Teaching Tips' for a given set of users. (Either via API, RapidStart, Code, ...) 

As the table is marked as 'Internal', we do not have access to it. Following the suggestion of @JesperSchulz, I hereby kindly ask to mark the table as 'Public'

The table 9222 "Application User Settings" is internal, meaning it cannot be accessed by the RapidStart tool. By default, we hide implementation details. If there's a need to be able to control data in that table through RapidStart, that table would have to be made external. The table is part of the "User Settings" module in the System Application. You are welcome to create a PR on GitHub with a suggestion to change the Access property. From top of mind, I don't see why we wouldn't accept that request - the requirement seems fair!