### PR TITLE
Add "Locked = true" to HttpHeader Labels

### DIFF
--- a/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
@@ -192,7 +192,7 @@ codeunit 9047 "ABS Optional Parameters"
     /// <param name="BytesEndValue">Integer value specifying the Bytes end range value</param>
     procedure Range(BytesStartValue: Integer; BytesEndValue: Integer)
     var
-        RangeBytesLbl: Label 'bytes=%1-%2', Comment = '%1 = Start Range; %2 = End Range';
+        RangeBytesLbl: Label 'bytes=%1-%2', Comment = '%1 = Start Range; %2 = End Range', Locked = true;
     begin
         SetRequestHeader('x-ms-range', StrSubstNo(RangeBytesLbl, BytesStartValue, BytesEndValue));
     end;
@@ -204,7 +204,7 @@ codeunit 9047 "ABS Optional Parameters"
     /// <param name="BytesEndValue">Integer value specifying the Bytes end range value</param>
     procedure SourceRange(BytesStartValue: Integer; BytesEndValue: Integer)
     var
-        RangeBytesLbl: Label 'bytes=%1-%2', Comment = '%1 = Start Range; %2 = End Range';
+        RangeBytesLbl: Label 'bytes=%1-%2', Comment = '%1 = Start Range; %2 = End Range', Locked = true;
     begin
         SetRequestHeader('x-ms-source-range', StrSubstNo(RangeBytesLbl, BytesStartValue, BytesEndValue));
     end;


### PR DESCRIPTION
In the module Azure Blob Service Api it is possible to set HTTP Header via the predefined codeunit "ABS Optional Parameters". When using the "Range" function, a label is used that does not have locked = true. This means that the translation is always used when setting the HTTP header. The problem is that in some XLF files the translation is different from the caption, so the HTTP request runs into an error. (e.g. in the German translation)