### PR TITLE
Clean up GP migration settings for any companies previously migrated

### DIFF
--- a/Apps/W1/HybridGP/app/src/pages/HybridCloudWizardExtension.PageExt.al
+++ b/Apps/W1/HybridGP/app/src/pages/HybridCloudWizardExtension.PageExt.al
@@ -73,9 +73,27 @@ pageextension 4014 "Hybrid Cloud Wizard Extension" extends "Hybrid Cloud Setup W
         {
             trigger OnAfterAction()
             begin
-                if Rec."Product ID" = 'DynamicsGP' then
+                if Rec."Product ID" = 'DynamicsGP' then begin
+                    CleanupSettingsForCompaniesPreviouslyMigrated();
                     Page.Run(Page::"GP Migration Configuration");
+                end;
             end;
         }
     }
+
+    local procedure CleanupSettingsForCompaniesPreviouslyMigrated()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        HybridCompany: Record "Hybrid Company";
+    begin
+        GPCompanyAdditionalSettings.SetFilter("Name", '<>%1', '');
+        if GPCompanyAdditionalSettings.FindSet() then
+            repeat
+                HybridCompany.SetRange(Name, GPCompanyAdditionalSettings.Name);
+                HybridCompany.SetRange(Replicate, false);
+
+                if not HybridCompany.IsEmpty() then
+                    GPCompanyAdditionalSettings.Delete();
+            until GPCompanyAdditionalSettings.Next() = 0;
+    end;
 }


### PR DESCRIPTION
Clean up the GP migration settings for companies that have already been migrated. This issue was found while going through a subsequent migration test for another company after a previously successful migration.