### PR TITLE
Skip running tests

### DIFF
--- a/Modules/.AL-Go/settings.json
+++ b/Modules/.AL-Go/settings.json
@@ -14,5 +14,6 @@
                     ],
     "artifact":  "//21.1/base/first",
     "enablePerTenantExtensionCop":  false,
-    "repoVersion":  "21.1"
+    "repoVersion":  "21.1",
+    "doNotRunTests": true
 }


### PR DESCRIPTION
Running tests is currently halting the runners and rendering CICD pipeline to fail.

Running tests will be re-enabled once the jobs are stable.