### PR TITLE
Fix SharePoint AcquireToken

### DIFF
--- a/Modules/System/SharePoint Authorization/src/AuthorizationCode/SharePointAuthorizationCode.Codeunit.al
+++ b/Modules/System/SharePoint Authorization/src/AuthorizationCode/SharePointAuthorizationCode.Codeunit.al
@@ -67,7 +67,7 @@ codeunit 9144 "SharePoint Authorization Code" implements "SharePoint Authorizati
         OnBeforeGetToken(IsHandled, IsSuccess, ErrorText, AccessToken);
 
         if not IsHandled then begin
-            OAuth2.AcquireTokenByAuthorizationCode(ClientId, ClientSecret, StrSubstNo(AuthorityTxt, AadTenantId), '', Scopes, "Prompt Interaction"::Login, AccessToken, AuthCodeErr);
+            IsSuccess := OAuth2.AcquireTokenByAuthorizationCode(ClientId, ClientSecret, StrSubstNo(AuthorityTxt, AadTenantId), '', Scopes, "Prompt Interaction"::None, AccessToken, AuthCodeErr);
 
             if not IsSuccess then
                 if AuthCodeErr <> '' then


### PR DESCRIPTION
- IsSuccess never received a value from OAuth2.AcquireTokenByAuthorizationCode.
- Changed "Prompt Interaction"::Login to "Prompt Interaction"::None. Otherwise, you always need to login again. Now, you can select an account already signed in.