### PR TITLE
Add new permission Types for SAS

### DIFF
--- a/Modules/System Tests/Azure Storage Services Authorization/src/StorServAccountSASTest.Codeunit.al
+++ b/Modules/System Tests/Azure Storage Services Authorization/src/StorServAccountSASTest.Codeunit.al
@@ -35,6 +35,7 @@ codeunit 132918 "Stor. Serv. Account SAS Test"
         Resources.Add(Enum::"SAS Resource Type"::Container);
         Permissions.Add(Enum::"SAS Permission"::Read);
         Permissions.Add(Enum::"SAS Permission"::Write);
+        Permissions.Add(Enum::"SAS Permission"::Tag);
 
         SASAuthorization := StorageServiceAuthorization.CreateAccountSAS(AccountKey, Enum::"Storage Service API Version"::"2020-10-02", Services, Resources, Permissions, ExpiryDate);
         SASAuthorization.Authorize(HttpRequest, StorageAccount);
@@ -48,7 +49,7 @@ codeunit 132918 "Stor. Serv. Account SAS Test"
 
         Assert.IsTrue(StrPos(NewUri, 'ss=b') > 0, 'SignedServices parameter is missing or is incorrect');
         Assert.IsTrue(StrPos(NewUri, 'srt=c') > 0, 'SignedResources parameter is missing or is incorrect');
-        Assert.IsTrue(StrPos(NewUri, 'sp=rw') > 0, 'SignedServices parameter is missing or is incorrect');
+        Assert.IsTrue(StrPos(NewUri, 'sp=rwt') > 0, 'SignedServices parameter is missing or is incorrect');
 
     end;
 

--- a/Modules/System/Azure Storage Services Authorization/src/SAS/SASPermission.Enum.al
+++ b/Modules/System/Azure Storage Services Authorization/src/SAS/SASPermission.Enum.al
@@ -56,4 +56,28 @@ enum 9064 "SAS Permission"
     {
         Caption = 'p', Locked = true;
     }
+
+    /// <summary>
+    /// Valid for the following Object resource type only: blobs. Permits blob tag operations.
+    /// </summary>
+    value(9; Tag)
+    {
+        Caption = 't', Locked = true;
+    }
+
+    /// <summary>
+    /// Valid for the following Object resource type only: blob. Permits filtering by blob tag.
+    /// </summary>
+    value(10; Filter)
+    {
+        Caption = 'f', Locked = true;
+    }
+
+    /// <summary>
+    /// Valid for the following Object resource type only: blob. Permits set/delete immutability policy and legal hold on a blob.
+    /// </summary>
+    value(11; "Set Immutability Policy")
+    {
+        Caption = 'i', Locked = true;
+    }
 }


### PR DESCRIPTION
I tried to add the missing permission types for SAS Authentication of the azure storage authentication.

Reference: https://learn.microsoft.com/en-us/rest/api/storageservices/create-account-sas#specify-the-account-sas-parameters