### PR TITLE
Copy filters on test suite update

### DIFF
--- a/Modules/DevTools/TestFramework/TestRunner/src/TestSuiteMgt.Codeunit.al
+++ b/Modules/DevTools/TestFramework/TestRunner/src/TestSuiteMgt.Codeunit.al
@@ -401,14 +401,14 @@ codeunit 130456 "Test Suite Mgt."
         TestMethodLine.SetRange("Test Codeunit", BackupTestMethodLine."Test Codeunit");
         TestMethodLine.SetRange(Name, BackupTestMethodLine.Name);
         if TestMethodLine.FindFirst() then begin
-            TestMethodLine.SetView(BackupTestMethodLine.GetView());
+            TestMethodLine.CopyFilters(BackupTestMethodLine);
             exit;
         end;
 
         TestMethodLine.SetRange(Name);
         if TestMethodLine.FindFirst() then;
 
-        TestMethodLine.SetView(BackupTestMethodLine.GetView());
+        TestMethodLine.CopyFilters(BackupTestMethodLine);
     end;
 
     local procedure PromptUserToSelectTestsToRun(TestMethodLine: Record "Test Method Line"): Integer


### PR DESCRIPTION
Action "Update Test Methods" in AL Test Tool resets filters on the page, mixing test codeunit from different suites

Steps to reproduce

Run AL Test Tool and pull a test codeunit into the Default test suite
Create another test suite and get a test codeunit
Run Update Test Methods action
Result: Test codeunits from all suites are displayed, page filters are lost.
Expected result: The action should keep the filters.

Issue: Functions GetView/SetView which are used to copy filters between record instances only pick filters in the active filter group (currently 0), while the suite filter is applied in group 2.
Solution: Use CopyFilters instead, which copies filters in all groups.