### PR TITLE
GP - Fix for POPPOHeader DateInvalid error

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOPPOHeader.table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOPPOHeader.table.al
@@ -387,7 +387,7 @@ table 40102 "GP POPPOHeader"
             Caption = 'EXCHDATE';
             DataClassification = CustomerContent;
         }
-        field(77; TIME1; Date)
+        field(77; TIME1; DateTime)
         {
             Caption = 'TIME1';
             DataClassification = CustomerContent;
@@ -787,6 +787,7 @@ table 40102 "GP POPPOHeader"
         PostingDescriptionTxt: Label 'Migrated from GP';
         PostingGroupTxt: Label 'GP', Locked = true;
 
+    [Obsolete('Logic moved to GP PO Migrator codeunit')]
     procedure MoveStagingData()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
@@ -828,7 +829,10 @@ table 40102 "GP POPPOHeader"
                     end;
 
                     PurchaseHeader.Modify(true);
+
+#pragma warning disable AL0432
                     GPPOPPOLine.MoveStagingData(PONUMBER);
+#pragma warning restore AL0432
                 end;
             until Next() = 0;
         end;

--- a/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOPPOLine.table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOPPOLine.table.al
@@ -555,6 +555,7 @@ table 40103 "GP POPPOLine"
     var
         PostingGroupTxt: Label 'GP', Locked = true;
 
+    [Obsolete('Logic moved to GP PO Migrator codeunit')]
     procedure MoveStagingData(PO_Number: Text[18])
     var
         PurchaseLine: Record "Purchase Line";


### PR DESCRIPTION
This change fixes an issue with the GP cloud migration. The POPPOHeader TIME1 field data type was Date, but is a DateTime in the GP database. When that column contained a time value, it would fail the migration.

This change also includes the missing Obsolete attributes that weren't merged from one of my last pull requests.