### PR TITLE
ItemJnlLine being intialized after the event

### DIFF
--- a/Apps/IN/INGST/app/GSTSubcontracting/src/Codeunit/SubcontractingPost.Codeunit.al
+++ b/Apps/IN/INGST/app/GSTSubcontracting/src/Codeunit/SubcontractingPost.Codeunit.al
@@ -99,9 +99,10 @@ codeunit 18466 "Subcontracting Post"
         TrackingQtyToHandle: Decimal;
         QuantitySent: Decimal;
     begin
-        OnBeforeSubcontractComponentSendPost(ItemJnlLine, DeliveryChallanHeader, SubOrderCompList);
-
         ItemJnlLine.Init();
+         
+        OnBeforeSubcontractComponentSendPost(ItemJnlLine, DeliveryChallanHeader, SubOrderCompList);
+        
         ItemJnlLine."Posting Date" := DeliveryChallanHeader."Challan Date";
         ItemJnlLine."Document Date" := DeliveryChallanHeader."Challan Date";
         ItemJnlLine."Source Type" := ItemJnlLine."Source Type"::Item;


### PR DESCRIPTION
If we populate anything in ItemJnlLine by subscribing to OnBeforeSubcontractComponentSendPost event, it is lost in the next line "ItemJnlLine.Init();".