### PR TITLE
FIX: correct PI

### DIFF
--- a/Modules/System/Math/src/Math.Codeunit.al
+++ b/Modules/System/Math/src/Math.Codeunit.al
@@ -19,7 +19,7 @@ codeunit 710 Math
     /// <returns>Value of pi.</returns>
     procedure Pi(): Decimal
     begin
-        exit(3.1415926535897932);
+        exit(DotnetMath.PI);
     end;
 
     /// <summary>
@@ -28,7 +28,7 @@ codeunit 710 Math
     /// <returns>Value of E.</returns>
     procedure E(): Decimal
     begin
-        exit(2.7182818284590451);
+        exit(DotnetMath.E);
     end;
 
     /// <summary>


### PR DESCRIPTION
looking at various sources, the 17th position should be 2, not 1, the following digits would be 3846.

https://decimal.info/digits-of-pi/value-of-pi-to-20-decimal-places.html http://www.math.com/tables/constants/pi.htm
https://www.piday.org/million/