### PR TITLE
Do not create build tags on forks

### DIFF
--- a/.github/workflows/CreateBuildTag.yaml
+++ b/.github/workflows/CreateBuildTag.yaml
@@ -26,7 +26,8 @@ jobs:
             });
 
             if(!allArtifacts) {
-              throw `Could not fetch artifacts from run ID ${context.payload.workflow_run.id}`
+              console.log(`Could not fetch artifacts from run ID ${context.payload.workflow_run.id}`)
+              return;
             }
 
             // Determine the build number, based on the apps artifact name
@@ -35,7 +36,8 @@ jobs:
             })[0];
 
             if(!appsArtifact) {
-              throw `Could not find apps artifact from run ID ${context.payload.workflow_run.id}`
+              console.log(`Could not find apps artifact from run ID ${context.payload.workflow_run.id}`)
+              return;
             }
 
             // The build number is after -Apps-

--- a/.github/workflows/CreateBuildTag.yaml
+++ b/.github/workflows/CreateBuildTag.yaml
@@ -10,7 +10,7 @@ run-name: Create build tag on branch ${{ github.ref_name }}.
 
 jobs:
   TagSuccessfulBuild:
-    if: github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'Microsoft'
+    if: github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'microsoft'
     runs-on: windows-latest
     steps:
       - name: Create version tag

--- a/.github/workflows/CreateBuildTag.yaml
+++ b/.github/workflows/CreateBuildTag.yaml
@@ -4,13 +4,13 @@ on:
   workflow_run:
     workflows: ['CI/CD']
     types: ['completed']
-    branches: [ 'main', 'release/*']
+    branches: ['main', 'release/*']
 
 run-name: Create build tag on branch ${{ github.ref_name }}.
 
 jobs:
   TagSuccessfulBuild:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'Microsoft'
     runs-on: windows-latest
     steps:
       - name: Create version tag


### PR DESCRIPTION
Issue: _CreateBuildTag_ workflow run after the CICD completed successfully. However, CICD works on PRs as well so _CreateBuildTag_ is running in the PR branch is also _main_ (from a fork). 

Solution: Limit the _TagSuccessfulBuild_ job to only run on the main repo.