### PR TITLE
Add documentation that filter tokens need to start with a % sign

### DIFF
--- a/Modules/System/Filter Tokens/README.md
+++ b/Modules/System/Filter Tokens/README.md
@@ -12,7 +12,7 @@ You can add more filter tokens by subscribing to the following events:
 - `OnResolveTimeTokenFromDateTimeFilter`
 
 > **Warning**  
-> Every filter token needs to start with a `%` sign as first charakter. Otherwise the events listed above might not get raised at all.
+> Every filter token needs to start with a `%` sign as first character. Otherwise, the events listed above will not get raised at all.
 
 # Public Objects
 ## Filter Tokens (Codeunit 41)

--- a/Modules/System/Filter Tokens/README.md
+++ b/Modules/System/Filter Tokens/README.md
@@ -11,6 +11,8 @@ You can add more filter tokens by subscribing to the following events:
 - `OnResolveDateTokenFromDateTimeFilter`
 - `OnResolveTimeTokenFromDateTimeFilter`
 
+> **Warning**  
+> Every filter token needs to start with a `%` sign as first charakter. Otherwise the events listed above might not get raised at all.
 
 # Public Objects
 ## Filter Tokens (Codeunit 41)

--- a/Modules/System/Filter Tokens/README.md
+++ b/Modules/System/Filter Tokens/README.md
@@ -24,7 +24,7 @@ You can add more filter tokens by subscribing to the following events:
 
  Turns text that represents date formats into a valid date filter expression with respect to filter tokens and date formulas.
  Call this function from onValidate trigger of page field that should behave similar to system filters.
- The text from which the date filter should be extracted passed as VAR. For example: "%YESTERDAY", or " 01-01-2012 ".
+ The text from which the date filter should be extracted passed as VAR. For example: "%YESTERDAY", or "01-01-2012".
 
 #### Syntax
 ```
@@ -33,7 +33,7 @@ procedure MakeDateFilter(var DateFilterText: Text)
 #### Parameters
 *DateFilterText ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
 
-The text from which the date filter should be extracted passed as VAR. For example: "%YESTERDAY", or " 01-01-2012 ".
+The text from which the date filter should be extracted passed as VAR. For example: "%YESTERDAY", or "01-01-2012".
 
 ### MakeTimeFilter (Method) <a name="MakeTimeFilter"></a> 
 

--- a/Modules/System/Filter Tokens/README.md
+++ b/Modules/System/Filter Tokens/README.md
@@ -24,7 +24,7 @@ You can add more filter tokens by subscribing to the following events:
 
  Turns text that represents date formats into a valid date filter expression with respect to filter tokens and date formulas.
  Call this function from onValidate trigger of page field that should behave similar to system filters.
- The text from which the date filter should be extracted passed as VAR. For example: "YESTERDAY", or " 01-01-2012 ".
+ The text from which the date filter should be extracted passed as VAR. For example: "%YESTERDAY", or " 01-01-2012 ".
 
 #### Syntax
 ```
@@ -33,7 +33,7 @@ procedure MakeDateFilter(var DateFilterText: Text)
 #### Parameters
 *DateFilterText ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
 
-The text from which the date filter should be extracted passed as VAR. For example: "YESTERDAY", or " 01-01-2012 ".
+The text from which the date filter should be extracted passed as VAR. For example: "%YESTERDAY", or " 01-01-2012 ".
 
 ### MakeTimeFilter (Method) <a name="MakeTimeFilter"></a> 
 
@@ -48,7 +48,7 @@ procedure MakeTimeFilter(var TimeFilterText: Text)
 #### Parameters
 *TimeFilterText ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
 
-The text from which the time filter should be extracted, passed as VAR. For example: "NOW".
+The text from which the time filter should be extracted, passed as VAR. For example: "%NOW".
 
 ### MakeTextFilter (Method) <a name="MakeTextFilter"></a> 
 
@@ -63,7 +63,7 @@ procedure MakeTextFilter(var TextFilter: Text)
 #### Parameters
 *TextFilter ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
 
-The expression from which the text filter should be extracted, passed as VAR. For example: "ME".
+The expression from which the text filter should be extracted, passed as VAR. For example: "%ME".
 
 ### MakeDateTimeFilter (Method) <a name="MakeDateTimeFilter"></a> 
 
@@ -78,11 +78,11 @@ procedure MakeDateTimeFilter(var DateTimeFilterText: Text)
 #### Parameters
 *DateTimeFilterText ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
 
-The text from which the date and time should be extracted, passed as VAR. For example: "NOW" or "01-01-2012 11:11:11..NOW".
+The text from which the date and time should be extracted, passed as VAR. For example: "%NOW" or "01-01-2012 11:11:11..NOW".
 
 ### OnResolveDateFilterToken (Event) <a name="OnResolveDateFilterToken"></a> 
 
- Use this event if you want to add support for additional tokens that user will be able to use when working with date filters, for example "Christmas" or "StoneAge".
+ Use this event if you want to add support for additional tokens that user will be able to use when working with date filters, for example "%Christmas" or "%StoneAge".
  Ensure that in your subscriber you check that what user entered contains your keyword, then return proper date range for your filter token.
  
 
@@ -94,7 +94,7 @@ internal procedure OnResolveDateFilterToken(DateToken: Text; var FromDate: Date;
 #### Parameters
 *DateToken ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
 
-The date token to resolve, for example: "Summer".
+The date token to resolve, for example: "%Summer".
 
 *FromDate ([Date](https://go.microsoft.com/fwlink/?linkid=2210124))* 
 
@@ -134,7 +134,7 @@ Stores whether the operation was successful.
 
 ### OnResolveTimeFilterToken (Event) <a name="OnResolveTimeFilterToken"></a> 
 
- Use this event if you want to add support for additional filter tokens that user will be able to use when working with time filters, for example "Lunch".
+ Use this event if you want to add support for additional filter tokens that user will be able to use when working with time filters, for example "%Lunch".
  Ensure that in your subscriber you check that what user entered contains your token, then return properly formatted time for your filter token.
  
 
@@ -146,7 +146,7 @@ internal procedure OnResolveTimeFilterToken(TimeToken: Text; var TimeFilter: Tim
 #### Parameters
 *TimeToken ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
 
-The time token to resolve, for example: "Lunch".
+The time token to resolve, for example: "%Lunch".
 
 *TimeFilter ([Time](https://go.microsoft.com/fwlink/?linkid=2209849))* 
 
@@ -170,7 +170,7 @@ internal procedure OnResolveDateTokenFromDateTimeFilter(DateToken: Text; var Dat
 #### Parameters
 *DateToken ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
 
-The date token to resolve, for example: "Christmas".
+The date token to resolve, for example: "%Christmas".
 
 *DateFilter ([Date](https://go.microsoft.com/fwlink/?linkid=2210124))* 
 
@@ -194,7 +194,7 @@ internal procedure OnResolveTimeTokenFromDateTimeFilter(TimeToken: Text; var Tim
 #### Parameters
 *TimeToken ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
 
-The time token to resolve, for example: "Lunch".
+The time token to resolve, for example: "%Lunch".
 
 *TimeFilter ([Time](https://go.microsoft.com/fwlink/?linkid=2209849))* 
 

--- a/Modules/System/Filter Tokens/src/FilterTokens.Codeunit.al
+++ b/Modules/System/Filter Tokens/src/FilterTokens.Codeunit.al
@@ -14,12 +14,12 @@ codeunit 41 "Filter Tokens"
     var
         FilterTokensImpl: Codeunit "Filter Tokens Impl.";
 
-        /// <summary>
-        /// Turns text that represents date formats into a valid date filter expression with respect to filter tokens and date formulas.
-        /// Call this function from onValidate trigger of page field that should behave similar to system filters.
-        /// The leading '%' sign in the filter token is mandatory in order to have all event raised properly!
-        /// <param name="DateFilterText">The text from which the date filter should be extracted passed as VAR. For example: "%YESTERDAY", or " 01-01-2012 ".</param>
-        /// </summary>
+    /// <summary>
+    /// Turns text that represents date formats into a valid date filter expression with respect to filter tokens and date formulas.
+    /// Call this function from onValidate trigger of page field that should behave similar to system filters.
+    /// The leading '%' sign in the filter token is mandatory in order to have all event raised properly!
+    /// <param name="DateFilterText">The text from which the date filter should be extracted passed as VAR. For example: "%YESTERDAY", or "01-01-2012".</param>
+    /// </summary>
     procedure MakeDateFilter(var DateFilterText: Text)
     begin
         FilterTokensImpl.MakeDateFilter(DateFilterText);

--- a/Modules/System/Filter Tokens/src/FilterTokens.Codeunit.al
+++ b/Modules/System/Filter Tokens/src/FilterTokens.Codeunit.al
@@ -17,7 +17,8 @@ codeunit 41 "Filter Tokens"
         /// <summary>
         /// Turns text that represents date formats into a valid date filter expression with respect to filter tokens and date formulas.
         /// Call this function from onValidate trigger of page field that should behave similar to system filters.
-        /// <param name="DateFilterText">The text from which the date filter should be extracted passed as VAR. For example: "YESTERDAY", or " 01-01-2012 ".</param>
+        /// The leading '%' sign in the filter token is mandatory in order to have all event raised properly!
+        /// <param name="DateFilterText">The text from which the date filter should be extracted passed as VAR. For example: "%YESTERDAY", or " 01-01-2012 ".</param>
         /// </summary>
     procedure MakeDateFilter(var DateFilterText: Text)
     begin
@@ -27,8 +28,9 @@ codeunit 41 "Filter Tokens"
     /// <summary>
     /// Turns text that represents a time into a valid time filter with respect to filter tokens.
     /// Call this function from onValidate trigger of page field that should behave similar to system filters.
+    /// The leading '%' sign in the filter token is mandatory in order to have all event raised properly!
     /// </summary>
-    /// <param name="TimeFilterText">The text from which the time filter should be extracted, passed as VAR. For example: "NOW".</param>
+    /// <param name="TimeFilterText">The text from which the time filter should be extracted, passed as VAR. For example: "%NOW".</param>
     procedure MakeTimeFilter(var TimeFilterText: Text)
     begin
         FilterTokensImpl.MakeTimeFilter(TimeFilterText);
@@ -37,8 +39,9 @@ codeunit 41 "Filter Tokens"
     /// <summary>
     /// Turns text into a valid text filter with respect to filter tokens.
     /// Call this function from onValidate trigger of page field that should behave similar to system filters.
+    /// The leading '%' sign in the filter token is mandatory in order to have all event raised properly!
     /// </summary>
-    /// <param name="TextFilter">The expression from which the text filter should be extracted, passed as VAR. For example: "ME".</param>
+    /// <param name="TextFilter">The expression from which the text filter should be extracted, passed as VAR. For example: "%ME".</param>
     procedure MakeTextFilter(var TextFilter: Text)
     begin
         FilterTokensImpl.MakeTextFilter(TextFilter);
@@ -47,18 +50,20 @@ codeunit 41 "Filter Tokens"
     /// <summary>
     /// Turns text that represents a DateTime into a valid date and time filter with respect to filter tokens.
     /// Call this function from onValidate trigger of page field that should behave similar to system filters.
+    /// The leading '%' sign in the filter token is mandatory in order to have all event raised properly!
     /// </summary>
-    /// <param name="DateTimeFilterText">The text from which the date and time should be extracted, passed as VAR. For example: "NOW" or "01-01-2012 11:11:11..NOW".</param>
+    /// <param name="DateTimeFilterText">The text from which the date and time should be extracted, passed as VAR. For example: "%NOW" or "01-01-2012 11:11:11..NOW".</param>
     procedure MakeDateTimeFilter(var DateTimeFilterText: Text)
     begin
         FilterTokensImpl.MakeDateTimeFilter(DateTimeFilterText);
     end;
 
     /// <summary>
-    /// Use this event if you want to add support for additional tokens that user will be able to use when working with date filters, for example "Christmas" or "StoneAge".
+    /// Use this event if you want to add support for additional tokens that user will be able to use when working with date filters, for example "%Christmas" or "%StoneAge".
     /// Ensure that in your subscriber you check that what user entered contains your keyword, then return proper date range for your filter token.
+    /// The leading '%' sign in the filter token is mandatory in order to have all event raised properly!
     /// </summary>
-    /// <param name="DateToken">The date token to resolve, for example: "Summer".</param>
+    /// <param name="DateToken">The date token to resolve, for example: "%Summer".</param>
     /// <param name="FromDate">The start date to resolve from DateToken that the filter will use, for example: "01/06/2019". Passed by reference by using VAR keywords.</param>
     /// <param name="ToDate">The end date to resolve from DateToken that the filter will use, for example: "31/08/2019". Passed by reference by using VAR keywords.</param>
     /// <param name="Handled">Stores whether the operation was successful.</param>
@@ -68,8 +73,9 @@ codeunit 41 "Filter Tokens"
     end;
 
     /// <summary>
-    /// Use this event if you want to add support for additional filter tokens that user will be able to use when working with text or code filters, for example "MyFilter".
+    /// Use this event if you want to add support for additional filter tokens that user will be able to use when working with text or code filters, for example "%MyFilter".
     /// Ensure that in your subscriber you check that what user entered contains your token, then return properly formatted text for your filter token.
+    /// The leading '%' sign in the filter token is mandatory in order to have all event raised properly!
     /// </summary>
     /// <param name="TextToken">The text token to resolve.</param>
     /// <param name="TextFilter">The text to translate into a properly formatted text filter.</param>
@@ -80,10 +86,11 @@ codeunit 41 "Filter Tokens"
     end;
 
     /// <summary>
-    /// Use this event if you want to add support for additional filter tokens that user will be able to use when working with time filters, for example "Lunch".
+    /// Use this event if you want to add support for additional filter tokens that user will be able to use when working with time filters, for example "%Lunch".
     /// Ensure that in your subscriber you check that what user entered contains your token, then return properly formatted time for your filter token.
+    /// The leading '%' sign in the filter token is mandatory in order to have all event raised properly!
     /// </summary>
-    /// <param name="TimeToken">The time token to resolve, for example: "Lunch".</param>
+    /// <param name="TimeToken">The time token to resolve, for example: "%Lunch".</param>
     /// <param name="TimeFilter">The text to translate into a properly formatted time filter, for example: "12:00:00".</param>
     /// <param name="Handled">Stores whether the operation was successful.</param>
     [IntegrationEvent(false, false)]
@@ -94,8 +101,9 @@ codeunit 41 "Filter Tokens"
     /// <summary>
     /// Use this event if you want to add support for additional filter tokens that user will be able to use as date in DateTime filters.
     /// Parses and translates a date token into a date filter.
+    /// The leading '%' sign in the filter token is mandatory in order to have all event raised properly!
     /// </summary>
-    /// <param name="DateToken">The date token to resolve, for example: "Christmas".</param>
+    /// <param name="DateToken">The date token to resolve, for example: "%Christmas".</param>
     /// <param name="DateFilter">The text to translate into a properly formatted date filter, for example: "25/12/2019".</param>
     /// <param name="Handled">Stores whether the operation was successful.</param>
     [IntegrationEvent(false, false)]


### PR DESCRIPTION
I just struggled a few hours with the filter tokens for a code field. 

It seems like the filter token event implementation on the service it self is not consistent with how the events are raised.

For Date fields it works if the filter token is just some string.
But for Code/Text fields the events are not raised when the filter token does not start with a `%` sign.

I added this note to all procedure documentation and at the top of the readme to save this time for others :)