### PR TITLE
Fix localDevEnv: Do not skip user creation

### DIFF
--- a/Modules/.AL-Go/NewBcContainer.ps1
+++ b/Modules/.AL-Go/NewBcContainer.ps1
@@ -10,9 +10,6 @@ if ("$env:GITHUB_RUN_ID" -eq "") {
     $parameters.shortcuts = "none"
 }
 
-$parameters.myscripts = @( @{ "SetupNavUsers.ps1" = "Write-Host 'Skipping user creation'" } )
-$parameters.auth = 'Windows'
-
 New-BcContainer @parameters
 
 $installedApps = Get-BcContainerAppInfo -containerName $containerName -tenantSpecificProperties -sort DependenciesLast


### PR DESCRIPTION
Users were not created and the container auth was set to _Windows_ in order for the tests to pass.

However, using _Windows_ auth with no users causes issues when setting up local dev environment.
Fixing the tests will be addressed separately.