### PR TITLE
Intrastat breaks when a Posted Document is deleted

### DIFF
--- a/Apps/W1/Intrastat/app/src/IntrastatReportManagement.Codeunit.al
+++ b/Apps/W1/Intrastat/app/src/IntrastatReportManagement.Codeunit.al
@@ -47,8 +47,7 @@ codeunit 4810 IntrastatReportManagement
 
         case ItemLedgEntry."Document Type" of
             ItemLedgEntry."Document Type"::"Sales Shipment":
-                begin
-                    SalesShptHeader.Get(ItemLedgEntry."Document No.");
+                if SalesShptHeader.Get(ItemLedgEntry."Document No.") then
                     case IntrastatReportSetup."Shipments Based On" of
                         IntrastatReportSetup."Shipments Based On"::"Ship-to Country":
                             CountryCode := SalesShptHeader."Ship-to Country/Region Code";
@@ -57,10 +56,8 @@ codeunit 4810 IntrastatReportManagement
                         IntrastatReportSetup."Shipments Based On"::"Bill-to Country":
                             CountryCode := SalesShptHeader."Bill-to Country/Region Code";
                     end;
-                end;
             ItemLedgEntry."Document Type"::"Sales Return Receipt":
-                begin
-                    ReturnRcptHeader.Get(ItemLedgEntry."Document No.");
+                if ReturnRcptHeader.Get(ItemLedgEntry."Document No.") then
                     case IntrastatReportSetup."Shipments Based On" of
                         IntrastatReportSetup."Shipments Based On"::"Ship-to Country":
                             CountryCode := ReturnRcptHeader."Sell-to Country/Region Code";
@@ -69,10 +66,8 @@ codeunit 4810 IntrastatReportManagement
                         IntrastatReportSetup."Shipments Based On"::"Bill-to Country":
                             CountryCode := ReturnRcptHeader."Bill-to Country/Region Code";
                     end;
-                end;
             ItemLedgEntry."Document Type"::"Purchase Receipt":
-                begin
-                    PurchRcptHeader.Get(ItemLedgEntry."Document No.");
+                if PurchRcptHeader.Get(ItemLedgEntry."Document No.") then
                     case IntrastatReportSetup."Shipments Based On" of
                         IntrastatReportSetup."Shipments Based On"::"Ship-to Country":
                             CountryCode := PurchRcptHeader."Buy-from Country/Region Code";
@@ -81,10 +76,8 @@ codeunit 4810 IntrastatReportManagement
                         IntrastatReportSetup."Shipments Based On"::"Bill-to Country":
                             CountryCode := PurchRcptHeader."Pay-to Country/Region Code";
                     end;
-                end;
             ItemLedgEntry."Document Type"::"Purchase Return Shipment":
-                begin
-                    ReturnShptHeader.Get(ItemLedgEntry."Document No.");
+                if ReturnShptHeader.Get(ItemLedgEntry."Document No.") then
                     case IntrastatReportSetup."Shipments Based On" of
                         IntrastatReportSetup."Shipments Based On"::"Ship-to Country":
                             CountryCode := ReturnShptHeader."Ship-to Country/Region Code";
@@ -93,7 +86,6 @@ codeunit 4810 IntrastatReportManagement
                         IntrastatReportSetup."Shipments Based On"::"Bill-to Country":
                             CountryCode := ReturnShptHeader."Pay-to Country/Region Code";
                     end;
-                end;
         end;
     end;
 


### PR DESCRIPTION
Intrastat Module Codeunit first gets the Country/Region Code from the Item Ledger Entry as it used to do in the past when the app didn't exist.

However, now, based on the setup, it tries to update the country and re-read from the corresponding Posted Document, based on the setup field.

The problem is, BC allows you to delete those documents. Therefore, to use a Get without an if statements makes the Codeunit to break if the document doesn't exist anymore. Not only that, but there is no way to fix this functionally.

As a solution, BC needs to only update the country if it can find the document.

Also this logic is also executed in the functions for FA Ledger Entries and Job Ledger Entries