### PR TITLE
Add reference to Signed XML method

### DIFF
--- a/Modules/System/Cryptography Management/README.md
+++ b/Modules/System/Cryptography Management/README.md
@@ -2118,7 +2118,16 @@ procedure AddXmlDsigExcC14NTransformToReference()
 
 #### Syntax
 ```
-procedure AddXmlDsigEnvelopedSignatureTransform()
+procedure AddReferenceToSignedXML()
+```
+### AddReferenceToSignedXML (Method) <a name="AddReferenceToSignedXML"></a> 
+
+ Adds a Reference object to the Signed XML and clears Reference object.
+ 
+
+#### Syntax
+```
+procedure AddReferenceToSignedXML()
 ```
 ### ComputeSignature (Method) <a name="ComputeSignature"></a> 
 

--- a/Modules/System/Cryptography Management/README.md
+++ b/Modules/System/Cryptography Management/README.md
@@ -2118,7 +2118,7 @@ procedure AddXmlDsigExcC14NTransformToReference()
 
 #### Syntax
 ```
-procedure AddReferenceToSignedXML()
+procedure AddXmlDsigEnvelopedSignatureTransform()
 ```
 ### AddReferenceToSignedXML (Method) <a name="AddReferenceToSignedXML"></a> 
 

--- a/Modules/System/Cryptography Management/src/Xml/SignedXml.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/Xml/SignedXml.Codeunit.al
@@ -183,7 +183,13 @@ codeunit 1460 SignedXml
     begin
         SignedXmlImpl.AddXmlDsigEnvelopedSignatureTransform();
     end;
-
+    /// <summary>
+    /// Adds a Reference object to the Signed XML and clears Reference object
+    /// </summary>
+    procedure AddReferenceToSignedXML()
+    begin
+        SignedXmlImpl.AddReferenceToSignedXML();
+    end;
     /// <summary>
     /// Computes an Xml digital signature from Xml document.
     /// </summary>

--- a/Modules/System/Cryptography Management/src/Xml/SignedXmlImpl.Codeunit.al
+++ b/Modules/System/Cryptography Management/src/Xml/SignedXmlImpl.Codeunit.al
@@ -69,6 +69,16 @@ codeunit 1461 "SignedXml Impl."
         DotNetXmlDsigEnvelopedSignatureTransform := DotNetXmlDsigEnvelopedSignatureTransform.XmlDsigEnvelopedSignatureTransform();
         DotNetReference.AddTransform(DotNetXmlDsigEnvelopedSignatureTransform);
     end;
+
+    procedure AddReferenceToSignedXML()
+    begin
+        if IsNull(DotNetReference) then
+            exit;
+
+        DotNetSignedXml.AddReference(DotNetReference);
+
+        Clear(DotNetReference);
+    end;
     #endregion
 
     #region SignedInfo


### PR DESCRIPTION
Added method AddReferenceToSignedXML.
Gives us possibility to add multiple reference to Signed XML object.