### PR TITLE
[DRAFT] SharePoint Client Credentials Grant Flow

### DIFF
--- a/Modules/System/SharePoint Authorization/src/AuthorizationCode/SharePointClientCredentials.Codeunit.al
+++ b/Modules/System/SharePoint Authorization/src/AuthorizationCode/SharePointClientCredentials.Codeunit.al
@@ -1,0 +1,85 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+codeunit 9145 "SharePoint Client Credentials" implements "SharePoint Authorization"
+{
+    Access = Internal;
+
+    var
+        [NonDebuggable]
+        ClientId: Text;
+        [NonDebuggable]
+        Certificate: Text;
+        [NonDebuggable]
+        AuthCodeErr: Text;
+        [NonDebuggable]
+        AadTenantId: Text;
+        [NonDebuggable]
+        Scopes: List of [Text];
+        AuthorityTxt: Label 'https://login.microsoftonline.com/%1/oauth2/v2.0/authorize', Comment = '%1 = AAD tenant ID', Locked = true;
+        BearerTxt: Label 'Bearer %1', Comment = '%1 - Token', Locked = true;
+
+    [NonDebuggable]
+    procedure SetParameters(NewAadTenantId: Text; NewClientId: Text; NewCertificate: Text; NewScopes: List of [Text])
+    begin
+        AadTenantId := NewAadTenantId;
+        ClientId := NewClientId;
+        Certificate := NewCertificate;
+        Scopes := NewScopes;
+    end;
+
+    [NonDebuggable]
+    procedure Authorize(var HttpRequestMessage: HttpRequestMessage);
+    var
+        Headers: HttpHeaders;
+    begin
+        HttpRequestMessage.GetHeaders(Headers);
+        Headers.Add('Authorization', StrSubstNo(BearerTxt, GetToken()));
+    end;
+
+    [NonDebuggable]
+    local procedure GetToken(): Text
+    var
+        ErrorText: Text;
+        [NonDebuggable]
+        AccessToken: Text;
+    begin
+        if not AcquireToken(AccessToken, ErrorText) then
+            Error(ErrorText);
+        exit(AccessToken);
+    end;
+
+    [NonDebuggable]
+    local procedure AcquireToken(var AccessToken: Text; var ErrorText: Text): Boolean
+    var
+        OAuth2: Codeunit OAuth2;
+        FailedErr: Label 'Failed to retrieve an access token.';
+        IsHandled, IsSuccess : Boolean;
+        IdToken: Text;
+    begin
+        OnBeforeGetToken(IsHandled, IsSuccess, ErrorText, AccessToken);
+        ClearLastError();
+
+        if not IsHandled then begin
+            if (not OAuth2.AcquireTokensFromCacheWithCertificate(ClientId, Certificate, '', StrSubstNo(AuthorityTxt, AadTenantId), Scopes, AccessToken, IdToken)) or (AccessToken = '') then
+                OAuth2.AcquireTokensWithCertificate(ClientId, Certificate, '', StrSubstNo(AuthorityTxt, AadTenantId), Scopes, AccessToken, IdToken);
+
+            IsSuccess := AccessToken <> '';
+
+            if not IsSuccess then begin
+                ErrorText := GetLastErrorText();
+                if ErrorText = '' then
+                    ErrorText := FailedErr;
+            end;
+        end;
+
+        exit(IsSuccess);
+    end;
+
+    [InternalEvent(false, true)]
+    local procedure OnBeforeGetToken(var IsHandled: Boolean; var IsSuccess: Boolean; var ErrorText: Text; var AccessToken: Text)
+    begin
+    end;
+}

--- a/Modules/System/SharePoint Authorization/src/SharePointAuth.Codeunit.al
+++ b/Modules/System/SharePoint Authorization/src/SharePointAuth.Codeunit.al
@@ -42,4 +42,37 @@ codeunit 9142 "SharePoint Auth."
     begin
         exit(SharePointAuthImpl.CreateAuthorizationCode(AadTenantId, ClientId, ClientSecret, Scopes));
     end;
+
+    /// <summary>
+    /// Creates an authorization mechanism with the Client Credentials Grant Flow.
+    /// </summary>
+    /// <param name="AadTenantId">Azure Active Directory tenant ID</param>
+    /// <param name="ClientId">The Application (client) ID that the Azure portal - App registrations experience assigned to your app.</param>        
+    /// <param name="Certificate">The Base64-encoded certificate for the Application (client) configured in the Azure Portal - Certificates &amp; Secrets.</param>
+    /// <param name="Scope">A scope that you want the user to consent to.</param>
+    /// <returns>Codeunit instance implementing authorization interface</returns>
+    [NonDebuggable]
+    procedure CreateClientCredentials(AadTenantId: Text; ClientId: Text; Certificate: Text; Scope: Text): Interface "SharePoint Authorization";
+    var
+        Scopes: List of [Text];
+    begin
+        Scopes.Add(Scope);
+        exit(CreateAuthorizationCode(AadTenantId, ClientId, Certificate, Scopes));
+    end;
+
+    /// <summary>
+    /// Creates an authorization mechanism with the Client Credentials Grant Flow.
+    /// </summary>
+    /// <param name="AadTenantId">Azure Active Directory tenant ID</param>
+    /// <param name="ClientId">The Application (client) ID that the Azure portal - App registrations experience assigned to your app.</param>        
+    /// <param name="Certificate">The Base64-encoded certificate for the Application (client) configured in the Azure Portal - Certificates &amp; Secrets.</param>
+    /// <param name="Scopes">A list of scopes that you want the user to consent to.</param>
+    /// <returns>Codeunit instance implementing authorization interface</returns>
+    [NonDebuggable]
+    procedure CreateClientCredentials(AadTenantId: Text; ClientId: Text; Certificate: Text; Scopes: List of [Text]): Interface "SharePoint Authorization";
+    var
+        SharePointAuthImpl: Codeunit "SharePoint Auth. - Impl.";
+    begin
+        exit(SharePointAuthImpl.CreateAuthorizationCode(AadTenantId, ClientId, Certificate, Scopes));
+    end;
 }

--- a/Modules/System/SharePoint Authorization/src/SharePointAuthImpl.Codeunit.al
+++ b/Modules/System/SharePoint Authorization/src/SharePointAuthImpl.Codeunit.al
@@ -15,4 +15,13 @@ codeunit 9143 "SharePoint Auth. - Impl."
         SharePointAuthorizationCode.SetParameters(AadTenantId, ClientId, ClientSecret, Scopes);
         exit(SharePointAuthorizationCode);
     end;
+
+    [NonDebuggable]
+    procedure CreateClientCredentials(AadTenantId: Text; ClientId: Text; Certificate: Text; Scopes: List of [Text]): Interface "SharePoint Authorization";
+    var
+        SharePointClientCredentials: Codeunit "SharePoint Client Credentials";
+    begin
+        SharePointClientCredentials.SetParameters(AadTenantId, ClientId, Certificate, Scopes);
+        exit(SharePointClientCredentials);
+    end;
 }


### PR DESCRIPTION
This is a draft PR just to show that we are working on this topic.

Since the OAuth2 module does not yet support password protected certificates, I don't think we want to publish this PR just yet.
Support for password protected certificates are requested in #22261.

Missing pieces (at least):
- More manual tests
- Add certificate password when #22261 is implemented
- Tests
- Updated README