### PR TITLE
Bug: multiple versions of Guided Experience Items displayed

### DIFF
--- a/Modules/System/Guided Experience/src/Guided Experience/GuidedExperienceImpl.Codeunit.al
+++ b/Modules/System/Guided Experience/src/Guided Experience/GuidedExperienceImpl.Codeunit.al
@@ -532,6 +532,7 @@ codeunit 1991 "Guided Experience Impl."
         InsertItem: Boolean;
     begin
         repeat
+            InsertItem := false;
             if (GuidedExperienceItem."Object Type to Run" <> PrevGuidedExperienceItem."Object Type to Run")
                 or (GuidedExperienceItem."Object ID to Run" <> PrevGuidedExperienceItem."Object ID to Run")
                 or (GuidedExperienceItem.Link <> PrevGuidedExperienceItem.Link)
@@ -544,10 +545,10 @@ codeunit 1991 "Guided Experience Impl."
                 (GuidedExperienceItem."Guided Experience Type" = PrevGuidedExperienceItem."Guided Experience Type")
             then
                 if (GuidedExperienceItem."Title" <> PrevGuidedExperienceItem."Title")
-                or (GuidedExperienceItem.Description <> PrevGuidedExperienceItem.Description)
-                or (GuidedExperienceItem."Video Url" <> PrevGuidedExperienceItem."Video Url")
-                or (GuidedExperienceItem."Video Category" <> PrevGuidedExperienceItem."Video Category")
-            then
+                    or (GuidedExperienceItem.Description <> PrevGuidedExperienceItem.Description)
+                    or (GuidedExperienceItem."Video Url" <> PrevGuidedExperienceItem."Video Url")
+                    or (GuidedExperienceItem."Video Category" <> PrevGuidedExperienceItem."Video Category")
+                then
                     InsertItem := true;
 
             if InsertItem then


### PR DESCRIPTION
When multiple versions of Guided Experience Items exist then all versions are displayd in pages. E.g. Title in Guided Experience Type of Assisted Setup has been update and new Guided Exp. Item with same Code but with Version 1 is created. When user opens the Assisted Setup page the temporary table is populated and all versions is added.

Solution:
InsertItem variable is initialized to false in every pass in loop over Guided Experience Items before evaluating if item should be added to temp table.