### PR TITLE
Updated AL-Go System Files

### DIFF
--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -9,6 +9,16 @@ Note that when using the preview version of AL-Go for GitHub, you need to Update
 In v2.4 and earlier, the PullRequestHandler would trigger the CI/CD workflow to run the PR build.
 Now, the PullRequestHandler will perform the build and the CI/CD workflow is only run on push (or manual dispatch)
 
+### Build modes per project
+Build modes can now be specified per project
+
+### _DetermineProjectsToBuild_ action
+A new action has been added to determine the projects to build.
+
+The functionality was stripped from _ReadSettings_ action.
+
+Note that if `useProjectDependencies` is set to `true`, you may need to run _Update AL-Go System Files_ workflow twice.
+
 ## v2.4
 
 ### Issues

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -64,19 +64,7 @@ jobs:
         uses: mazhelez/AL-Go-Actions/DetermineProjectsToBuild@separate-load-projects
         with:
           shell: powershell
-
-      - name: Verify workflow depth
-        id: verifyWorkflowDepth
-        run: |
-          $ErrorActionPreference = "STOP"
-          Set-StrictMode -version 2.0
-          $buildOrder = '${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}' | ConvertFrom-Json
-          $buildDepth = $buildOrder.Count
-          $workflowDepth = ${{ env.workflowDepth }}
-          if ($buildDepth -gt $workflowDepth) {
-            Write-Host "::Error::Project Dependencies depth is $buildDepth. Workflow is only setup for $workflowDepth. You need to Run Update AL-Go System Files to update the workflows"
-            $host.SetShouldExit(1)
-          }
+          maxBuildDepth: ${{ env.workflowDepth }}
 
       - name: Determine Delivery Target Secrets
         id: DetermineDeliveryTargetSecrets

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -78,19 +78,7 @@ jobs:
         uses: mazhelez/AL-Go-Actions/DetermineProjectsToBuild@separate-load-projects
         with:
           shell: powershell
-
-      - name: Verify workflow depth
-        id: verifyWorkflowDepth
-        run: |
-          $ErrorActionPreference = "STOP"
-          Set-StrictMode -version 2.0
-          $buildOrder = '${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}' | ConvertFrom-Json
-          $buildDepth = $buildOrder.Count
-          $workflowDepth = ${{ env.workflowDepth }}
-          if ($buildDepth -gt $workflowDepth) {
-            Write-Host "::Error::Project Dependencies depth is $buildDepth. Workflow is only setup for $workflowDepth. You need to Run Update AL-Go System Files to update the workflows"
-            $host.SetShouldExit(1)
-          }
+          maxBuildDepth: ${{ env.workflowDepth }}
 
   Build1:
     needs: [ Initialization ]


### PR DESCRIPTION
## Preview

Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.

### Issues
- Issue [#391](https://github.com/microsoft/AL-Go/issues/391) Create release action - CreateReleaseBranch error

### Changes to Pull Request Process
In v2.4 and earlier, the PullRequestHandler would trigger the CI/CD workflow to run the PR build.
Now, the PullRequestHandler will perform the build and the CI/CD workflow is only run on push (or manual dispatch)

### Build modes per project
Build modes can now be specified per project

### _DetermineProjectsToBuild_ action
A new action has been added to determine the projects to build.

The functionality was stripped from _ReadSettings_ action.

Note that if `useProjectDependencies` is set to `true`, you may need to run _Update AL-Go System Files_ workflow twice.
