### PR TITLE
SharePoint.DownloadFileContent() overloads

### DIFF
--- a/Modules/System/SharePoint/src/SharePointClient.Codeunit.al
+++ b/Modules/System/SharePoint/src/SharePointClient.Codeunit.al
@@ -258,17 +258,6 @@ codeunit 9100 "SharePoint Client"
     end;
 
     /// <summary>
-    /// Downloads a file to the client.
-    /// </summary>
-    /// <param name="OdataId">The odata.id parameter of the file entity.</param>
-    /// <param name="FileName">Name to be given to the file on the client side. Does not need to match the server side name.</param>
-    /// <returns>True if the operation was successful; otherwise - false.</returns>
-    procedure DownloadFileContent(OdataId: Text; FileName: Text): Boolean
-    begin
-        exit(SharePointClientImpl.DownloadFileContent(OdataId, FileName));
-    end;
-
-    /// <summary>
     /// Downloads a file to an InStream.
     /// </summary>
     /// <param name="OdataId">The odata.id parameter of the file entity.</param>
@@ -277,6 +266,17 @@ codeunit 9100 "SharePoint Client"
     procedure DownloadFileContent(OdataId: Text; var FileInStream: InStream): Boolean
     begin
         exit(SharePointClientImpl.DownloadFileContent(OdataId, FileInStream));
+    end;
+
+    /// <summary>
+    /// Downloads a file to the client.
+    /// </summary>
+    /// <param name="OdataId">The odata.id parameter of the file entity.</param>
+    /// <param name="FileName">Name to be given to the file on the client side. Does not need to match the server side name.</param>
+    /// <returns>True if the operation was successful; otherwise - false.</returns>
+    procedure DownloadFileContent(OdataId: Text; FileName: Text): Boolean
+    begin
+        exit(SharePointClientImpl.DownloadFileContent(OdataId, FileName));
     end;
 
     /// <summary>

--- a/Modules/System/SharePoint/src/SharePointClient.Codeunit.al
+++ b/Modules/System/SharePoint/src/SharePointClient.Codeunit.al
@@ -269,6 +269,28 @@ codeunit 9100 "SharePoint Client"
     end;
 
     /// <summary>
+    /// Downloads a file to an InStream.
+    /// </summary>
+    /// <param name="OdataId">The odata.id parameter of the file entity.</param>
+    /// <param name="FileInStream">The InStream that will be populated with the file content.</param>
+    /// <returns>True if the operation was successful; otherwise - false.</returns>
+    procedure DownloadFileContent(OdataId: Text; var FileInStream: InStream): Boolean
+    begin
+        exit(SharePointClientImpl.DownloadFileContent(OdataId, FileInStream));
+    end;
+
+    /// <summary>
+    /// Downloads a file to a TempBlob.
+    /// </summary>
+    /// <param name="OdataId">The odata.id parameter of the file entity.</param>
+    /// <param name="TempBlob">The TempBlob that will be populated with the file content.</param>
+    /// <returns>True if the operation was successful; otherwise - false.</returns>
+    procedure DownloadFileContent(OdataId: Text; var TempBlob: Codeunit "Temp Blob"): Boolean
+    begin
+        exit(SharePointClientImpl.DownloadFileContent(OdataId, TempBlob));
+    end;
+
+    /// <summary>
     /// Gets root folder for the list entity (Document Library).
     /// </summary>    
     /// <remarks>See "Is Catalog" parameter of the list.</remarks>

--- a/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
+++ b/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
@@ -475,25 +475,6 @@ codeunit 9101 "SharePoint Client Impl."
         exit(true);
     end;
 
-    procedure DownloadFileContent(OdataId: Text; FileName: Text): Boolean
-    var
-        FileInStream: InStream;
-    begin
-        //GET https://{site_url}/_api/web/GetFileByServerRelativeUrl('/Folder Name/{file_name}')/$value
-        SharePointUriBuilder.ResetPath(OdataId);
-        SharePointUriBuilder.SetObject('$value');
-
-        SharePointRequestHelper.SetAuthorization(Authorization);
-        SharePointOperationResponse := SharePointRequestHelper.Get(SharePointUriBuilder);
-        if not SharePointOperationResponse.GetDiagnostics().IsSuccessStatusCode() then
-            exit(false);
-
-        SharePointOperationResponse.GetResultAsStream(FileInStream);
-
-        DownloadFromStream(FileInStream, '', '', '', FileName);
-        exit(true);
-    end;
-
     procedure DownloadFileContent(OdataId: Text; var FileInStream: InStream): Boolean
     begin
         //GET https://{site_url}/_api/web/GetFileByServerRelativeUrl('/Folder Name/{file_name}')/$value
@@ -509,12 +490,24 @@ codeunit 9101 "SharePoint Client Impl."
         exit(true);
     end;
 
+    procedure DownloadFileContent(OdataId: Text; FileName: Text): Boolean
+    var
+        FileInStream: InStream;
+    begin
+        if not DownloadFileContent(OdataId, FileInStream) then
+            exit(false);
+
+        DownloadFromStream(FileInStream, '', '', '', FileName);
+        exit(true);
+    end;
+
     procedure DownloadFileContent(OdataId: Text; var TempBlob: Codeunit "Temp Blob"): Boolean
     var
         FileInStream: InStream;
         OS: OutStream;
     begin
-        DownloadFileContent(OdataId, FileInStream);
+        if not DownloadFileContent(OdataId, FileInStream) then
+            exit(false);
         TempBlob.CreateOutStream(OS);
         CopyStream(OS, FileInStream);
         exit(true);

--- a/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
+++ b/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
@@ -494,6 +494,32 @@ codeunit 9101 "SharePoint Client Impl."
         exit(true);
     end;
 
+    procedure DownloadFileContent(OdataId: Text; var FileInStream: InStream): Boolean
+    begin
+        //GET https://{site_url}/_api/web/GetFileByServerRelativeUrl('/Folder Name/{file_name}')/$value
+        SharePointUriBuilder.ResetPath(OdataId);
+        SharePointUriBuilder.SetObject('$value');
+
+        SharePointRequestHelper.SetAuthorization(Authorization);
+        SharePointOperationResponse := SharePointRequestHelper.Get(SharePointUriBuilder);
+        if not SharePointOperationResponse.GetDiagnostics().IsSuccessStatusCode() then
+            exit(false);
+
+        SharePointOperationResponse.GetResultAsStream(FileInStream);
+        exit(true);
+    end;
+
+    procedure DownloadFileContent(OdataId: Text; var TempBlob: Codeunit "Temp Blob"): Boolean
+    var
+        FileInStream: InStream;
+        OS: OutStream;
+    begin
+        DownloadFileContent(OdataId, FileInStream);
+        TempBlob.CreateOutStream(OS);
+        CopyStream(OS, FileInStream);
+        exit(true);
+    end;
+
     procedure GetDocumentLibraryRootFolder(OdataID: Text; var SharePointFolder: Record "SharePoint Folder"): Boolean
     var
         SharePointFolderParser: Codeunit "SharePoint Folder";

--- a/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
+++ b/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
@@ -479,7 +479,7 @@ codeunit 9101 "SharePoint Client Impl."
     var
         FileInStream: InStream;
     begin
-        //GET https://{site_url}/_api/web/lists/getbytitle('{list_title}')/items({item_id})/AttachmentFiles('{file_name}')/$value
+        //GET https://{site_url}/_api/web/GetFileByServerRelativeUrl('/Folder Name/{file_name}')/$value
         SharePointUriBuilder.ResetPath(OdataId);
         SharePointUriBuilder.SetObject('$value');
 


### PR DESCRIPTION
Adds two DownloadFileContent() overloads to the SharePoint client, that might come in handy in several cases.