### PR TITLE
Nextmarker And ListBlobs overload

### DIFF
--- a/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
@@ -74,6 +74,31 @@ codeunit 9053 "ABS Blob Client"
     end;
 
     /// <summary>
+    /// Lists the blobs in a specific container.
+    /// see: https://go.microsoft.com/fwlink/?linkid=2210588
+    /// </summary>    
+    /// <param name="BlobList">Collection of the result (BlobList of [Text, XmlNode]).</param>
+    /// <returns>An operation reponse object</returns>
+    procedure ListBlobs(var BlobList: Dictionary of [Text, XmlNode]): Codeunit "ABS Operation Response"
+    var
+        ABSOptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(ABSClientImpl.ListBlobs(BlobList, ABSOptionalParameters));
+    end;
+
+    /// <summary>
+    /// Lists the blobs in a specific container.
+    /// see: https://go.microsoft.com/fwlink/?linkid=2210588
+    /// </summary>    
+    /// <param name="BlobList">Collection of the result (BlobList of [Text, XmlNode]).</param>
+    /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation reponse object</returns>
+    procedure ListBlobs(var BlobList: Dictionary of [Text, XmlNode]; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(ABSClientImpl.ListBlobs(BlobList, ABSOptionalParameters));
+    end;
+
+    /// <summary>
     /// Uploads a file as a BlockBlob (with File Selection Dialog).
     /// see: https://go.microsoft.com/fwlink/?linkid=2210387
     /// </summary>

--- a/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
@@ -77,7 +77,8 @@ codeunit 9053 "ABS Blob Client"
     /// Lists the blobs in a specific container.
     /// see: https://go.microsoft.com/fwlink/?linkid=2210588
     /// </summary>    
-    /// <param name="BlobList">Collection of the result (BlobList of [Text, XmlNode]).</param>
+    /// <param name="BlobList">Collection of the result (BlobList of [Text, XmlNode]).
+    /// The key in the dictionary is the full blob path and the value is the complete blob xmlnode from the response</param>
     /// <returns>An operation reponse object</returns>
     procedure ListBlobs(var BlobList: Dictionary of [Text, XmlNode]): Codeunit "ABS Operation Response"
     var
@@ -90,7 +91,8 @@ codeunit 9053 "ABS Blob Client"
     /// Lists the blobs in a specific container.
     /// see: https://go.microsoft.com/fwlink/?linkid=2210588
     /// </summary>    
-    /// <param name="BlobList">Collection of the result (BlobList of [Text, XmlNode]).</param>
+    /// <param name="BlobList">Collection of the result (BlobList of [Text, XmlNode]).
+    /// The key in the dictionary is the full blob path and the value is the complete blob xmlnode from the response</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
     /// <returns>An operation reponse object</returns>
     procedure ListBlobs(var BlobList: Dictionary of [Text, XmlNode]; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"

--- a/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
@@ -132,7 +132,7 @@ codeunit 9051 "ABS Client Impl."
         ABSOperationResponse: Codeunit "ABS Operation Response";
         Operation: Enum "ABS Operation";
         NextMarker, ResponseText : Text;
-        NextMarkerNodeList, NodeList : XmlNodeList;
+        NodeList: XmlNodeList;
     begin
         Clear(BlobList);
         ABSOperationPayload.SetOperation(Operation::ListBlobs);

--- a/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
@@ -106,10 +106,10 @@ codeunit 9051 "ABS Client Impl."
     [NonDebuggable]
     procedure ListBlobs(var ABSContainerContent: Record "ABS Container Content"; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     var
-        ABSOperationResponse: Codeunit "ABS Operation Response";
         ABSHelperLibrary: Codeunit "ABS Helper Library";
+        ABSOperationResponse: Codeunit "ABS Operation Response";
         Operation: Enum "ABS Operation";
-        ResponseText: Text;
+        NextMarker, ResponseText : Text;
         NodeList: XmlNodeList;
     begin
         ABSOperationPayload.SetOperation(Operation::ListBlobs);
@@ -117,8 +117,33 @@ codeunit 9051 "ABS Client Impl."
 
         ABSOperationResponse := ABSWebRequestHelper.GetOperationAsText(ABSOperationPayload, ResponseText, StrSubstNo(ListBlobsContainercOperationNotSuccessfulErr, ABSOperationPayload.GetContainerName()));
 
-        NodeList := ABSHelperLibrary.CreateBlobNodeListFromResponse(ResponseText);
+        NodeList := ABSHelperLibrary.CreateBlobNodeListFromResponse(ResponseText, NextMarker);
+        ABSOperationResponse.SetNextMarker(NextMarker);
+
         ABSHelperLibrary.BlobNodeListToTempRecord(NodeList, ABSContainerContent);
+
+        exit(ABSOperationResponse);
+    end;
+
+    [NonDebuggable]
+    procedure ListBlobs(var BlobList: Dictionary of [Text, XmlNode]; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    var
+        ABSHelperLibrary: Codeunit "ABS Helper Library";
+        ABSOperationResponse: Codeunit "ABS Operation Response";
+        Operation: Enum "ABS Operation";
+        NextMarker, ResponseText : Text;
+        NextMarkerNodeList, NodeList : XmlNodeList;
+    begin
+        Clear(BlobList);
+        ABSOperationPayload.SetOperation(Operation::ListBlobs);
+        ABSOperationPayload.SetOptionalParameters(ABSOptionalParameters);
+
+        ABSOperationResponse := ABSWebRequestHelper.GetOperationAsText(ABSOperationPayload, ResponseText, StrSubstNo(ListBlobsContainercOperationNotSuccessfulErr, ABSOperationPayload.GetContainerName()));
+
+        NodeList := ABSHelperLibrary.CreateBlobNodeListFromResponse(ResponseText, NextMarker);
+        ABSOperationResponse.SetNextMarker(NextMarker);
+
+        ABSHelperLibrary.BlobNodeListToBlobList(NodeList, BlobList);
 
         exit(ABSOperationResponse);
     end;

--- a/Modules/System/Azure Blob Services API/src/ABSOperationResponse.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSOperationResponse.Codeunit.al
@@ -34,6 +34,20 @@ codeunit 9050 "ABS Operation Response"
     end;
 
     /// <summary>
+    /// Gets the NextMarker (if any) of the response.
+    /// </summary>
+    /// <returns>Text representation of the NextMarker that is returned during the operation.</returns>
+    procedure GetNextMarker(): Text
+    begin
+        exit(ResponseNextMarker);
+    end;
+
+    internal procedure SetNextMarker(NextMarker: Text)
+    begin
+        ResponseNextMarker := NextMarker;
+    end;
+
+    /// <summary>
     /// Gets the result of a ABS client operation as text, 
     /// </summary>
     /// <returns>The content of the response.</returns>
@@ -76,5 +90,5 @@ codeunit 9050 "ABS Operation Response"
     var
         [NonDebuggable]
         HttpResponseMessage: HttpResponseMessage;
-        ResponseError: Text;
+        ResponseError, ResponseNextMarker : Text;
 }

--- a/Modules/System/Azure Blob Services API/src/Helper/ABSContainerContentHelper.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSContainerContentHelper.Codeunit.al
@@ -8,7 +8,7 @@ codeunit 9054 "ABS Container Content Helper"
     Access = Internal;
 
     [NonDebuggable]
-    procedure AddNewEntryFromNode(var ABSContainerContent: Record "ABS Container Content"; var Node: XmlNode; XPathName: Text)
+    procedure AddNewEntryFromNode(var ABSContainerContent: Record "ABS Container Content"; var Node: XmlNode; XPathName: Text; var EntryNo: Integer)
     var
         ABSHelperLibrary: Codeunit "ABS Helper Library";
         NameFromXml: Text;
@@ -21,24 +21,21 @@ codeunit 9054 "ABS Container Content Helper"
         Node.SelectSingleNode('.//Properties', PropertiesNode);
         ChildNodes := PropertiesNode.AsXmlElement().GetChildNodes();
 
-        AddNewEntry(ABSContainerContent, NameFromXml, OuterXml, ChildNodes);
+        AddNewEntry(ABSContainerContent, NameFromXml, OuterXml, ChildNodes, EntryNo);
     end;
 
     [NonDebuggable]
-    procedure AddNewEntry(var ABSContainerContent: Record "ABS Container Content"; NameFromXml: Text; OuterXml: Text; ChildNodes: XmlNodeList)
+    procedure AddNewEntry(var ABSContainerContent: Record "ABS Container Content"; NameFromXml: Text; OuterXml: Text; ChildNodes: XmlNodeList; var EntryNo: Integer)
     var
         OutStream: OutStream;
-        EntryNo: Integer;
     begin
-        AddParentEntries(NameFromXml, ABSContainerContent);
-
-        EntryNo := GetNextEntryNo(ABSContainerContent);
+        AddParentEntries(NameFromXml, ABSContainerContent, EntryNo);
 
         ABSContainerContent.Init();
         ABSContainerContent.Level := GetLevel(NameFromXml);
-        ABSContainerContent."Parent Directory" := GetParentDirectory(NameFromXml);
-        ABSContainerContent."Full Name" := CopyStr(NameFromXml, 1, 250);
-        ABSContainerContent.Name := GetName(NameFromXml);
+        ABSContainerContent."Parent Directory" := CopyStr(GetParentDirectory(NameFromXml), 1, MaxStrLen(ABSContainerContent."Parent Directory"));
+        ABSContainerContent."Full Name" := CopyStr(NameFromXml, 1, MaxStrLen(ABSContainerContent."Full Name"));
+        ABSContainerContent.Name := CopyStr(GetName(NameFromXml), 1, MaxStrLen(ABSContainerContent.Name));
 
         SetPropertyFields(ABSContainerContent, ChildNodes);
 
@@ -47,14 +44,15 @@ codeunit 9054 "ABS Container Content Helper"
 
         ABSContainerContent."Entry No." := EntryNo;
         ABSContainerContent.Insert(true);
+        EntryNo += 1;
     end;
 
     [NonDebuggable]
-    local procedure AddParentEntries(NameFromXml: Text; var ABSContainerContent: Record "ABS Container Content")
+    local procedure AddParentEntries(NameFromXml: Text; var ABSContainerContent: Record "ABS Container Content"; var EntryNo: Integer)
     var
         ParentEntries: List of [Text];
         CurrentParent, ParentEntryFullName, ParentEntryName : Text[2048];
-        Level, EntryNo : Integer;
+        Level: Integer;
     begin
         // Check if the entry has parents: the Name will be something like /folder1/folder2/blob-name.
         // For every parent folder, add a parent entry.
@@ -67,16 +65,14 @@ codeunit 9054 "ABS Container Content Helper"
 
         ParentEntries := NameFromXml.Split('/');
 
-        for Level := 1 to ParentEntries.Count() - 1
-        do begin
+        for Level := 1 to ParentEntries.Count() - 1 do begin
             ParentEntryName := CopyStr(ParentEntries.Get(Level), 1, MaxStrLen(ABSContainerContent.Name));
             ParentEntryFullName := CopyStr(CurrentParent + ParentEntryName, 1, MaxStrLen(ABSContainerContent.Name));
 
             // Only create the parent entry if it doesn't exist already.
             // The full name should be unique.
-            ABSContainerContent.SetRange("Full Name", ParentEntryFullName);
-            if not ABSContainerContent.FindLast() then begin
-                EntryNo := GetNextEntryNo(ABSContainerContent);
+            if not ParentEntryFullNameList.Contains(ParentEntryFullName) then begin
+                ParentEntryFullNameList.Add(ParentEntryFullName);
 
                 ABSContainerContent.Init();
                 ABSContainerContent.Level := Level - 1; // Levels start from 0 to be used for indentation
@@ -86,6 +82,7 @@ codeunit 9054 "ABS Container Content Helper"
 
                 ABSContainerContent."Entry No." := EntryNo;
                 ABSContainerContent.Insert(true);
+                EntryNo += 1;
             end;
 
             CurrentParent := CopyStr(ABSContainerContent."Full Name" + '/', 1, MaxStrLen(ABSContainerContent.Name));
@@ -131,17 +128,6 @@ codeunit 9054 "ABS Container Content Helper"
     end;
 
     [NonDebuggable]
-    local procedure GetNextEntryNo(var ABSContainerContent: Record "ABS Container Content"): Integer
-    begin
-        ABSContainerContent.Reset();
-
-        if ABSContainerContent.FindLast() then
-            exit(ABSContainerContent."Entry No." + 1)
-        else
-            exit(1);
-    end;
-
-    [NonDebuggable]
     local procedure GetLevel(Name: Text): Integer
     var
         StringSplit: List of [Text];
@@ -153,18 +139,18 @@ codeunit 9054 "ABS Container Content Helper"
     end;
 
     [NonDebuggable]
-    local procedure GetName(Name: Text): Text[250]
+    local procedure GetName(Name: Text): Text
     var
         StringSplit: List of [Text];
     begin
         if not Name.Contains('/') then
-            exit(CopyStr(Name, 1, 250));
+            exit(Name);
         StringSplit := Name.Split('/');
-        exit(CopyStr(StringSplit.Get(StringSplit.Count()), 1, 250));
+        exit(StringSplit.Get(StringSplit.Count()));
     end;
 
     [NonDebuggable]
-    local procedure GetParentDirectory(Name: Text): Text[250]
+    local procedure GetParentDirectory(Name: Text): Text
     var
         Parent: Text;
     begin
@@ -173,7 +159,7 @@ codeunit 9054 "ABS Container Content Helper"
 
         Parent := CopyStr(Name, 1, Name.LastIndexOf('/'));
 
-        exit(CopyStr(Parent, 1, 250));
+        exit(Parent);
     end;
 
     /// <summary>
@@ -206,4 +192,7 @@ codeunit 9054 "ABS Container Content Helper"
         XmlDocument.ReadFrom(XmlAsText, Document);
         Node := Document.AsXmlNode();
     end;
+
+    var
+        ParentEntryFullNameList: List of [Text];
 }

--- a/Modules/System/Azure Blob Services API/src/Helper/ABSContainerContentHelper.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSContainerContentHelper.Codeunit.al
@@ -50,6 +50,7 @@ codeunit 9054 "ABS Container Content Helper"
     [NonDebuggable]
     local procedure AddParentEntries(NameFromXml: Text; var ABSContainerContent: Record "ABS Container Content"; var EntryNo: Integer)
     var
+        DirectoryContentTypeTxt: Label 'Directory', Locked = true;
         ParentEntries: List of [Text];
         CurrentParent, ParentEntryFullName, ParentEntryName : Text[2048];
         Level: Integer;
@@ -79,13 +80,14 @@ codeunit 9054 "ABS Container Content Helper"
                 ABSContainerContent.Name := ParentEntryName;
                 ABSContainerContent."Full Name" := ParentEntryFullName;
                 ABSContainerContent."Parent Directory" := CurrentParent;
+                ABSContainerContent."Content Type" := DirectoryContentTypeTxt;
 
                 ABSContainerContent."Entry No." := EntryNo;
                 ABSContainerContent.Insert(true);
                 EntryNo += 1;
             end;
 
-            CurrentParent := CopyStr(ABSContainerContent."Full Name" + '/', 1, MaxStrLen(ABSContainerContent.Name));
+            CurrentParent := CopyStr(ParentEntryFullName + '/', 1, MaxStrLen(CurrentParent));
         end;
     end;
 

--- a/Modules/System/Azure Blob Services API/src/Helper/ABSHelperLibrary.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSHelperLibrary.Codeunit.al
@@ -88,9 +88,18 @@ codeunit 9043 "ABS Helper Library"
 
     // #region Blob-specific Helper
     [NonDebuggable]
-    procedure CreateBlobNodeListFromResponse(ResponseAsText: Text): XmlNodeList
+    procedure CreateBlobNodeListFromResponse(ResponseAsText: Text; var NextMarker: Text): XmlNodeList
+    var
+        XmlDoc: XmlDocument;
+        Node: XmlNode;
+        NodeList: XmlNodeList;
     begin
-        exit(CreateXPathNodeListFromResponse(ResponseAsText, '/*/Blobs/Blob'));
+        Clear(NextMarker);
+        GetXmlDocumentFromResponse(XmlDoc, ResponseAsText);
+        if XmlDoc.SelectSingleNode('//NextMarker', Node) then
+            NextMarker := Node.AsXmlElement().InnerText;
+        XmlDoc.SelectNodes('//Blobs/Blob', NodeList);
+        exit(NodeList);
     end;
 
     [NonDebuggable]
@@ -105,6 +114,16 @@ codeunit 9043 "ABS Helper Library"
     procedure BlobNodeListToTempRecord(NodeList: XmlNodeList; var ABSContainerContent: Record "ABS Container Content")
     begin
         NodeListToTempRecord(NodeList, './/Name', ABSContainerContent);
+    end;
+
+    procedure BlobNodeListToBlobList(NodeList: XmlNodeList; var BlobList: Dictionary of [Text, XmlNode])
+    var
+        Name, Node : XmlNode;
+    begin
+        foreach Node in NodeList do begin
+            Node.SelectSingleNode('Name', Name);
+            BlobList.Add(Name.AsXmlElement().InnerText, Node);
+        end;
     end;
     // #endregion
 
@@ -158,14 +177,16 @@ codeunit 9043 "ABS Helper Library"
     var
         ABSContainerContentHelper: Codeunit "ABS Container Content Helper";
         Node: XmlNode;
+        EntryNo: Integer;
     begin
+        ABSContainerContent.Reset();
         ABSContainerContent.DeleteAll();
 
         if NodeList.Count = 0 then
             exit;
 
         foreach Node in NodeList do
-            ABSContainerContentHelper.AddNewEntryFromNode(ABSContainerContent, Node, XPathName);
+            ABSContainerContentHelper.AddNewEntryFromNode(ABSContainerContent, Node, XPathName, EntryNo);
     end;
 
     [NonDebuggable]

--- a/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
@@ -335,9 +335,12 @@ codeunit 9047 "ABS Optional Parameters"
 
     /// <summary>
     /// Specifies the maximum number of blobs to be fetch, from 1 to 5000 if not defined it will fetch 5000
-    /// If more than 5000 blobs then use NextMarker to fetch the next set of blobs
+    /// If more than 5000 blobs then use NextMarker to fetch the next set of blobs.
+    /// In certain cases, the service might return fewer results than specified by maxresults, and also return a continuation token.
+    /// Setting maxresults to a value less than or equal to zero results in error response code 400 (Bad Request).
+    /// see: https://learn.microsoft.com/en-us/rest/api/storageservices/list-blobs?tabs=azure-ad#uri-parameters
     /// </summary>
-    /// <param name="Value">Max. number of results to fetch. Must be positive</param>
+    /// <param name="Value">Max. number of results to fetch. Must be positive between 1 - 5000</param>
     procedure MaxResults("Value": Integer)
     begin
         SetParameter('maxresults', Format("Value"));
@@ -345,6 +348,7 @@ codeunit 9047 "ABS Optional Parameters"
 
     /// <summary>
     /// Specifies the NextMarker of blobs to fetch
+    /// see: https://learn.microsoft.com/en-us/rest/api/storageservices/list-blobs?tabs=azure-ad#uri-parameters
     /// </summary>
     /// <param name="Value">NextMarker From previous response to fetch the next 5000 or what you have defined in MaxResults</param>
     procedure NextMarker("Value": Text)

--- a/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
@@ -334,12 +334,22 @@ codeunit 9047 "ABS Optional Parameters"
     end;
 
     /// <summary>
-    /// Specifies the maximum number of blobs to return
+    /// Specifies the maximum number of blobs to be fetch, from 1 to 5000 if not defined it will fetch 5000
+    /// If more than 5000 blobs then use NextMarker to fetch the next set of blobs
     /// </summary>
-    /// <param name="Value">Max. number of results to return. Must be positive, must not be greater than 5000</param>
+    /// <param name="Value">Max. number of results to fetch. Must be positive</param>
     procedure MaxResults("Value": Integer)
     begin
         SetParameter('maxresults', Format("Value"));
+    end;
+
+    /// <summary>
+    /// Specifies the NextMarker of blobs to fetch
+    /// </summary>
+    /// <param name="Value">NextMarker From previous response to fetch the next 5000 or what you have defined in MaxResults</param>
+    procedure NextMarker("Value": Text)
+    begin
+        SetParameter('marker', "Value");
     end;
 
     /// <summary>


### PR DESCRIPTION
Return of NextMarker so it is possible to use paging an select more than the first 5000 Blobs

Preformance optimized so collection of 5000 Blobs goes from 45 sec. to  around 9 sec. when using "ABS Container Content" table

Using new overload on ListBlobs will return a dictionary instead of "ABS Container Content" table and the time goes down to 2 sec.

All measurements are based on a local Sandbox Container version 21.5.53619.54870