### PR TITLE
Fix length of Product Group Code in Shopify Connector

### DIFF
--- a/Apps/W1/Shopify/app/src/Products/Tables/ShpfyShopCollectionMap.Table.al
+++ b/Apps/W1/Shopify/app/src/Products/Tables/ShpfyShopCollectionMap.Table.al
@@ -40,7 +40,7 @@ table 30128 "Shpfy Shop Collection Map"
             DataClassification = CustomerContent;
         }
 
-        field(4; "Product Group Code"; Code[10])
+        field(4; "Product Group Code"; Code[20])
         {
             Caption = 'Product Group Code';
             DataClassification = CustomerContent;


### PR DESCRIPTION
The length of the field Product Group Code in the table  "Shpfy Shop Collection Map" was 10. Which gave the error with longer VAT Product Posting Groups.

It was possible to add the VAT Product Posting Group more than 10 chars but there was an issue when renaming the value.

<img width="248" alt="image" src="https://user-images.githubusercontent.com/104026807/229514433-270b09a9-288e-43ca-a4eb-2518ec6cf312.png">

I checked where the field is used and looks like there are no references in Shopify Connector that would break anything else.