### PR TITLE
Encoding.Convert() overloads

### DIFF
--- a/Modules/System/Encoding/README.md
+++ b/Modules/System/Encoding/README.md
@@ -34,3 +34,32 @@ The text to convert.
 *[Text](https://go.microsoft.com/fwlink/?linkid=2210031)*
 
 The text in the destination encoding.
+
+
+### Convert (Method) <a name="Convert"></a> 
+
+Convert a text contained in an InStream from one encoding to another.
+ 
+
+#### Syntax
+```
+procedure Convert(SourceCodepage: Integer; DestinationCodepage: Integer; TextInStream: InStream): InStream
+```
+#### Parameters
+*SourceCodepage ([Integer](https://go.microsoft.com/fwlink/?linkid=2209956))* 
+
+Encoding code page identifier of the source text. Valid values are between 0 and 65535.
+
+*DestinationCodepage ([Integer](https://go.microsoft.com/fwlink/?linkid=2209956))* 
+
+Encoding code page identifier for the result text. Valid values are between 0 and 65535.
+
+*TextInStream ([InStream](https://go.microsoft.com/fwlink/?linkid=2210033))* 
+
+The InStream containing the text to convert.
+
+#### Return Value
+*[InStream](https://go.microsoft.com/fwlink/?linkid=2210033)* 
+
+The InStream containing the text in the destination encoding.
+

--- a/Modules/System/Encoding/src/Encoding.Codeunit.al
+++ b/Modules/System/Encoding/src/Encoding.Codeunit.al
@@ -24,4 +24,16 @@ codeunit 1486 "Encoding"
     begin
         exit(EncodingImpl.Convert(SourceCodepage, DestinationCodepage, Text));
     end;
+
+    /// <summary>
+    /// Converts a text from one encoding to another.
+    /// </summary>
+    /// <param name="SourceCodepage">Encoding code page identifier of the source text. Valid values are between 0 and 65535.</param>
+    /// <param name="DestinationCodepage">Encoding code page identifier for the result text. Valid values are between 0 and 65535.</param>
+    /// <param name="TextInStream">The InStream containing the text to convert.</param>
+    /// <returns>The Instream containing text in the destination encoding.</returns>
+    procedure Convert(SourceCodepage: Integer; DestinationCodepage: Integer; TextInStream: InStream): InStream
+    begin
+        exit(EncodingImpl.Convert(SourceCodepage, DestinationCodepage, TextInStream));
+    end;
 }

--- a/Modules/System/Encoding/src/EncodingImpl.Codeunit.al
+++ b/Modules/System/Encoding/src/EncodingImpl.Codeunit.al
@@ -22,4 +22,16 @@ codeunit 1487 "Encoding Impl."
         DestinationBytes := Encoding.Convert(SourceEncoding, DestinationEncoding, SourceBytes);
         ConvertedText := DestinationEncoding.GetString(DestinationBytes);
     end;
+
+    procedure Convert(SourceCodepage: Integer; DestinationCodepage: Integer; TextInStream: InStream) ConvertedTextInStream: InStream
+    var
+        Encoding: DotNet Encoding;
+        SourceEncoding: DotNet Encoding;
+        DestinationEncoding: DotNet Encoding;
+    begin
+        SourceEncoding := Encoding.GetEncoding(SourceCodepage);
+        DestinationEncoding := Encoding.GetEncoding(DestinationCodepage);
+
+        ConvertedTextInStream := Encoding.CreateTranscodingStream(TextInStream, SourceEncoding, DestinationEncoding, true);
+    end;
 }


### PR DESCRIPTION
Adds Convert() overload to Encoding. The goal is to be able to work directly on streams rather than texts 