### PR TITLE
Cache baseline packages 

### DIFF
--- a/Build/Scripts/EnlistmentHelperFunctions.psm1
+++ b/Build/Scripts/EnlistmentHelperFunctions.psm1
@@ -113,14 +113,11 @@ function Get-PackageFromNuget() {
 
     $NugetExePath = Restore-NugetExe
 
-    $NugetPackagePath = Join-Path $OutputPath "$PackageId.$Version"
-    if (!(Test-Path $NugetPackagePath)) {
+    if (!(Test-Path $OutputPath)) {
         Write-Host "install $PackageId -Version $Version -OutputDirectory $OutputPath -Source https://api.nuget.org/v3/index.json"
         $NugetExeArguments = "install $PackageId -Version $Version -OutputDirectory $OutputPath -Source https://api.nuget.org/v3/index.json"
         Invoke-Expression "$NugetExePath $NugetExeArguments" | Out-Null
     }
-
-    return $NugetPackagePath
 }
 
 Export-ModuleMember -Function *-*

--- a/Build/Scripts/EnlistmentHelperFunctions.psm1
+++ b/Build/Scripts/EnlistmentHelperFunctions.psm1
@@ -77,10 +77,7 @@ function Set-ConfigValue() {
     The path where the nuget.exe will be downloaded to
 #>
 function Restore-NugetExe() {
-    param(
-        [Parameter(Mandatory=$true)]
-        [string]$OutputPath
-    )
+    $OutputPath = Join-Path (Get-BaseFolder) "out"
 
     if (!(Test-Path $OutputPath)) {
         New-Item -ItemType Directory -Path $OutputPath | Out-Null
@@ -114,7 +111,7 @@ function Get-PackageFromNuget() {
         [string]$OutputPath
     )
 
-    $NugetExePath = Restore-NugetExe -OutputPath $OutputPath
+    $NugetExePath = Restore-NugetExe
 
     $NugetPackagePath = Join-Path $OutputPath "$PackageId.$Version"
     if (!(Test-Path $NugetPackagePath)) {

--- a/Build/Scripts/EnlistmentHelperFunctions.psm1
+++ b/Build/Scripts/EnlistmentHelperFunctions.psm1
@@ -73,8 +73,6 @@ function Set-ConfigValue() {
 .Synopsis
     Get the nuget.exe if it doesn't exist
     Downloads the nuget.exe if it doesn't exist
-.Parameter OutputPath
-    The path where the nuget.exe will be downloaded to
 #>
 function Restore-NugetExe() {
     $OutputPath = Join-Path (Get-BaseFolder) "out"
@@ -113,11 +111,9 @@ function Get-PackageFromNuget() {
 
     $NugetExePath = Restore-NugetExe
 
-    if (!(Test-Path $OutputPath)) {
-        Write-Host "install $PackageId -Version $Version -OutputDirectory $OutputPath -Source https://api.nuget.org/v3/index.json"
-        $NugetExeArguments = "install $PackageId -Version $Version -OutputDirectory $OutputPath -Source https://api.nuget.org/v3/index.json"
-        Invoke-Expression "$NugetExePath $NugetExeArguments" | Out-Null
-    }
+    Write-Host "install $PackageId -Version $Version -OutputDirectory $OutputPath -Source https://api.nuget.org/v3/index.json"
+    $NugetExeArguments = "install $PackageId -Version $Version -OutputDirectory $OutputPath -Source https://api.nuget.org/v3/index.json"
+    Invoke-Expression "$NugetExePath $NugetExeArguments" | Out-Null
 }
 
 Export-ModuleMember -Function *-*


### PR DESCRIPTION
Cache baseline packages so they're only downloaded once per job. 

Right now we download the same baseline package every time we invoke CompileAppInBcContainer. This happens 5 times in the "Build Test Framework" task, so this PR would reduce that to downloading it once. 