### PR TITLE
SharePoint library add functions and function overloads

### DIFF
--- a/Modules/System/SharePoint/src/SharePointClient.Codeunit.al
+++ b/Modules/System/SharePoint/src/SharePointClient.Codeunit.al
@@ -325,6 +325,16 @@ codeunit 9100 "SharePoint Client"
     end;
 
     /// <summary>
+    /// Deletes a folder.
+    /// </summary>
+    /// <param name="OdataId">The odata.id parameter of the folder entity.</param>
+    /// <returns>True if the operation was successful; otherwise - false.</returns>
+    procedure DeleteFolder(OdataId: Text): Boolean
+    begin
+        exit(SharePointClientImpl.DeleteFolder(OdataId));
+    end;
+
+    /// <summary>
     /// Adds a file to specific folder.
     /// </summary>
     /// <remarks>Requires UI interaction to pick a file.</remarks>

--- a/Modules/System/SharePoint/src/SharePointClient.Codeunit.al
+++ b/Modules/System/SharePoint/src/SharePointClient.Codeunit.al
@@ -258,6 +258,17 @@ codeunit 9100 "SharePoint Client"
     end;
 
     /// <summary>
+    /// Downloads a file to an InStream.
+    /// </summary>
+    /// <param name="OdataId">The odata.id parameter of the file entity.</param>
+    /// <param name="FileInStream">The InStream that will be populated with the file content.</param>
+    /// <returns>True if the operation was successful; otherwise - false.</returns>
+    procedure DownloadFileContent(OdataId: Text; var FileInStream: InStream): Boolean
+    begin
+        exit(SharePointClientImpl.DownloadFileContent(OdataId, FileInStream));
+    end;
+
+    /// <summary>
     /// Downloads a file to the client.
     /// </summary>
     /// <param name="OdataId">The odata.id parameter of the file entity.</param>
@@ -266,6 +277,27 @@ codeunit 9100 "SharePoint Client"
     procedure DownloadFileContent(OdataId: Text; FileName: Text): Boolean
     begin
         exit(SharePointClientImpl.DownloadFileContent(OdataId, FileName));
+    end;
+
+    /// <summary>
+    /// Downloads a file to a TempBlob.
+    /// </summary>
+    /// <param name="OdataId">The odata.id parameter of the file entity.</param>
+    /// <param name="TempBlob">The TempBlob that will be populated with the file content.</param>
+    /// <returns>True if the operation was successful; otherwise - false.</returns>
+    procedure DownloadFileContent(OdataId: Text; var TempBlob: Codeunit "Temp Blob"): Boolean
+    begin
+        exit(SharePointClientImpl.DownloadFileContent(OdataId, TempBlob));
+    end;
+
+    /// <summary>
+    /// Deletes a file.
+    /// </summary>
+    /// <param name="OdataId">The odata.id parameter of the file entity.</param>
+    /// <returns>True if the operation was successful; otherwise - false.</returns>
+    procedure DeleteFile(OdataId: Text): Boolean
+    begin
+        exit(SharePointClientImpl.DeleteFile(OdataId));
     end;
 
     /// <summary>

--- a/Modules/System/SharePoint/src/SharePointClient.Codeunit.al
+++ b/Modules/System/SharePoint/src/SharePointClient.Codeunit.al
@@ -291,6 +291,39 @@ codeunit 9100 "SharePoint Client"
     end;
 
     /// <summary>
+    /// Downloads a file to an InStream.
+    /// </summary>
+    /// <param name="ServerRelativeUrl">URL of the file to Download.</param>
+    /// <param name="FileInStream">The InStream that will be populated with the file content.</param>
+    /// <returns>True if the operation was successful; otherwise - false.</returns>
+    procedure DownloadFileContentByServerRelativeUrl(ServerRelativeUrl: Text; var FileInStream: InStream): Boolean
+    begin
+        exit(SharePointClientImpl.DownloadFileContentByServerRelativeUrl(ServerRelativeUrl, FileInStream));
+    end;
+
+    /// <summary>
+    /// Downloads a file to the client.
+    /// </summary>
+    /// <param name="ServerRelativeUrl">URL of the file to Download.</param>
+    /// <param name="FileName">Name to be given to the file on the client side. Does not need to match the server side name.</param>
+    /// <returns>True if the operation was successful; otherwise - false.</returns>
+    procedure DownloadFileContentByServerRelativeUrl(ServerRelativeUrl: Text; FileName: Text): Boolean
+    begin
+        exit(SharePointClientImpl.DownloadFileContentByServerRelativeUrl(ServerRelativeUrl, FileName));
+    end;
+
+    /// <summary>
+    /// Downloads a file to a TempBlob.
+    /// </summary>
+    /// <param name="ServerRelativeUrl">URL of the file to Download.</param>
+    /// <param name="TempBlob">The TempBlob that will be populated with the file content.</param>
+    /// <returns>True if the operation was successful; otherwise - false.</returns>
+    procedure DownloadFileContentByServerRelativeUrl(ServerRelativeUrl: Text; var TempBlob: Codeunit "Temp Blob"): Boolean
+    begin
+        exit(SharePointClientImpl.DownloadFileContentByServerRelativeUrl(ServerRelativeUrl, TempBlob));
+    end;
+
+    /// <summary>
     /// Deletes a file.
     /// </summary>
     /// <param name="OdataId">The odata.id parameter of the file entity.</param>
@@ -298,6 +331,16 @@ codeunit 9100 "SharePoint Client"
     procedure DeleteFile(OdataId: Text): Boolean
     begin
         exit(SharePointClientImpl.DeleteFile(OdataId));
+    end;
+
+    /// <summary>
+    /// Deletes a file.
+    /// </summary>
+    /// <param name="ServerRelativeUrl">URL of the file to delete.</param>
+    /// <returns>True if the operation was successful; otherwise - false.</returns>
+    procedure DeleteFileByServerRelativeUrl(ServerRelativeUrl: Text): Boolean
+    begin
+        exit(SharePointClientImpl.DeleteFileByServerRelativeUrl(OdataId));
     end;
 
     /// <summary>
@@ -332,6 +375,16 @@ codeunit 9100 "SharePoint Client"
     procedure DeleteFolder(OdataId: Text): Boolean
     begin
         exit(SharePointClientImpl.DeleteFolder(OdataId));
+    end;
+
+    /// <summary>
+    /// Deletes a folder.
+    /// </summary>
+    /// <param name="ServerRelativeUrl">URL of the folder to delete.</param>
+    /// <returns>True if the operation was successful; otherwise - false.</returns>
+    procedure DeleteFolderByServerRelativeUrl(ServerRelativeUrl: Text): Boolean
+    begin
+        exit(SharePointClientImpl.DeleteFolderByServerRelativeUrl(ServerRelativeUrl));
     end;
 
     /// <summary>

--- a/Modules/System/SharePoint/src/SharePointClient.Codeunit.al
+++ b/Modules/System/SharePoint/src/SharePointClient.Codeunit.al
@@ -340,7 +340,7 @@ codeunit 9100 "SharePoint Client"
     /// <returns>True if the operation was successful; otherwise - false.</returns>
     procedure DeleteFileByServerRelativeUrl(ServerRelativeUrl: Text): Boolean
     begin
-        exit(SharePointClientImpl.DeleteFileByServerRelativeUrl(OdataId));
+        exit(SharePointClientImpl.DeleteFileByServerRelativeUrl(ServerRelativeUrl));
     end;
 
     /// <summary>

--- a/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
+++ b/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
@@ -475,11 +475,9 @@ codeunit 9101 "SharePoint Client Impl."
         exit(true);
     end;
 
-    procedure DownloadFileContent(OdataId: Text; FileName: Text): Boolean
-    var
-        FileInStream: InStream;
+    procedure DownloadFileContent(OdataId: Text; var FileInStream: InStream): Boolean
     begin
-        //GET https://{site_url}/_api/web/lists/getbytitle('{list_title}')/items({item_id})/AttachmentFiles('{file_name}')/$value
+        //GET https://{site_url}/_api/web/GetFileByServerRelativeUrl('/Folder Name/{file_name}')/$value
         SharePointUriBuilder.ResetPath(OdataId);
         SharePointUriBuilder.SetObject('$value');
 
@@ -489,8 +487,42 @@ codeunit 9101 "SharePoint Client Impl."
             exit(false);
 
         SharePointOperationResponse.GetResultAsStream(FileInStream);
+        exit(true);
+    end;
+
+    procedure DownloadFileContent(OdataId: Text; FileName: Text): Boolean
+    var
+        FileInStream: InStream;
+    begin
+        if not DownloadFileContent(OdataId, FileInStream) then
+            exit(false);
 
         DownloadFromStream(FileInStream, '', '', '', FileName);
+        exit(true);
+    end;
+
+    procedure DownloadFileContent(OdataId: Text; var TempBlob: Codeunit "Temp Blob"): Boolean
+    var
+        FileInStream: InStream;
+        FileOutStream: OutStream;
+    begin
+        if not DownloadFileContent(OdataId, FileInStream) then
+            exit(false);
+        TempBlob.CreateOutStream(FileOutStream);
+        CopyStream(FileOutStream, FileInStream);
+        exit(true);
+    end;
+
+    procedure DeleteFile(OdataId: Text): Boolean
+    begin
+        //DELETE https://{site_url}/_api/web/GetFileByServerRelativeUrl('/Folder Name/{file_name}')
+        SharePointUriBuilder.ResetPath(OdataId);
+
+        SharePointRequestHelper.SetAuthorization(Authorization);
+        SharePointOperationResponse := SharePointRequestHelper.Delete(SharePointUriBuilder);
+        if not SharePointOperationResponse.GetDiagnostics().IsSuccessStatusCode() then
+            exit(false);
+
         exit(true);
     end;
 
@@ -536,6 +568,19 @@ codeunit 9101 "SharePoint Client Impl."
 
         SharePointOperationResponse.GetResultAsText(Result);
         SharePointFolderParser.ParseSingleReturnValue(Result, SharePointFolder);
+        exit(true);
+    end;
+
+    procedure DeleteFolder(OdataId: Text): Boolean
+    begin
+        //DELETE https://{site_url}/_api/web/GetFolderByServerRelativeUrl('{folder_name}')
+        SharePointUriBuilder.ResetPath(OdataId);
+
+        SharePointRequestHelper.SetAuthorization(Authorization);
+        SharePointOperationResponse := SharePointRequestHelper.Delete(SharePointUriBuilder);
+        if not SharePointOperationResponse.GetDiagnostics().IsSuccessStatusCode() then
+            exit(false);
+
         exit(true);
     end;
 

--- a/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
+++ b/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
@@ -513,10 +513,63 @@ codeunit 9101 "SharePoint Client Impl."
         exit(true);
     end;
 
+    procedure DownloadFileContentByServerRelativeUrl(ServerRelativeUrl: Text; var FileInStream: InStream): Boolean
+    begin
+        //GET https://{site_url}/_api/web/GetFileByServerRelativeUrl('/Folder Name/{file_name}')/$value
+        SharePointUriBuilder.ResetPath();
+        SharePointUriBuilder.SetMethod('GetFileByServerRelativeUrl', ServerRelativeUrl);
+        SharePointUriBuilder.SetObject('$value');
+
+        SharePointRequestHelper.SetAuthorization(Authorization);
+        SharePointOperationResponse := SharePointRequestHelper.Get(SharePointUriBuilder);
+        if not SharePointOperationResponse.GetDiagnostics().IsSuccessStatusCode() then
+            exit(false);
+
+        SharePointOperationResponse.GetResultAsStream(FileInStream);
+        exit(true);
+    end;
+
+    procedure DownloadFileContentByServerRelativeUrl(ServerRelativeUrl: Text; FileName: Text): Boolean
+    var
+        FileInStream: InStream;
+    begin
+        if not DownloadFileContentByServerRelativeUrl(ServerRelativeUrl, FileInStream) then
+            exit(false);
+
+        DownloadFromStream(FileInStream, '', '', '', FileName);
+        exit(true);
+    end;
+
+    procedure DownloadFileContentByServerRelativeUrl(ServerRelativeUrl: Text; var TempBlob: Codeunit "Temp Blob"): Boolean
+    var
+        FileInStream: InStream;
+        FileOutStream: OutStream;
+    begin
+        if not DownloadFileContentByServerRelativeUrl(ServerRelativeUrl, FileInStream) then
+            exit(false);
+        TempBlob.CreateOutStream(FileOutStream);
+        CopyStream(FileOutStream, FileInStream);
+        exit(true);
+    end;
+
     procedure DeleteFile(OdataId: Text): Boolean
     begin
         //DELETE https://{site_url}/_api/web/GetFileByServerRelativeUrl('/Folder Name/{file_name}')
         SharePointUriBuilder.ResetPath(OdataId);
+
+        SharePointRequestHelper.SetAuthorization(Authorization);
+        SharePointOperationResponse := SharePointRequestHelper.Delete(SharePointUriBuilder);
+        if not SharePointOperationResponse.GetDiagnostics().IsSuccessStatusCode() then
+            exit(false);
+
+        exit(true);
+    end;
+
+    procedure DeleteFileByServerRelativeUrl(ServerRelativeUrl: Text): Boolean
+    begin
+        //DELETE https://{site_url}/_api/web/GetFileByServerRelativeUrl('/Folder Name/{file_name}')
+        SharePointUriBuilder.ResetPath();
+        SharePointUriBuilder.SetMethod('GetFileByServerRelativeUrl', ServerRelativeUrl);
 
         SharePointRequestHelper.SetAuthorization(Authorization);
         SharePointOperationResponse := SharePointRequestHelper.Delete(SharePointUriBuilder);
@@ -575,6 +628,20 @@ codeunit 9101 "SharePoint Client Impl."
     begin
         //DELETE https://{site_url}/_api/web/GetFolderByServerRelativeUrl('{folder_name}')
         SharePointUriBuilder.ResetPath(OdataId);
+
+        SharePointRequestHelper.SetAuthorization(Authorization);
+        SharePointOperationResponse := SharePointRequestHelper.Delete(SharePointUriBuilder);
+        if not SharePointOperationResponse.GetDiagnostics().IsSuccessStatusCode() then
+            exit(false);
+
+        exit(true);
+    end;
+
+    procedure DeleteFolderByServerRelativeUrl(ServerRelativeUrl: Text): Boolean
+    begin
+        //DELETE https://{site_url}/_api/web/GetFolderByServerRelativeUrl('{folder_name}')
+        SharePointUriBuilder.ResetPath();
+        SharePointUriBuilder.SetMethod('GetFolderByServerRelativeUrl', ServerRelativeUrl);
 
         SharePointRequestHelper.SetAuthorization(Authorization);
         SharePointOperationResponse := SharePointRequestHelper.Delete(SharePointUriBuilder);

--- a/Modules/System/SharePoint/src/helpers/SharePointRequestHelper.Codeunit.al
+++ b/Modules/System/SharePoint/src/helpers/SharePointRequestHelper.Codeunit.al
@@ -35,6 +35,11 @@ codeunit 9109 "SharePoint Request Helper"
         OperationResponse := SendRequest(PrepareRequestMsg("Http Request Type"::POST, SharePointUriBuilder, SharePointHttpContent));
     end;
 
+    procedure Delete(SharePointUriBuilder: Codeunit "SharePoint Uri Builder") OperationResponse: Codeunit "SharePoint Operation Response"
+    begin
+        OperationResponse := SendRequest(PrepareRequestMsg("Http Request Type"::DELETE, SharePointUriBuilder));
+    end;
+
     [NonDebuggable]
     local procedure PrepareRequestMsg(HttpRequestType: Enum "Http Request Type"; SharePointUriBuilder: Codeunit "SharePoint Uri Builder") RequestMessage: HttpRequestMessage
     var


### PR DESCRIPTION
Adds DownloadFileContent() overloads to SharePoint client
Adds new functions DeleteFile() and DeleteFolder() to SharePoint client

This PR can replace PR #22565 and PR #22402 as discussed with @pri-kise and @jwikman in PR #22402 


