### PR TITLE
default values for Permissions with Type=TableData

### DIFF
--- a/Modules/System/Permission Sets/src/PermissionImpl.Codeunit.al
+++ b/Modules/System/Permission Sets/src/PermissionImpl.Codeunit.al
@@ -117,9 +117,9 @@ codeunit 9864 "Permission Impl."
     begin
         if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then begin
             TenantPermission."Read Permission" := TenantPermission."Read Permission"::Yes;
-            TenantPermission."Insert Permission" := TenantPermission."Insert Permission"::Yes;
-            TenantPermission."Modify Permission" := TenantPermission."Modify Permission"::Yes;
-            TenantPermission."Delete Permission" := TenantPermission."Delete Permission"::Yes;
+            TenantPermission."Insert Permission" := TenantPermission."Insert Permission"::" ";
+            TenantPermission."Modify Permission" := TenantPermission."Modify Permission"::" ";
+            TenantPermission."Delete Permission" := TenantPermission."Delete Permission"::" ";
         end else
             TenantPermission."Execute Permission" := TenantPermission."Execute Permission"::Yes;
     end;

--- a/Modules/System/Permission Sets/src/PermissionImpl.Codeunit.al
+++ b/Modules/System/Permission Sets/src/PermissionImpl.Codeunit.al
@@ -229,6 +229,7 @@ codeunit 9864 "Permission Impl."
 
         VerifyPermissionAlreadyExists(TenantPermission);
         EmptyIrrelevantPermissionFields(TenantPermission);
+        SetRelevantPermissionFieldsToYes(TenantPermission);
 
         TenantPermission.Insert();
     end;


### PR DESCRIPTION
**🕮 Describe the issue**

When user creates new permission for a certain permission set, the default values for Table Data are to generous. Only "read permission" should be defaulted to Yes during record initialization. Currently insert, modify and delete are also defaulted to Yes.

**🔧 To Reproduce**

Steps to reproduce the behavior:
1. Go to Permission Sets
2. Click on any user defined permission set or create a new one.
3. Open page permissions
4. Click on "New Line" on permissions subpage.
5. enter some table id, for example 3 (Payment Terms)
6. Observe that all permission types - read, insert, modify and delete are defaulted to Yes

**📣 Expected behavior**

Only Read Permission should be defaulted to Yes and the user can set other permission types to Yes if needed. Similar to the function "Add Read Permission to Related Tables"

**Screenshots**

<img width="1088" alt="image" src="https://user-images.githubusercontent.com/42636293/236218449-719ff2bd-1e78-4c01-8bbe-1904d6d58c3b.png">




