### PR TITLE
remove filters on TableData when objects for permission are being selected

### DIFF
--- a/Modules/System/Permission Sets/src/PermissionImpl.Codeunit.al
+++ b/Modules/System/Permission Sets/src/PermissionImpl.Codeunit.al
@@ -25,8 +25,6 @@ codeunit 9864 "Permission Impl."
         TempAllObjWithCaption: Record AllObjWithCaption temporary;
         Objects: Page Objects;
     begin
-        TempAllObjWithCaption.SetRange("Object Type", TempAllObjWithCaption."Object Type"::TableData);
-
         SetupObjectsPage(SelectObjectsLbl, Objects, TempAllObjWithCaption);
 
         if Objects.RunModal() <> Action::LookupOK then


### PR DESCRIPTION
Our consultants reported that they do not see a value to have filter only on TableData when selecting a group of objects for permissions. Therefore, this pull request with hope that the change can be accepted. If not please let me know so that I can inform the consulting department.