### PR TITLE
Fix translated build jobs

### DIFF
--- a/Build/Scripts/AppTranslations.psm1
+++ b/Build/Scripts/AppTranslations.psm1
@@ -20,7 +20,7 @@ function Restore-TranslationsForApp {
 
     Import-Module $PSScriptRoot\EnlistmentHelperFunctions.psm1 -DisableNameChecking
     $translationsOutputFolder = Join-Path (Get-BaseFolder) "out/translations/"
-    $translationPackagePath = Install-PackageFromConfig -PackageName "AppTranslations" -OutputPath $translationsOutputFolder
+    $translationPackagePath = Install-PackageFromConfig -PackageName "Microsoft.Dynamics.BusinessCentral.Translations" -OutputPath $translationsOutputFolder
     $tranlationsPath = Join-Path $translationPackagePath "Translations"
 
     $translationsFound = $false

--- a/Build/Scripts/AppTranslations.psm1
+++ b/Build/Scripts/AppTranslations.psm1
@@ -12,6 +12,8 @@ function Restore-TranslationsForApp {
         [Parameter(Mandatory=$true)]
         [string] $AppProjectFolder
     )
+    Import-Module $PSScriptRoot\EnlistmentHelperFunctions.psm1 -DisableNameChecking
+
     # Translations need to be restored in the Translations folder in the app folder
     $appTranslationsFolder = Join-Path $AppProjectFolder "Translations"
     New-Directory -Path "$appTranslationsFolder" -ForceEmpty
@@ -20,7 +22,6 @@ function Restore-TranslationsForApp {
    
     Write-Host "Restoring translations for app $appName in $appTranslationsFolder"
 
-    Import-Module $PSScriptRoot\EnlistmentHelperFunctions.psm1 -DisableNameChecking
     $translationsOutputFolder = Join-Path (Get-BaseFolder) "out/translations/"
     $translationPackagePath = Install-PackageFromConfig -PackageName "Microsoft.Dynamics.BusinessCentral.Translations" -OutputPath $translationsOutputFolder
     $tranlationsPath = Join-Path $translationPackagePath "Translations"

--- a/Build/Scripts/AppTranslations.psm1
+++ b/Build/Scripts/AppTranslations.psm1
@@ -14,6 +14,8 @@ function Restore-TranslationsForApp {
     )
     # Translations need to be restored in the Translations folder in the app folder
     $appTranslationsFolder = Join-Path $AppProjectFolder "Translations"
+    New-Directory -Path "$appTranslationsFolder" -ForceEmpty
+    
     $appName = (Get-ChildItem -Path $AppProjectFolder -Filter "app.json" | Get-Content | ConvertFrom-Json).name
    
     Write-Host "Restoring translations for app $appName in $appTranslationsFolder"
@@ -33,7 +35,7 @@ function Restore-TranslationsForApp {
         # Translations are located in the ExtensionsV2 folder
         $translationFilePath = Join-Path $localeFolder "ExtensionsV2/$appName.$locale.xlf" 
         if(Test-Path $translationFilePath) {
-            Write-Host "Using translation for $appName in $locale"
+            Write-Host "Using translation for $appName in $locale. FileName: $translationFilePath"
             $translationsFound = $true
 
             Copy-Item -Path $translationFilePath -Destination $appTranslationsFolder -Force | Out-Null

--- a/Build/Scripts/AppTranslations.psm1
+++ b/Build/Scripts/AppTranslations.psm1
@@ -36,7 +36,7 @@ function Restore-TranslationsForApp {
         # Translations are located in the ExtensionsV2 folder
         $translationFilePath = Join-Path $localeFolder "ExtensionsV2/$appName.$locale.xlf" 
         if(Test-Path $translationFilePath) {
-            Write-Host "Using translation for $appName in $locale. FileName: $translationFilePath"
+            Write-Host "Using translation for $appName in locale $locale."
             $translationsFound = $true
 
             Copy-Item -Path $translationFilePath -Destination $appTranslationsFolder -Force | Out-Null

--- a/Build/Scripts/CompileAppInBcContainer.ps1
+++ b/Build/Scripts/CompileAppInBcContainer.ps1
@@ -23,8 +23,6 @@ if($app)
     }
 
     if($appBuildMode -eq 'Translated') {
-        $parameters["Features"] += @("translationfile")
-
         Import-Module $PSScriptRoot\AppTranslations.psm1
         Restore-TranslationsForApp -AppProjectFolder $parameters["appProjectFolder"]
     }

--- a/Build/Scripts/CompileAppInBcContainer.ps1
+++ b/Build/Scripts/CompileAppInBcContainer.ps1
@@ -23,6 +23,8 @@ if($app)
     }
 
     if($appBuildMode -eq 'Translated') {
+        $parameters["Features"] += @("translationfile")
+
         Import-Module $PSScriptRoot\AppTranslations.psm1
         Restore-TranslationsForApp -AppProjectFolder $parameters["appProjectFolder"]
     }

--- a/Build/Scripts/EnlistmentHelperFunctions.psm1
+++ b/Build/Scripts/EnlistmentHelperFunctions.psm1
@@ -14,6 +14,30 @@ function Get-BuildMode() {
 
 <#
 .Synopsis
+    Creates a new directory if it does not exist. If the directory exists, it will be emptied.
+.Parameter Path
+    The path of the directory to create
+.Parameter ForceEmpty
+    If specified, the directory will be emptied if it exists
+#>
+function New-Directory()
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [string] $Path,
+        [switch] $ForceEmpty
+    )
+    if ($ForceEmpty -and (Test-Path $Path)) {
+        Remove-Item -Path $Path -Recurse -Force | Out-Null
+    }
+
+    if (!(Test-Path $Path)) {
+        New-Item -ItemType Directory -Path $Path | Out-Null
+    }
+}
+
+<#
+.Synopsis
     Get the value of a key from a config file
 .Parameter ConfigType
     The type of config file to read from. Can be either "BuildConfig" or "AL-GO", or "Packages".


### PR DESCRIPTION
- Fix package name 
- Force create `Translations` folder when restoring translations

CICD on branch succeeded: https://github.com/microsoft/ALAppExtensions/actions/runs/4919277665