### PR TITLE
Wrong field APIReportsFinance- external document no.

### DIFF
--- a/Apps/W1/APIReportsFinance/App/src/APIFinCustLedgEntry.Query.al
+++ b/Apps/W1/APIReportsFinance/App/src/APIFinCustLedgEntry.Query.al
@@ -33,7 +33,7 @@ query 30302 "API Fin - Cust Ledg Entry"
             {
                 Caption = 'Document Number';
             }
-            column(externalDocumentNumber; "Document No.")
+            column(externalDocumentNumber; "External Document No.")
             {
                 Caption = 'External Document Number';
             }

--- a/Apps/W1/APIReportsFinance/App/src/APIFinVendLedgEntry.Query.al
+++ b/Apps/W1/APIReportsFinance/App/src/APIFinVendLedgEntry.Query.al
@@ -33,7 +33,7 @@ query 30303 "API Fin - Vend Ledg Entry"
             {
                 Caption = 'Document Number';
             }
-            column(externalDocumentNumber; "Document No.")
+            column(externalDocumentNumber; "External Document No.")
             {
                 Caption = 'External Document Number';
             }

--- a/Apps/W1/APIReportsFinance/App/src/APIFinanceGLEntry.Query.al
+++ b/Apps/W1/APIReportsFinance/App/src/APIFinanceGLEntry.Query.al
@@ -45,7 +45,7 @@ query 30300 "API Finance - GL Entry"
             {
                 Caption = 'Document Number';
             }
-            column(externalDocumentNumber; "Document No.")
+            column(externalDocumentNumber; "External Document No.")
             {
                 Caption = 'External Document Number';
             }


### PR DESCRIPTION
In APIReportsFinance the Customer/Vendor/GL Entries have wrong field for externalDocumentNo, it shows Document No. instead of External Document No.