### PR TITLE
Escape URI ParameterValue for Azure Blob Storage Request URI

### DIFF
--- a/Modules/System/Azure Blob Services API/src/Helper/ABSFormatHelper.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSFormatHelper.Codeunit.al
@@ -8,19 +8,23 @@ codeunit 9044 "ABS Format Helper"
     Access = Internal;
 
     [NonDebuggable]
-    procedure AppendToUri(var Uri: Text; ParameterIdentifier: Text; ParameterValue: Text)
+    procedure AppendToUri(var UriText: Text; ParameterIdentifier: Text; ParameterValue: Text)
     var
+        Uri: Codeunit Uri;
         ConcatChar: Text;
         AppendType1Lbl: Label '%1%2=%3', Comment = '%1 = Concatenation character, %2 = Parameter Identifer, %3 = Parameter Value', Locked = true;
         AppendType2Lbl: Label '%1%2', Comment = '%1 = Concatenation character, %2 = Parameter Value', Locked = true;
+        EscapedParameterValue: Text;
+
     begin
         ConcatChar := '?';
-        if Uri.Contains('?') then
+        if UriText.Contains('?') then
             ConcatChar := '&';
+        EscapedParameterValue := Uri.EscapeDataString(ParameterValue);
         if ParameterIdentifier <> '' then
-            Uri += StrSubstNo(AppendType1Lbl, ConcatChar, ParameterIdentifier, ParameterValue)
+            UriText += StrSubstNo(AppendType1Lbl, ConcatChar, ParameterIdentifier, EscapedParameterValue)
         else
-            Uri += StrSubstNo(AppendType2Lbl, ConcatChar, ParameterValue)
+            UriText += StrSubstNo(AppendType2Lbl, ConcatChar, ParameterValue, EscapedParameterValue)
     end;
 
     [NonDebuggable]


### PR DESCRIPTION
This PR targets the issue that the URI Parameters weren't escaped for the azure blob storage request uri.

https://github.com/microsoft/ALAppExtensions/issues/23475