### PR TITLE
actions for processing multiple permissions

### DIFF
--- a/Modules/System Tests/Permission Sets/src/UpdatingPermissionTests.Codeunit.al
+++ b/Modules/System Tests/Permission Sets/src/UpdatingPermissionTests.Codeunit.al
@@ -1,0 +1,185 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+codeunit 132440 "Updating Permission Tests"
+{
+    // [FEATURE] [Permission Sets] [UT]
+
+    Subtype = Test;
+
+    var
+        LibraryAssert: Codeunit "Library Assert";
+        RoleIdLbl: Label 'Test Set A', Locked = true;
+        PermissionSetNotfoundLbl: Label '%1 permission set could not be found.', Comment = '%1 - Permission set name', Locked = true;
+        Scope: Option System,Tenant;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure UpdateSelectedPermissionLines()
+    var
+        MetadataPermissionSet: Record "Metadata Permission Set";
+        TenantPermission: Record "Tenant Permission";
+        PermissionSetRelation: Codeunit "Permission Set Relation";
+        PermissionImpl: Codeunit "Permission Impl.";
+        NewRoleId: Code[30];
+        NewName: Text;
+        AppId: Guid;
+        NullGuid: Guid;
+        TenantPermissionOriginalCount: Integer;
+    begin
+        // [SCENARIO] Updating a newly created tenant permission set
+
+        // [GIVEN] An existing permission set and a new role ID and name
+        NewRoleId := 'ToBeUpdated';
+        NewName := 'ToBeUpdated';
+
+        MetadataPermissionSet.SetRange("Role ID", RoleIdLbl);
+        LibraryAssert.IsTrue(MetadataPermissionSet.FindFirst(), StrSubstNo(PermissionSetNotfoundLbl, RoleIdLbl));
+        AppId := MetadataPermissionSet."App ID";
+        PermissionSetRelation.CopyPermissionSet(NewRoleId, NewName, RoleIdLbl, AppId, Scope::System, Enum::"Permission Set Copy Type"::Flat);
+
+        // [WHEN] removing all permissions using action for each permission type
+        TenantPermission.SetRange("Role ID", NewRoleId);
+        TenantPermission.SetRange("App ID", NullGuid);
+        TenantPermissionOriginalCount := TenantPermission.Count;
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'R', TenantPermission."Read Permission"::" ");
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'I', TenantPermission."Insert Permission"::" ");
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'M', TenantPermission."Modify Permission"::" ");
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'D', TenantPermission."Delete Permission"::" ");
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'X', TenantPermission."Execute Permission"::" ");
+
+        // [THEN] all permissions have lost all of the permissions previously assigned
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'R', TenantPermission."Read Permission"::" ");
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'I', TenantPermission."Insert Permission"::" ");
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'M', TenantPermission."Modify Permission"::" ");
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'D', TenantPermission."Delete Permission"::" ");
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'X', TenantPermission."Execute Permission"::" ");
+
+        // [WHEN] adding direct access for table data using action for each permission type
+        TenantPermission.SetRange("Object Type", TenantPermission."Object Type"::"Table Data");
+        TenantPermissionOriginalCount := TenantPermission.Count;
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'R', TenantPermission."Read Permission"::"Yes");
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'I', TenantPermission."Insert Permission"::"Yes");
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'M', TenantPermission."Modify Permission"::"Yes");
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'D', TenantPermission."Delete Permission"::"Yes");
+
+        // [THEN] all permissions for table data have direct access
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'R', TenantPermission."Read Permission"::"Yes");
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'I', TenantPermission."Insert Permission"::"Yes");
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'M', TenantPermission."Modify Permission"::"Yes");
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'D', TenantPermission."Delete Permission"::"Yes");
+
+        // [WHEN] adding direct permissions for object types other than table data using action for execute
+        TenantPermission.SetFilter("Object Type", '<>%1', TenantPermission."Object Type"::"Table Data");
+        TenantPermissionOriginalCount := TenantPermission.Count;
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'X', TenantPermission."Execute Permission"::"Yes");
+
+        // [THEN] all permissions have direct permissions
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'X', TenantPermission."Execute Permission"::"Yes");
+
+        // [WHEN] adding indirect access for table data using action for each permission type
+        TenantPermission.SetRange("Object Type", TenantPermission."Object Type"::"Table Data");
+        TenantPermissionOriginalCount := TenantPermission.Count;
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'R', TenantPermission."Read Permission"::"Indirect");
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'I', TenantPermission."Insert Permission"::"Indirect");
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'M', TenantPermission."Modify Permission"::"Indirect");
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'D', TenantPermission."Delete Permission"::"Indirect");
+
+        // [THEN] all permissions for table data have indirect access
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'R', TenantPermission."Read Permission"::"Indirect");
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'I', TenantPermission."Insert Permission"::"Indirect");
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'M', TenantPermission."Modify Permission"::"Indirect");
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'D', TenantPermission."Delete Permission"::"Indirect");
+
+        // [WHEN] adding indirect permissions for object types other than table data using action for execute
+        TenantPermission.SetFilter("Object Type", '<>%1', TenantPermission."Object Type"::"Table Data");
+        TenantPermissionOriginalCount := TenantPermission.Count;
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, 'X', TenantPermission."Execute Permission"::"Indirect");
+
+        // [THEN] all permissions have indirect permissions
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, 'X', TenantPermission."Execute Permission"::"Indirect");
+
+        // [WHEN] removing all permissions using action for all permission types for table data
+        TenantPermission.SetRange("Object Type", TenantPermission."Object Type"::"Table Data");
+        TenantPermissionOriginalCount := TenantPermission.Count;
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, '*', TenantPermission."Read Permission"::" ");
+
+        // [THEN] all permissions have lost all of the permissions previously assigned
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, '*', TenantPermission."Read Permission"::" ");
+
+        // [WHEN] removing all permissions using action for all permission types for object types other than table data
+        TenantPermission.SetFilter("Object Type", '<>%1', TenantPermission."Object Type"::"Table Data");
+        TenantPermissionOriginalCount := TenantPermission.Count;
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, '*', TenantPermission."Read Permission"::" ");
+
+        // [THEN] all permissions have lost all of the permissions previously assigned
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, '*', TenantPermission."Read Permission"::" ");
+
+        // [WHEN] adding direct access for table data using action for all permission types
+        TenantPermission.SetRange("Object Type", TenantPermission."Object Type"::"Table Data");
+        TenantPermissionOriginalCount := TenantPermission.Count;
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, '*', TenantPermission."Read Permission"::"Yes");
+
+        // [THEN] all permissions for table data have direct access
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, '*', TenantPermission."Read Permission"::"Yes");
+
+        // [WHEN] adding direct permissions for object types other than table data using action for execute
+        TenantPermission.SetFilter("Object Type", '<>%1', TenantPermission."Object Type"::"Table Data");
+        TenantPermissionOriginalCount := TenantPermission.Count;
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, '*', TenantPermission."Read Permission"::"Yes");
+
+        // [THEN] all permissions have direct permissions
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, '*', TenantPermission."Read Permission"::"Yes");
+
+        // [WHEN] adding direct access for table data using action for all permission types
+        TenantPermission.SetRange("Object Type", TenantPermission."Object Type"::"Table Data");
+        TenantPermissionOriginalCount := TenantPermission.Count;
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, '*', TenantPermission."Read Permission"::"Indirect");
+
+        // [THEN] all permissions for table data have indirect access
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, '*', TenantPermission."Read Permission"::"Indirect");
+
+        // [WHEN] adding direct permissions for object types other than table data using action for execute
+        TenantPermission.SetFilter("Object Type", '<>%1', TenantPermission."Object Type"::"Table Data");
+        TenantPermissionOriginalCount := TenantPermission.Count;
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, '*', TenantPermission."Read Permission"::"Indirect");
+
+        // [THEN] all permissions have indirect permissions
+        VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, '*', TenantPermission."Read Permission"::"Indirect");
+
+    end;
+
+    local procedure VerifyTenantPermissionsHavePermissionsAssigned(var TenantPermission: Record "Tenant Permission"; TenantPermissionOriginalCount: Integer; RIMDX: Text[1]; PermissionOption: Option)
+    begin
+        case RIMDX of
+            'R':
+                TenantPermission.SetRange("Read Permission", PermissionOption);
+            'I':
+                TenantPermission.SetRange("Insert Permission", PermissionOption);
+            'M':
+                TenantPermission.SetRange("Modify Permission", PermissionOption);
+            'D':
+                TenantPermission.SetRange("Delete Permission", PermissionOption);
+            'X':
+                TenantPermission.SetRange("Execute Permission", PermissionOption);
+            '*':
+                begin
+                    if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then begin
+                        TenantPermission.SetRange("Read Permission", PermissionOption);
+                        TenantPermission.SetRange("Insert Permission", PermissionOption);
+                        TenantPermission.SetRange("Modify Permission", PermissionOption);
+                        TenantPermission.SetRange("Delete Permission", PermissionOption);
+                    end else
+                        TenantPermission.SetRange("Execute Permission", PermissionOption);
+                end;
+        end;
+        LibraryAssert.AreEqual(TenantPermissionOriginalCount, TenantPermission.Count(), 'Update of tenant permissions failed.');
+        TenantPermission.SetRange("Read Permission");
+        TenantPermission.SetRange("Insert Permission");
+        TenantPermission.SetRange("Modify Permission");
+        TenantPermission.SetRange("Delete Permission");
+        TenantPermission.SetRange("Execute Permission");
+    end;
+}

--- a/Modules/System Tests/Permission Sets/src/UpdatingPermissionTests.Codeunit.al
+++ b/Modules/System Tests/Permission Sets/src/UpdatingPermissionTests.Codeunit.al
@@ -125,7 +125,7 @@ codeunit 132440 "Updating Permission Tests"
         // [THEN] all permissions for table data have direct access
         VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, '*', TenantPermission."Read Permission"::"Yes");
 
-        // [WHEN] adding direct permissions for object types other than table data using action for execute
+        // [WHEN] adding direct permissions for object types other than table data using using action for all permission types
         TenantPermission.SetFilter("Object Type", '<>%1', TenantPermission."Object Type"::"Table Data");
         TenantPermissionOriginalCount := TenantPermission.Count;
         PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, '*', TenantPermission."Read Permission"::"Yes");
@@ -141,7 +141,7 @@ codeunit 132440 "Updating Permission Tests"
         // [THEN] all permissions for table data have indirect access
         VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, '*', TenantPermission."Read Permission"::"Indirect");
 
-        // [WHEN] adding direct permissions for object types other than table data using action for execute
+        // [WHEN] adding direct permissions for object types other than table data using using action for all permission types
         TenantPermission.SetFilter("Object Type", '<>%1', TenantPermission."Object Type"::"Table Data");
         TenantPermissionOriginalCount := TenantPermission.Count;
         PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, '*', TenantPermission."Read Permission"::"Indirect");

--- a/Modules/System Tests/Permission Sets/src/UpdatingPermissionTests.Codeunit.al
+++ b/Modules/System Tests/Permission Sets/src/UpdatingPermissionTests.Codeunit.al
@@ -69,7 +69,6 @@ codeunit 132440 "Updating Permission Tests"
         NewRoleId: Code[30];
         NewName: Text;
         AppId: Guid;
-        NullGuid: Guid;
         TenantPermissionOriginalCount: Integer;
     begin
         // [SCENARIO] Updating a newly created tenant permission set
@@ -111,7 +110,6 @@ codeunit 132440 "Updating Permission Tests"
         NewRoleId: Code[30];
         NewName: Text;
         AppId: Guid;
-        NullGuid: Guid;
         TenantPermissionOriginalCount: Integer;
     begin
         // [SCENARIO] Updating a newly created tenant permission set
@@ -160,7 +158,6 @@ codeunit 132440 "Updating Permission Tests"
         NewRoleId: Code[30];
         NewName: Text;
         AppId: Guid;
-        NullGuid: Guid;
         TenantPermissionOriginalCount: Integer;
     begin
         // [SCENARIO] Updating a newly created tenant permission set
@@ -203,7 +200,6 @@ codeunit 132440 "Updating Permission Tests"
         NewRoleId: Code[30];
         NewName: Text;
         AppId: Guid;
-        NullGuid: Guid;
         TenantPermissionOriginalCount: Integer;
     begin
         // [SCENARIO] Updating a newly created tenant permission set
@@ -252,7 +248,6 @@ codeunit 132440 "Updating Permission Tests"
         NewRoleId: Code[30];
         NewName: Text;
         AppId: Guid;
-        NullGuid: Guid;
         TenantPermissionOriginalCount: Integer;
     begin
         // [SCENARIO] Updating a newly created tenant permission set
@@ -284,7 +279,6 @@ codeunit 132440 "Updating Permission Tests"
         VerifyTenantPermissionsHavePermissionsAssigned(TenantPermission, TenantPermissionOriginalCount, '*', TenantPermission."Read Permission"::"Indirect");
     end;
 
-
     local procedure VerifyTenantPermissionsHavePermissionsAssigned(var TenantPermission: Record "Tenant Permission"; TenantPermissionOriginalCount: Integer; RIMDX: Text[1]; PermissionOption: Option)
     begin
         case RIMDX of
@@ -299,15 +293,13 @@ codeunit 132440 "Updating Permission Tests"
             'X':
                 TenantPermission.SetRange("Execute Permission", PermissionOption);
             '*':
-                begin
-                    if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then begin
-                        TenantPermission.SetRange("Read Permission", PermissionOption);
-                        TenantPermission.SetRange("Insert Permission", PermissionOption);
-                        TenantPermission.SetRange("Modify Permission", PermissionOption);
-                        TenantPermission.SetRange("Delete Permission", PermissionOption);
-                    end else
-                        TenantPermission.SetRange("Execute Permission", PermissionOption);
-                end;
+                if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then begin
+                    TenantPermission.SetRange("Read Permission", PermissionOption);
+                    TenantPermission.SetRange("Insert Permission", PermissionOption);
+                    TenantPermission.SetRange("Modify Permission", PermissionOption);
+                    TenantPermission.SetRange("Delete Permission", PermissionOption);
+                end else
+                    TenantPermission.SetRange("Execute Permission", PermissionOption);
         end;
         LibraryAssert.AreEqual(TenantPermissionOriginalCount, TenantPermission.Count(), 'Update of tenant permissions failed.');
         TenantPermission.SetRange("Read Permission");

--- a/Modules/System/Permission Sets/src/PermissionImpl.Codeunit.al
+++ b/Modules/System/Permission Sets/src/PermissionImpl.Codeunit.al
@@ -121,25 +121,23 @@ codeunit 9864 "Permission Impl."
                                 ModifyPermissionLine := true;
                             end;
                     '*':
-                        begin
-                            if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then begin
-                                if (TenantPermission."Read Permission" <> PermissionOption) or
-                                    (TenantPermission."Insert Permission" <> PermissionOption) or
-                                    (TenantPermission."Modify Permission" <> PermissionOption) or
-                                    (TenantPermission."Delete Permission" <> PermissionOption)
-                                then begin
-                                    TenantPermission."Read Permission" := PermissionOption;
-                                    TenantPermission."Insert Permission" := PermissionOption;
-                                    TenantPermission."Modify Permission" := PermissionOption;
-                                    TenantPermission."Delete Permission" := PermissionOption;
-                                    ModifyPermissionLine := true;
-                                end;
-                            end else
-                                if TenantPermission."Execute Permission" <> PermissionOption then begin
-                                    TenantPermission."Execute Permission" := PermissionOption;
-                                    ModifyPermissionLine := true;
-                                end;
-                        end;
+                        if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then begin
+                            if (TenantPermission."Read Permission" <> PermissionOption) or
+                                (TenantPermission."Insert Permission" <> PermissionOption) or
+                                (TenantPermission."Modify Permission" <> PermissionOption) or
+                                (TenantPermission."Delete Permission" <> PermissionOption)
+                            then begin
+                                TenantPermission."Read Permission" := PermissionOption;
+                                TenantPermission."Insert Permission" := PermissionOption;
+                                TenantPermission."Modify Permission" := PermissionOption;
+                                TenantPermission."Delete Permission" := PermissionOption;
+                                ModifyPermissionLine := true;
+                            end;
+                        end else
+                            if TenantPermission."Execute Permission" <> PermissionOption then begin
+                                TenantPermission."Execute Permission" := PermissionOption;
+                                ModifyPermissionLine := true;
+                            end;
                 end;
                 if ModifyPermissionLine then
                     TenantPermission.Modify();

--- a/Modules/System/Permission Sets/src/PermissionImpl.Codeunit.al
+++ b/Modules/System/Permission Sets/src/PermissionImpl.Codeunit.al
@@ -88,6 +88,7 @@ codeunit 9864 "Permission Impl."
     begin
         if TenantPermission.FindSet() then
             repeat
+                ModifyPermissionLine := false;
                 case RIMDX of
                     'R':
                         if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then
@@ -97,8 +98,8 @@ codeunit 9864 "Permission Impl."
                             end;
                     'I':
                         if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then
-                            if TenantPermission."Read Permission" <> PermissionOption then begin
-                                TenantPermission."Read Permission" := PermissionOption;
+                            if TenantPermission."Insert Permission" <> PermissionOption then begin
+                                TenantPermission."Insert Permission" := PermissionOption;
                                 ModifyPermissionLine := true;
                             end;
                     'M':

--- a/Modules/System/Permission Sets/src/PermissionImpl.Codeunit.al
+++ b/Modules/System/Permission Sets/src/PermissionImpl.Codeunit.al
@@ -82,6 +82,69 @@ codeunit 9864 "Permission Impl."
         ExecutePermissionAsTxt := GetPermissionAsTxt(TenantPermission.Type, TenantPermission."Execute Permission");
     end;
 
+    procedure UpdateSelectedPermissionLines(var TenantPermission: Record "Tenant Permission"; RIMDX: Text[1]; PermissionOption: Option)
+    var
+        ModifyPermissionLine: Boolean;
+    begin
+        if TenantPermission.FindSet() then
+            repeat
+                case RIMDX of
+                    'R':
+                        if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then
+                            if TenantPermission."Read Permission" <> PermissionOption then begin
+                                TenantPermission."Read Permission" := PermissionOption;
+                                ModifyPermissionLine := true;
+                            end;
+                    'I':
+                        if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then
+                            if TenantPermission."Read Permission" <> PermissionOption then begin
+                                TenantPermission."Read Permission" := PermissionOption;
+                                ModifyPermissionLine := true;
+                            end;
+                    'M':
+                        if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then
+                            if TenantPermission."Modify Permission" <> PermissionOption then begin
+                                TenantPermission."Modify Permission" := PermissionOption;
+                                ModifyPermissionLine := true;
+                            end;
+                    'D':
+                        if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then
+                            if TenantPermission."Delete Permission" <> PermissionOption then begin
+                                TenantPermission."Delete Permission" := PermissionOption;
+                                ModifyPermissionLine := true;
+                            end;
+                    'X':
+                        if TenantPermission."Object Type" <> TenantPermission."Object Type"::"Table Data" then
+                            if TenantPermission."Execute Permission" <> PermissionOption then begin
+                                TenantPermission."Execute Permission" := PermissionOption;
+                                ModifyPermissionLine := true;
+                            end;
+                    '*':
+                        begin
+                            if TenantPermission."Object Type" = TenantPermission."Object Type"::"Table Data" then begin
+                                if (TenantPermission."Read Permission" <> PermissionOption) or
+                                    (TenantPermission."Insert Permission" <> PermissionOption) or
+                                    (TenantPermission."Modify Permission" <> PermissionOption) or
+                                    (TenantPermission."Delete Permission" <> PermissionOption)
+                                then begin
+                                    TenantPermission."Read Permission" := PermissionOption;
+                                    TenantPermission."Insert Permission" := PermissionOption;
+                                    TenantPermission."Modify Permission" := PermissionOption;
+                                    TenantPermission."Delete Permission" := PermissionOption;
+                                    ModifyPermissionLine := true;
+                                end;
+                            end else
+                                if TenantPermission."Execute Permission" <> PermissionOption then begin
+                                    TenantPermission."Execute Permission" := PermissionOption;
+                                    ModifyPermissionLine := true;
+                                end;
+                        end;
+                end;
+                if ModifyPermissionLine then
+                    TenantPermission.Modify();
+            until TenantPermission.Next() = 0;
+    end;
+
     procedure IsPermissionEmpty(var TenantPermission: Record "Tenant Permission"): Boolean
     begin
         exit(

--- a/Modules/System/Permission Sets/src/TenantPermissionSubForm.page.al
+++ b/Modules/System/Permission Sets/src/TenantPermissionSubForm.page.al
@@ -256,6 +256,275 @@ page 9859 "Tenant Permission Subform"
                         until TenantPermission.Next() = 0;
                 end;
             }
+            group("Allow Read")
+            {
+                Caption = 'Allow Read';
+                Enabled = "Object Type" = "Object Type"::"Table Data";
+                Image = Confirm;
+                action(AllowReadYes)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Yes';
+                    Image = Approve;
+                    ToolTip = 'Allow access to read data in the object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('R', "Read Permission"::Yes);
+                    end;
+                }
+                action(AllowReadNo)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'No';
+                    Image = Reject;
+                    ToolTip = 'Disallow access to read data in the object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('R', "Read Permission"::" ");
+                    end;
+                }
+                action(AllowReadIndirect)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Indirect';
+                    Image = Indent;
+                    ToolTip = 'Allow access to read data in the object if there is read access to a related object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('R', "Read Permission"::Indirect);
+                    end;
+                }
+            }
+            group("Allow Insertion")
+            {
+                Caption = 'Allow Insertion';
+                Enabled = "Object Type" = "Object Type"::"Table Data";
+                Image = Confirm;
+                action(AllowInsertYes)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Yes';
+                    Image = Approve;
+                    ToolTip = 'Allow access to insert data in the object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('I', "Insert Permission"::Yes);
+                    end;
+                }
+                action(AllowInsertNo)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'No';
+                    Image = Reject;
+                    ToolTip = 'Disallow access to insert data in the object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('I', "Insert Permission"::" ");
+                    end;
+                }
+                action(AllowInsertIndirect)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Indirect';
+                    Image = Indent;
+                    ToolTip = 'Allow access to insert data in the object if there is insert access to a related object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('I', "Insert Permission"::Indirect);
+                    end;
+                }
+            }
+            group("Allow Modification")
+            {
+                Caption = 'Allow Modification';
+                Enabled = "Object Type" = "Object Type"::"Table Data";
+                Image = Confirm;
+                action(AllowModifyYes)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Yes';
+                    Image = Approve;
+                    ToolTip = 'Allow access to modify data in the object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('M', "Modify Permission"::Yes);
+                    end;
+                }
+                action(AllowModifyNo)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'No';
+                    Image = Reject;
+                    ToolTip = 'Disallow access to modify data in the object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('M', "Modify Permission"::" ");
+                    end;
+                }
+                action(AllowModifyIndirect)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Indirect';
+                    Image = Indent;
+                    ToolTip = 'Allow access to modify data in the object if there is modify access to a related object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('M', "Modify Permission"::Indirect);
+                    end;
+                }
+            }
+            group("Allow Deletion")
+            {
+                Caption = 'Allow Deletion';
+                Enabled = "Object Type" = "Object Type"::"Table Data";
+                Image = Confirm;
+                action(AllowDeleteYes)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Yes';
+                    Image = Approve;
+                    ToolTip = 'Allow access to delete data in the object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('D', "Delete Permission"::Yes);
+                    end;
+                }
+                action(AllowDeleteNo)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'No';
+                    Image = Reject;
+                    ToolTip = 'Disallow access to delete data in the object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('D', "Delete Permission"::" ");
+                    end;
+                }
+                action(AllowDeleteIndirect)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Indirect';
+                    Image = Indent;
+                    ToolTip = 'Allow access to delete data in the object if there is delete access to a related object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('D', "Delete Permission"::Indirect);
+                    end;
+                }
+            }
+            group("Allow Execution")
+            {
+                Caption = 'Allow Execution';
+                Enabled = "Object Type" <> "Object Type"::"Table Data";
+                Image = Confirm;
+                action(AllowExecuteYes)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Yes';
+                    Image = Approve;
+                    ToolTip = 'Allow access to execute functions in the object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('X', "Execute Permission"::Yes);
+                    end;
+                }
+                action(AllowExecuteNo)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'No';
+                    Image = Reject;
+                    ToolTip = 'Disallow access to execute functions in the object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('X', "Execute Permission"::" ");
+                    end;
+                }
+                action(AllowExecuteIndirect)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Indirect';
+                    Image = Indent;
+                    ToolTip = 'Allow access to execute functions in the object if there is execute access to a related object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('X', "Execute Permission"::Indirect);
+                    end;
+                }
+            }
+            group("Allow All")
+            {
+                Caption = 'Allow All';
+                Image = Confirm;
+                action(AllowAllYes)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Yes';
+                    Image = Approve;
+                    ToolTip = 'Allow access to perform all actions in the object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('*', "Read Permission"::Yes);
+                    end;
+                }
+                action(AllowAllNo)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'No';
+                    Image = Reject;
+                    ToolTip = 'Disallow access to perform all actions in the object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('*', "Read Permission"::" ");
+                    end;
+                }
+                action(AllowAllIndirect)
+                {
+                    AccessByPermission = TableData "Tenant Permission" = M;
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Indirect';
+                    Image = Indent;
+                    ToolTip = 'Allow access to perform all actions in the object if there is full access to a related object.';
+
+                    trigger OnAction()
+                    begin
+                        UpdateSelected('*', "Read Permission"::Indirect);
+                    end;
+                }
+            }
         }
     }
 
@@ -373,6 +642,46 @@ page 9859 "Tenant Permission Subform"
     begin
         PermissionSetRelationImpl.RefreshPermissionSets(CurrentRoleID, CurrentAppID, CurrentScope);
         CurrPage.Update(false);
+    end;
+
+    local procedure UpdateSelected(RIMDX: Text[1]; PermissionOption: Option)
+    var
+        TenantPermission: Record "Tenant Permission";
+        OriginalTenantPermission: Record "Tenant Permission";
+    begin
+        CurrPage.SetSelectionFilter(TenantPermission);
+
+        if TenantPermission.FindSet() then
+            repeat
+                case RIMDX of
+                    'R':
+                        if TenantPermission."Object Type" = "Object Type"::"Table Data" then
+                            TenantPermission."Read Permission" := PermissionOption;
+                    'I':
+                        if TenantPermission."Object Type" = "Object Type"::"Table Data" then
+                            TenantPermission."Insert Permission" := PermissionOption;
+                    'M':
+                        if TenantPermission."Object Type" = "Object Type"::"Table Data" then
+                            TenantPermission."Modify Permission" := PermissionOption;
+                    'D':
+                        if TenantPermission."Object Type" = "Object Type"::"Table Data" then
+                            TenantPermission."Delete Permission" := PermissionOption;
+                    'X':
+                        if TenantPermission."Object Type" <> "Object Type"::"Table Data" then
+                            TenantPermission."Execute Permission" := PermissionOption;
+                    '*':
+                        begin
+                            if TenantPermission."Object Type" = "Object Type"::"Table Data" then begin
+                                TenantPermission."Read Permission" := PermissionOption;
+                                TenantPermission."Insert Permission" := PermissionOption;
+                                TenantPermission."Modify Permission" := PermissionOption;
+                                TenantPermission."Delete Permission" := PermissionOption;
+                            end else
+                                TenantPermission."Execute Permission" := PermissionOption;
+                        end;
+                end;
+                TenantPermission.Modify();
+            until TenantPermission.Next() = 0;
     end;
 
     var

--- a/Modules/System/Permission Sets/src/TenantPermissionSubForm.page.al
+++ b/Modules/System/Permission Sets/src/TenantPermissionSubForm.page.al
@@ -301,9 +301,9 @@ page 9859 "Tenant Permission Subform"
                     end;
                 }
             }
-            group("Allow Insertion")
+            group("Allow Insert")
             {
-                Caption = 'Allow Insertion';
+                Caption = 'Allow Insert';
                 Enabled = "Object Type" = "Object Type"::"Table Data";
                 Image = Confirm;
                 action(AllowInsertYes)
@@ -346,9 +346,9 @@ page 9859 "Tenant Permission Subform"
                     end;
                 }
             }
-            group("Allow Modification")
+            group("Allow Modify")
             {
-                Caption = 'Allow Modification';
+                Caption = 'Allow Modify';
                 Enabled = "Object Type" = "Object Type"::"Table Data";
                 Image = Confirm;
                 action(AllowModifyYes)
@@ -391,9 +391,9 @@ page 9859 "Tenant Permission Subform"
                     end;
                 }
             }
-            group("Allow Deletion")
+            group("Allow Delete")
             {
-                Caption = 'Allow Deletion';
+                Caption = 'Allow Delete';
                 Enabled = "Object Type" = "Object Type"::"Table Data";
                 Image = Confirm;
                 action(AllowDeleteYes)
@@ -436,9 +436,9 @@ page 9859 "Tenant Permission Subform"
                     end;
                 }
             }
-            group("Allow Execution")
+            group("Allow Execute")
             {
-                Caption = 'Allow Execution';
+                Caption = 'Allow Execute';
                 Enabled = "Object Type" <> "Object Type"::"Table Data";
                 Image = Confirm;
                 action(AllowExecuteYes)

--- a/Modules/System/Permission Sets/src/TenantPermissionSubForm.page.al
+++ b/Modules/System/Permission Sets/src/TenantPermissionSubForm.page.al
@@ -271,7 +271,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('R', "Read Permission"::Yes);
+                        UpdateSelectedPermissionLines('R', "Read Permission"::Yes);
                     end;
                 }
                 action(AllowReadNo)
@@ -284,7 +284,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('R', "Read Permission"::" ");
+                        UpdateSelectedPermissionLines('R', "Read Permission"::" ");
                     end;
                 }
                 action(AllowReadIndirect)
@@ -297,7 +297,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('R', "Read Permission"::Indirect);
+                        UpdateSelectedPermissionLines('R', "Read Permission"::Indirect);
                     end;
                 }
             }
@@ -316,7 +316,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('I', "Insert Permission"::Yes);
+                        UpdateSelectedPermissionLines('I', "Insert Permission"::Yes);
                     end;
                 }
                 action(AllowInsertNo)
@@ -329,7 +329,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('I', "Insert Permission"::" ");
+                        UpdateSelectedPermissionLines('I', "Insert Permission"::" ");
                     end;
                 }
                 action(AllowInsertIndirect)
@@ -342,7 +342,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('I', "Insert Permission"::Indirect);
+                        UpdateSelectedPermissionLines('I', "Insert Permission"::Indirect);
                     end;
                 }
             }
@@ -361,7 +361,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('M', "Modify Permission"::Yes);
+                        UpdateSelectedPermissionLines('M', "Modify Permission"::Yes);
                     end;
                 }
                 action(AllowModifyNo)
@@ -374,7 +374,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('M', "Modify Permission"::" ");
+                        UpdateSelectedPermissionLines('M', "Modify Permission"::" ");
                     end;
                 }
                 action(AllowModifyIndirect)
@@ -387,7 +387,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('M', "Modify Permission"::Indirect);
+                        UpdateSelectedPermissionLines('M', "Modify Permission"::Indirect);
                     end;
                 }
             }
@@ -406,7 +406,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('D', "Delete Permission"::Yes);
+                        UpdateSelectedPermissionLines('D', "Delete Permission"::Yes);
                     end;
                 }
                 action(AllowDeleteNo)
@@ -419,7 +419,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('D', "Delete Permission"::" ");
+                        UpdateSelectedPermissionLines('D', "Delete Permission"::" ");
                     end;
                 }
                 action(AllowDeleteIndirect)
@@ -432,7 +432,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('D', "Delete Permission"::Indirect);
+                        UpdateSelectedPermissionLines('D', "Delete Permission"::Indirect);
                     end;
                 }
             }
@@ -451,7 +451,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('X', "Execute Permission"::Yes);
+                        UpdateSelectedPermissionLines('X', "Execute Permission"::Yes);
                     end;
                 }
                 action(AllowExecuteNo)
@@ -464,7 +464,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('X', "Execute Permission"::" ");
+                        UpdateSelectedPermissionLines('X', "Execute Permission"::" ");
                     end;
                 }
                 action(AllowExecuteIndirect)
@@ -477,7 +477,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('X', "Execute Permission"::Indirect);
+                        UpdateSelectedPermissionLines('X', "Execute Permission"::Indirect);
                     end;
                 }
             }
@@ -495,7 +495,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('*', "Read Permission"::Yes);
+                        UpdateSelectedPermissionLines('*', "Read Permission"::Yes);
                     end;
                 }
                 action(AllowAllNo)
@@ -508,7 +508,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('*', "Read Permission"::" ");
+                        UpdateSelectedPermissionLines('*', "Read Permission"::" ");
                     end;
                 }
                 action(AllowAllIndirect)
@@ -521,7 +521,7 @@ page 9859 "Tenant Permission Subform"
 
                     trigger OnAction()
                     begin
-                        UpdateSelected('*', "Read Permission"::Indirect);
+                        UpdateSelectedPermissionLines('*', "Read Permission"::Indirect);
                     end;
                 }
             }
@@ -644,44 +644,12 @@ page 9859 "Tenant Permission Subform"
         CurrPage.Update(false);
     end;
 
-    local procedure UpdateSelected(RIMDX: Text[1]; PermissionOption: Option)
+    local procedure UpdateSelectedPermissionLines(RIMDX: Text[1]; PermissionOption: Option)
     var
         TenantPermission: Record "Tenant Permission";
-        OriginalTenantPermission: Record "Tenant Permission";
     begin
         CurrPage.SetSelectionFilter(TenantPermission);
-
-        if TenantPermission.FindSet() then
-            repeat
-                case RIMDX of
-                    'R':
-                        if TenantPermission."Object Type" = "Object Type"::"Table Data" then
-                            TenantPermission."Read Permission" := PermissionOption;
-                    'I':
-                        if TenantPermission."Object Type" = "Object Type"::"Table Data" then
-                            TenantPermission."Insert Permission" := PermissionOption;
-                    'M':
-                        if TenantPermission."Object Type" = "Object Type"::"Table Data" then
-                            TenantPermission."Modify Permission" := PermissionOption;
-                    'D':
-                        if TenantPermission."Object Type" = "Object Type"::"Table Data" then
-                            TenantPermission."Delete Permission" := PermissionOption;
-                    'X':
-                        if TenantPermission."Object Type" <> "Object Type"::"Table Data" then
-                            TenantPermission."Execute Permission" := PermissionOption;
-                    '*':
-                        begin
-                            if TenantPermission."Object Type" = "Object Type"::"Table Data" then begin
-                                TenantPermission."Read Permission" := PermissionOption;
-                                TenantPermission."Insert Permission" := PermissionOption;
-                                TenantPermission."Modify Permission" := PermissionOption;
-                                TenantPermission."Delete Permission" := PermissionOption;
-                            end else
-                                TenantPermission."Execute Permission" := PermissionOption;
-                        end;
-                end;
-                TenantPermission.Modify();
-            until TenantPermission.Next() = 0;
+        PermissionImpl.UpdateSelectedPermissionLines(TenantPermission, RIMDX, PermissionOption);
     end;
 
     var


### PR DESCRIPTION
The goal is to introduce the actions that existed on the page that is marked as obsoleted and named "Permissions (legacy)" on a page listing all permission sets. Processing multiple objects in a batch was highly appreciated feature so far.

How it looked on a paged marked for obsoletion:
<img width="961" alt="image" src="https://github.com/microsoft/ALAppExtensions/assets/42636293/f3884473-e826-4859-8ff8-50d7d0fbdf16">

How it is desired to look a new permission set card page:
<img width="902" alt="image" src="https://github.com/microsoft/ALAppExtensions/assets/42636293/e31ca2e7-1339-412c-8035-cece7008642f">



