### PR TITLE
GP migration bug fixes, May 2023

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Accounts/GPAccountMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Accounts/GPAccountMigrator.codeunit.al
@@ -114,8 +114,12 @@ codeunit 4017 "GP Account Migrator"
 #endif
     var
         GPAccount: Record "GP Account";
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
     begin
         if RecordIdToMigrate.TableNo() <> Database::"GP Account" then
+            exit;
+
+        if GPCompanyAdditionalSettings.GetMigrateOnlyGLMaster() then
             exit;
 
         GPAccount.Get(RecordIdToMigrate);

--- a/Apps/W1/HybridGP/app/src/Migration/GPTables/GPPopulateCombinedTables.Codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/GPTables/GPPopulateCombinedTables.Codeunit.al
@@ -691,6 +691,7 @@ codeunit 40125 "GP Populate Combined Tables"
         GPPopulateItemTransactions: Query "GP Populate Item Transactions";
     begin
         GPPopulateItemTransactions.SetRange(RCPTSOLD, false);
+        GPPopulateItemTransactions.SetRange(QTYTYPE, 1);
         GPPopulateItemTransactions.Open();
         while GPPopulateItemTransactions.Read() do begin
             Clear(GPItemTransactions);

--- a/Apps/W1/HybridGP/app/src/Migration/Items/GPPopulateItemTransactions.Query.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Items/GPPopulateItemTransactions.Query.al
@@ -35,12 +35,15 @@ query 40100 "GP Populate Item Transactions"
             {
             }
 
-
             column(QTYRECVD; QTYRECVD)
             {
             }
 
             column(QTYSOLD; QTYSOLD)
+            {
+            }
+
+            column(QTYTYPE; QTYTYPE)
             {
             }
 

--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorAddress.table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorAddress.table.al
@@ -1,7 +1,7 @@
 table 4049 "GP Vendor Address"
 {
-    ReplicateData = false;
     Permissions = tabledata "Ship-to Address" = rim;
+    DataClassification = CustomerContent;
 
     fields
     {


### PR DESCRIPTION
This update fixes four issues found within the GP migration.

**Item on hand quantity incorrect**
- Item on hand quantity no longer includes damaged, returned, in use, or in service counts.

**Vendor/Customer posting group assignment issue**
- Fixed an issue where Vendor and Customer posting groups were not getting assigned every time.

**Master data only should not migrate beginning balances**
- Don't generate beginning balances when migrating on master data.

**Vendor Address replication issue**
- Removed the [ReplicateData = false] property from the GP Vendor Address staging table. This was causing Vendor Addresses not to be replicated in a PTE, but would also cause the same issue for the main extension if the table hardcodings are removed in the service.