### PR TITLE
Add ready SAS authorization

### DIFF
--- a/Modules/System/Azure Storage Services Authorization/src/ReadySAS/StorServAuthReadySAS.Codeunit.al
+++ b/Modules/System/Azure Storage Services Authorization/src/ReadySAS/StorServAuthReadySAS.Codeunit.al
@@ -16,7 +16,6 @@ codeunit 9065 "Stor. Serv. Auth. Ready SAS" implements "Storage Service Authoriz
         UriBuilder: Codeunit "Uri Builder";
         UriText, QueryText : Text;
     begin
-        StorageAccountName := StorageAccount;
         UriText := HttpRequestMessage.GetRequestUri();
 
         UriBuilder.Init(UriText);

--- a/Modules/System/Azure Storage Services Authorization/src/ReadySAS/StorServAuthReadySAS.Codeunit.al
+++ b/Modules/System/Azure Storage Services Authorization/src/ReadySAS/StorServAuthReadySAS.Codeunit.al
@@ -44,6 +44,8 @@ codeunit 9065 "Stor. Serv. Auth. Ready SAS" implements "Storage Service Authoriz
     procedure SetSharedAccessSignature(NewSharedAccessSignature: Text)
     begin
         SharedAccessSignature := NewSharedAccessSignature;
+        if SharedAccessSignature.StartsWith('?') then
+            SharedAccessSignature := DelChr(SharedAccessSignature, '<', '?');
     end;
 
     var

--- a/Modules/System/Azure Storage Services Authorization/src/ReadySAS/StorServAuthReadySAS.Codeunit.al
+++ b/Modules/System/Azure Storage Services Authorization/src/ReadySAS/StorServAuthReadySAS.Codeunit.al
@@ -1,0 +1,51 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+codeunit 9065 "Stor. Serv. Auth. Ready SAS" implements "Storage Service Authorization"
+{
+    Access = Internal;
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    [NonDebuggable]
+    procedure Authorize(var HttpRequestMessage: HttpRequestMessage; StorageAccount: Text)
+    var
+        Uri: Codeunit Uri;
+        UriBuilder: Codeunit "Uri Builder";
+        UriText, QueryText : Text;
+    begin
+        StorageAccountName := StorageAccount;
+        UriText := HttpRequestMessage.GetRequestUri();
+
+        UriBuilder.Init(UriText);
+        QueryText := UriBuilder.GetQuery();
+
+        QueryText := DelChr(QueryText, '<', '?'); // remove ? from the query
+
+        if QueryText <> '' then
+            QueryText += '&';
+        QueryText += GetSharedAccessSignature();
+        UriBuilder.SetQuery(QueryText);
+
+        UriBuilder.GetUri(Uri);
+
+        HttpRequestMessage.SetRequestUri(Uri.GetAbsoluteUri());
+    end;
+
+    [NonDebuggable]
+    procedure GetSharedAccessSignature(): Text
+    begin
+        exit(SharedAccessSignature);
+    end;
+
+    [NonDebuggable]
+    procedure SetSharedAccessSignature(NewSharedAccessSignature: Text)
+    begin
+        SharedAccessSignature := NewSharedAccessSignature;
+    end;
+
+    var
+        SharedAccessSignature: Text;
+}

--- a/Modules/System/Azure Storage Services Authorization/src/SAS/StorServAuthSAS.Codeunit.al
+++ b/Modules/System/Azure Storage Services Authorization/src/SAS/StorServAuthSAS.Codeunit.al
@@ -24,7 +24,9 @@ codeunit 9061 "Stor. Serv. Auth. SAS" implements "Storage Service Authorization"
 
         QueryText := DelChr(QueryText, '<', '?'); // remove ? from the query
 
-        QueryText += '&' + GetSharedAccessSignature();
+        if QueryText <> '' then
+            QueryText += '&';
+        QueryText += GetSharedAccessSignature();
         UriBuilder.SetQuery(QueryText);
 
         UriBuilder.GetUri(Uri);

--- a/Modules/System/Azure Storage Services Authorization/src/StorServAuthImpl.Codeunit.al
+++ b/Modules/System/Azure Storage Services Authorization/src/StorServAuthImpl.Codeunit.al
@@ -50,6 +50,16 @@ codeunit 9063 "Stor. Serv. Auth. Impl."
         exit(StorServAuthSharedKey);
     end;
 
+    [NonDebuggable]
+    procedure ReadySAS(SASToken: Text)
+    var
+        StorServAuthReadySAS: Codeunit "Stor. Serv. Auth. Ready SAS";
+    begin
+        StorServAuthReadySAS.SetSharedAccessSignature(SASToken);
+
+        exit(StorServAuthReadySAS);
+    end;
+
     procedure GetDefaultAPIVersion(): Enum "Storage Service API Version"
     begin
         exit(Enum::"Storage Service API Version"::"2020-10-02");

--- a/Modules/System/Azure Storage Services Authorization/src/StorServAuthImpl.Codeunit.al
+++ b/Modules/System/Azure Storage Services Authorization/src/StorServAuthImpl.Codeunit.al
@@ -51,7 +51,7 @@ codeunit 9063 "Stor. Serv. Auth. Impl."
     end;
 
     [NonDebuggable]
-    procedure ReadySAS(SASToken: Text)
+    procedure ReadySAS(SASToken: Text): Interface "Storage Service Authorization"
     var
         StorServAuthReadySAS: Codeunit "Stor. Serv. Auth. Ready SAS";
     begin

--- a/Modules/System/Azure Storage Services Authorization/src/StorageServiceAuthorization.Codeunit.al
+++ b/Modules/System/Azure Storage Services Authorization/src/StorageServiceAuthorization.Codeunit.al
@@ -81,6 +81,20 @@ codeunit 9062 "Storage Service Authorization"
     end;
 
     /// <summary>
+    /// Uses a pre-generated account SAS (Shared Access Signature) for authorizing HTTP request to Azure Storage Services.
+    /// see: https://go.microsoft.com/fwlink/?linkid=2210398
+    /// </summary>
+    /// <param name="SASToken">A pre-generated SAS token.</param>
+    /// <returns>An account SAS authorization.</returns>
+    [NonDebuggable]
+    procedure UseReadySAS(SASToken: Text;): Interface "Storage Service Authorization"
+    var
+        StorServAuthImpl: Codeunit "Stor. Serv. Auth. Impl.";
+    begin
+        exit(StorServAuthImpl.ReadySAS(SASToken));
+    end;
+
+    /// <summary>
     /// Get the default Storage Service API Version.
     /// </summary>
     /// <returns>The default Storage Service API Version</returns>

--- a/Modules/System/Azure Storage Services Authorization/src/StorageServiceAuthorization.Codeunit.al
+++ b/Modules/System/Azure Storage Services Authorization/src/StorageServiceAuthorization.Codeunit.al
@@ -87,7 +87,7 @@ codeunit 9062 "Storage Service Authorization"
     /// <param name="SASToken">A pre-generated SAS token.</param>
     /// <returns>An account SAS authorization.</returns>
     [NonDebuggable]
-    procedure UseReadySAS(SASToken: Text;): Interface "Storage Service Authorization"
+    procedure UseReadySAS(SASToken: Text): Interface "Storage Service Authorization"
     var
         StorServAuthImpl: Codeunit "Stor. Serv. Auth. Impl.";
     begin


### PR DESCRIPTION
- Add new authorization option to use pre-generated SAS Token.
This allows to use a token that was generated directly in azure portal, the benefit is that we don't have to store storage account key in BC.
- Fix unnecessary '&' being appended to query text if there weren't any parameters in the query in SAS authorization.