### PR TITLE
Additional GP migration updates for May 2023

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerAddress.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerAddress.Table.al
@@ -72,6 +72,9 @@ table 4048 "GP Customer Address"
     var
         ShipToAddress: Record "Ship-to Address";
         Customer: Record Customer;
+        GPSY01200: Record "GP SY01200";
+        MailManagement: Codeunit "Mail Management";
+        EmailAddress: Text[80];
         Exists: Boolean;
     begin
         if Customer.Get(CUSTNMBR) then begin
@@ -96,6 +99,14 @@ table 4048 "GP Customer Address"
 
             if (CopyStr(ShipToAddress."Fax No.", 1, 14) = '00000000000000') then
                 ShipToAddress."Fax No." := '';
+
+            if GPSY01200.Get('CUS', CUSTNMBR, ADRSCODE) then
+                EmailAddress := CopyStr(GPSY01200.INET1.Trim(), 1, MaxStrLen(ShipToAddress."E-Mail"));
+
+#pragma warning disable AA0139
+            if MailManagement.ValidateEmailAddressField(EmailAddress) then
+                ShipToAddress."E-Mail" := EmailAddress;
+#pragma warning restore AA0139
 
             if not Exists then
                 ShipToAddress.Insert()

--- a/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerAddress.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerAddress.Table.al
@@ -100,7 +100,7 @@ table 4048 "GP Customer Address"
             if (CopyStr(ShipToAddress."Fax No.", 1, 14) = '00000000000000') then
                 ShipToAddress."Fax No." := '';
 
-            if GPSY01200.Get('CUS', CUSTNMBR, ADRSCODE) then
+            if GPSY01200.Get(CustomerEmailTypeCodeLbl, CUSTNMBR, ADRSCODE) then
                 EmailAddress := CopyStr(GPSY01200.INET1.Trim(), 1, MaxStrLen(ShipToAddress."E-Mail"));
 
 #pragma warning disable AA0139
@@ -114,4 +114,7 @@ table 4048 "GP Customer Address"
                 ShipToAddress.Modify();
         end;
     end;
+
+    var
+        CustomerEmailTypeCodeLbl: Label 'CUS', Locked = true;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
@@ -370,7 +370,10 @@ codeunit 4022 "GP Vendor Migrator"
     local procedure CreateOrUpdateOrderAddress(Vendor: Record Vendor; GPVendorAddress: Record "GP Vendor Address"; AddressCode: Code[10])
     var
         OrderAddress: Record "Order Address";
+        GPSY01200: Record "GP SY01200";
         HelperFunctions: Codeunit "Helper Functions";
+        MailManagement: Codeunit "Mail Management";
+        EmailAddress: Text[80];
     begin
         if not OrderAddress.Get(Vendor."No.", AddressCode) then begin
             OrderAddress."Vendor No." := Vendor."No.";
@@ -387,13 +390,25 @@ codeunit 4022 "GP Vendor Migrator"
         OrderAddress."Fax No." := HelperFunctions.CleanGPPhoneOrFaxNumber(GPVendorAddress.FAXNUMBR);
         OrderAddress."Post Code" := GPVendorAddress.ZIPCODE;
         OrderAddress.County := GPVendorAddress.STATE;
+
+        if GPSY01200.Get('VEN', Vendor."No.", AddressCode) then
+            EmailAddress := CopyStr(GPSY01200.INET1.Trim(), 1, MaxStrLen(OrderAddress."E-Mail"));
+
+#pragma warning disable AA0139
+        if MailManagement.ValidateEmailAddressField(EmailAddress) then
+            OrderAddress."E-Mail" := EmailAddress;
+#pragma warning restore AA0139
+
         OrderAddress.Modify();
     end;
 
     local procedure CreateOrUpdateRemitAddress(Vendor: Record Vendor; GPVendorAddress: Record "GP Vendor Address"; AddressCode: Code[10])
     var
         RemitAddress: Record "Remit Address";
+        GPSY01200: Record "GP SY01200";
         HelperFunctions: Codeunit "Helper Functions";
+        MailManagement: Codeunit "Mail Management";
+        EmailAddress: Text[80];
     begin
         if not RemitAddress.Get(AddressCode, Vendor."No.") then begin
             RemitAddress."Vendor No." := Vendor."No.";
@@ -410,6 +425,15 @@ codeunit 4022 "GP Vendor Migrator"
         RemitAddress."Fax No." := HelperFunctions.CleanGPPhoneOrFaxNumber(GPVendorAddress.FAXNUMBR);
         RemitAddress."Post Code" := GPVendorAddress.ZIPCODE;
         RemitAddress.County := GPVendorAddress.STATE;
+
+        if GPSY01200.Get('VEN', Vendor."No.", AddressCode) then
+            EmailAddress := CopyStr(GPSY01200.INET1.Trim(), 1, MaxStrLen(RemitAddress."E-Mail"));
+
+#pragma warning disable AA0139
+        if MailManagement.ValidateEmailAddressField(EmailAddress) then
+            RemitAddress."E-Mail" := EmailAddress;
+#pragma warning restore AA0139
+
         RemitAddress.Modify();
     end;
 

--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
@@ -8,6 +8,7 @@ codeunit 4022 "GP Vendor Migrator"
         VendorBatchNameTxt: Label 'GPVEND', Locked = true;
         SourceCodeTxt: Label 'GENJNL', Locked = true;
         PostingGroupDescriptionTxt: Label 'Migrated from GP', Locked = true;
+        VendorEmailTypeCodeLbl: Label 'VEN', Locked = true;
 
 #if not CLEAN22
 #pragma warning disable AA0207
@@ -391,7 +392,7 @@ codeunit 4022 "GP Vendor Migrator"
         OrderAddress."Post Code" := GPVendorAddress.ZIPCODE;
         OrderAddress.County := GPVendorAddress.STATE;
 
-        if GPSY01200.Get('VEN', Vendor."No.", AddressCode) then
+        if GPSY01200.Get(VendorEmailTypeCodeLbl, Vendor."No.", AddressCode) then
             EmailAddress := CopyStr(GPSY01200.INET1.Trim(), 1, MaxStrLen(OrderAddress."E-Mail"));
 
 #pragma warning disable AA0139
@@ -426,7 +427,7 @@ codeunit 4022 "GP Vendor Migrator"
         RemitAddress."Post Code" := GPVendorAddress.ZIPCODE;
         RemitAddress.County := GPVendorAddress.STATE;
 
-        if GPSY01200.Get('VEN', Vendor."No.", AddressCode) then
+        if GPSY01200.Get(VendorEmailTypeCodeLbl, Vendor."No.", AddressCode) then
             EmailAddress := CopyStr(GPSY01200.INET1.Trim(), 1, MaxStrLen(RemitAddress."E-Mail"));
 
 #pragma warning disable AA0139

--- a/Apps/W1/HybridGP/app/src/codeunits/HybridGPWizard.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/codeunits/HybridGPWizard.codeunit.al
@@ -135,6 +135,7 @@ codeunit 4015 "Hybrid GP Wizard"
     var
         GPCompanyMigrationSettings: Record "GP Company Migration Settings";
         GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        HybridCompanyStatus: Record "Hybrid Company Status";
     begin
         GPCompanyMigrationSettings.Reset();
         if GPCompanyMigrationSettings.FindSet() then
@@ -142,6 +143,9 @@ codeunit 4015 "Hybrid GP Wizard"
 
         if not GPCompanyAdditionalSettings.IsEmpty() then
             GPCompanyAdditionalSettings.DeleteAll();
+
+        if not HybridCompanyStatus.IsEmpty() then
+            HybridCompanyStatus.DeleteAll();
     end;
 
     local procedure ProcessesAreRunning(): Boolean

--- a/Apps/W1/HybridGP/app/src/pages/GPCompanyAddSettingsList.Page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPCompanyAddSettingsList.Page.al
@@ -3,7 +3,7 @@ page 4051 "GP Company Add. Settings List"
     Caption = 'GP Company Additional Settings List';
     PageType = ListPart;
     SourceTable = "GP Company Additional Settings";
-    SourceTableView = sorting(Name) where("Name" = filter(<> ''));
+    SourceTableView = sorting(Name) where("Name" = filter(<> ''), "Migration Completed" = const(false));
     DeleteAllowed = false;
     InsertAllowed = false;
     ModifyAllowed = true;

--- a/Apps/W1/HybridGP/app/src/pages/GPMigrationConfiguration.Page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPMigrationConfiguration.Page.al
@@ -603,6 +603,7 @@ page 4050 "GP Migration Configuration"
     local procedure PrepSettingsForFieldUpdate(): Boolean
     begin
         GPCompanyAdditionalSettings.SetFilter("Name", '<>%1', '');
+        GPCompanyAdditionalSettings.SetRange("Migration Completed", false);
         exit(GPCompanyAdditionalSettings.FindSet());
     end;
 
@@ -610,6 +611,7 @@ page 4050 "GP Migration Configuration"
     var
         GPCompanyAdditionalSettingsInit: Record "GP Company Additional Settings";
     begin
+        GPCompanyAdditionalSettingsInit.SetRange("Migration Completed", false);
         GPCompanyAdditionalSettingsInit.DeleteAll();
 
         Rec.Init();
@@ -678,6 +680,7 @@ page 4050 "GP Migration Configuration"
         GPCompanyAdditionalSettingsCompanies: Record "GP Company Additional Settings";
     begin
         GPCompanyAdditionalSettingsCompanies.SetFilter("Name", '<>%1', '');
+        GPCompanyAdditionalSettingsCompanies.SetRange("Migration Completed", false);
         if GPCompanyAdditionalSettingsCompanies.FindSet() then
             repeat
                 if (GPCompanyAdditionalSettingsCompanies."Global Dimension 1" = '') then
@@ -696,6 +699,7 @@ page 4050 "GP Migration Configuration"
         GPCompanyAdditionalSettingsCompanies: Record "GP Company Additional Settings";
     begin
         GPCompanyAdditionalSettingsCompanies.SetFilter("Name", '<>%1', '');
+        GPCompanyAdditionalSettingsCompanies.SetRange("Migration Completed", false);
         if GPCompanyAdditionalSettingsCompanies.FindSet() then
             repeat
                 if (DimensionLabel = '') or CompanyHasSegment(GPCompanyAdditionalSettingsCompanies.Name, DimensionLabel) then begin

--- a/Apps/W1/HybridGP/app/src/pages/HybridCloudWizardExtension.PageExt.al
+++ b/Apps/W1/HybridGP/app/src/pages/HybridCloudWizardExtension.PageExt.al
@@ -73,28 +73,9 @@ pageextension 4014 "Hybrid Cloud Wizard Extension" extends "Hybrid Cloud Setup W
         {
             trigger OnAfterAction()
             begin
-                if Rec."Product ID" = 'DynamicsGP' then begin
-                    CleanupSettingsForCompaniesPreviouslyMigrated();
+                if Rec."Product ID" = 'DynamicsGP' then
                     Page.Run(Page::"GP Migration Configuration");
-                end;
             end;
-
         }
     }
-
-    local procedure CleanupSettingsForCompaniesPreviouslyMigrated()
-    var
-        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
-        HybridCompany: Record "Hybrid Company";
-    begin
-        GPCompanyAdditionalSettings.SetFilter("Name", '<>%1', '');
-        if GPCompanyAdditionalSettings.FindSet() then
-            repeat
-                HybridCompany.SetRange(Name, GPCompanyAdditionalSettings.Name);
-                HybridCompany.SetRange(Replicate, false);
-
-                if not HybridCompany.IsEmpty() then
-                    GPCompanyAdditionalSettings.Delete();
-            until GPCompanyAdditionalSettings.Next() = 0;
-    end;
 }

--- a/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
+++ b/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
@@ -320,6 +320,11 @@ table 40105 "GP Company Additional Settings"
             DataClassification = SystemMetadata;
             InitValue = true;
         }
+        field(35; "Migration Completed"; Boolean)
+        {
+            FieldClass = FlowField;
+            CalcFormula = exist("Hybrid Company Status" where("Name" = field(Name), "Upgrade Status" = const("Completed")));
+        }
     }
 
     keys


### PR DESCRIPTION
This submission contains the following enhancements to the GP migration.

**Migrate email addresses with Vendor and Customer addresses**
Include the email address with Vendor and Customer addresses if they are valid email addresses.

**Retain Company migration configuration settings record after migration**
The Company config settings was being deleted after the Company is migrated, but it has since been learned that it's better to keep it for troubleshooting purposes. The record will remain but will be hidden from the configuration page if the Company has been migrated.