### PR TITLE
Extend Azure Blob Services API with Content Type

### DIFF
--- a/Modules/System/Azure Blob Services API/README.md
+++ b/Modules/System/Azure Blob Services API/README.md
@@ -129,7 +129,7 @@ Collection of the result (temporary record).
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### ListBlobs (Method) <a name="ListBlobs"></a> 
 
  Lists the blobs in a specific container.
@@ -152,7 +152,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### PutBlobBlockBlobUI (Method) <a name="PutBlobBlockBlobUI"></a> 
 
  Uploads a file as a BlockBlob (with File Selection Dialog).
@@ -166,7 +166,7 @@ procedure PutBlobBlockBlobUI(): Codeunit "ABS Operation Response"
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### PutBlobBlockBlobUI (Method) <a name="PutBlobBlockBlobUI"></a> 
 
  Uploads a file as a BlockBlob (with File Selection Dialog).
@@ -185,7 +185,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### PutBlobBlockBlobStream (Method) <a name="PutBlobBlockBlobStream"></a> 
 
  Uploads the content of an InStream as a BlockBlob
@@ -208,7 +208,35 @@ The Content of the Blob as InStream.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
+
+### PutBlobBlockBlobStream (Method) <a name="PutBlobBlockBlobStream"></a> 
+
+ Uploads the content of an InStream as a BlockBlob
+ see: https://go.microsoft.com/fwlink/?linkid=2210387
+ 
+
+#### Syntax
+```
+procedure PutBlobBlockBlobStream(BlobName: Text; var SourceStream: InStream; ContentType: Text): Codeunit "ABS Operation Response"
+```
+#### Parameters
+*BlobName ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
+
+The name of the blob.
+
+*SourceStream ([InStream](https://go.microsoft.com/fwlink/?linkid=2210033))* 
+
+The Content of the Blob as InStream.
+
+*ContentType ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
+
+Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')
+
+#### Return Value
+*[Codeunit "ABS Operation Response"]()*
+
+An operation response object
 ### PutBlobBlockBlobStream (Method) <a name="PutBlobBlockBlobStream"></a> 
 
  Uploads the content of an InStream as a BlockBlob.
@@ -235,7 +263,39 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
+
+### PutBlobBlockBlobStream (Method) <a name="PutBlobBlockBlobStream"></a> 
+
+ Uploads the content of an InStream as a BlockBlob.
+ see: https://go.microsoft.com/fwlink/?linkid=2210387
+ 
+
+#### Syntax
+```
+procedure PutBlobBlockBlobStream(BlobName: Text; var SourceStream: InStream; ContentType: Text; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+```
+#### Parameters
+*BlobName ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
+
+The name of the blob.
+
+*SourceStream ([InStream](https://go.microsoft.com/fwlink/?linkid=2210033))* 
+
+The Content of the Blob as InStream.
+
+*ContentType ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
+
+Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')
+
+*OptionalParameters ([Codeunit "ABS Optional Parameters"]())* 
+
+Optional parameters to pass.
+
+#### Return Value
+*[Codeunit "ABS Operation Response"]()*
+
+An operation response object
 ### PutBlobBlockBlobText (Method) <a name="PutBlobBlockBlobText"></a> 
 
  Uploads text as a BlockBlob.
@@ -258,7 +318,34 @@ The Content of the Blob as Text.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
+### PutBlobBlockBlobText (Method) <a name="PutBlobBlockBlobText"></a> 
+
+ Uploads text as a BlockBlob.
+ see: https://go.microsoft.com/fwlink/?linkid=2210387
+ 
+
+#### Syntax
+```
+procedure PutBlobBlockBlobText(BlobName: Text; SourceText: Text; ContentType: Text): Codeunit "ABS Operation Response"
+```
+#### Parameters
+*BlobName ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
+
+The name of the blob.
+
+*SourceText ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
+
+The Content of the Blob as Text.
+
+*ContentType ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
+
+Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')
+
+#### Return Value
+*[Codeunit "ABS Operation Response"]()*
+
+An operation response object
 ### PutBlobBlockBlobText (Method) <a name="PutBlobBlockBlobText"></a> 
 
  Uploads text as a BlockBlob.
@@ -285,7 +372,38 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
+### PutBlobBlockBlobText (Method) <a name="PutBlobBlockBlobText"></a> 
+
+ Uploads text as a BlockBlob.
+ see: https://go.microsoft.com/fwlink/?linkid=2210387
+ 
+
+#### Syntax
+```
+procedure PutBlobBlockBlobText(BlobName: Text; SourceText: Text; ContentType: Text; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+```
+#### Parameters
+*BlobName ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
+
+The name of the blob.
+
+*SourceText ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
+
+The Content of the Blob as Text.
+
+*ContentType ([Text](https://go.microsoft.com/fwlink/?linkid=2210031))* 
+
+Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')
+
+*OptionalParameters ([Codeunit "ABS Optional Parameters"]())* 
+
+Optional parameters to pass.
+
+#### Return Value
+*[Codeunit "ABS Operation Response"]()*
+
+An operation response object
 ### PutBlobPageBlob (Method) <a name="PutBlobPageBlob"></a> 
 
  Creates a PageBlob.
@@ -308,7 +426,7 @@ Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### PutBlobPageBlob (Method) <a name="PutBlobPageBlob"></a> 
 
  Creates a PageBlob.
@@ -335,7 +453,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### PutBlobAppendBlobStream (Method) <a name="PutBlobAppendBlobStream"></a> 
 
  The Put Blob operation creates a new append blob
@@ -355,7 +473,7 @@ The name of the blob.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### PutBlobAppendBlobStream (Method) <a name="PutBlobAppendBlobStream"></a> 
 
  The Put Blob operation creates a new append blob
@@ -379,7 +497,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### PutBlobAppendBlobText (Method) <a name="PutBlobAppendBlobText"></a> 
 
  The Put Blob operation creates a new append blob
@@ -403,7 +521,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### PutBlobAppendBlob (Method) <a name="PutBlobAppendBlob"></a> 
 
  The Put Blob operation creates a new append blob
@@ -430,7 +548,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### AppendBlockText (Method) <a name="AppendBlockText"></a> 
 
  The Append Block operation commits a new block of data to the end of an existing append blob.
@@ -454,7 +572,7 @@ Text-variable containing the content that should be added to the Blob
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### AppendBlockText (Method) <a name="AppendBlockText"></a> 
 
  The Append Block operation commits a new block of data to the end of an existing append blob.
@@ -481,7 +599,7 @@ Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### AppendBlockText (Method) <a name="AppendBlockText"></a> 
 
  The Append Block operation commits a new block of data to the end of an existing append blob.
@@ -512,7 +630,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### AppendBlockStream (Method) <a name="AppendBlockStream"></a> 
 
  The Append Block operation commits a new block of data to the end of an existing append blob.
@@ -536,7 +654,7 @@ InStream containing the content that should be added to the Blob
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### AppendBlockStream (Method) <a name="AppendBlockStream"></a> 
 
  The Append Block operation commits a new block of data to the end of an existing append blob.
@@ -567,7 +685,7 @@ Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### AppendBlock (Method) <a name="AppendBlock"></a> 
 
  The Append Block operation commits a new block of data to the end of an existing append blob.
@@ -598,7 +716,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### AppendBlockFromURL (Method) <a name="AppendBlockFromURL"></a> 
 
  The Append Block From URL operation commits a new block of data to the end of an existing append blob.
@@ -621,7 +739,7 @@ Specifies the name of the source blob.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### AppendBlockFromURL (Method) <a name="AppendBlockFromURL"></a> 
 
  The Append Block From URL operation commits a new block of data to the end of an existing append blob.
@@ -648,7 +766,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### GetBlobAsFile (Method) <a name="GetBlobAsFile"></a> 
 
  Receives a Blob as a File from a Container.
@@ -667,7 +785,7 @@ The name of the blob.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### GetBlobAsFile (Method) <a name="GetBlobAsFile"></a> 
 
  Receives a Blob as a File from a Container.
@@ -690,7 +808,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### GetBlobAsStream (Method) <a name="GetBlobAsStream"></a> 
 
  Receives a Blob as a InStream from a Container.
@@ -713,7 +831,7 @@ The result InStream containg the content of the Blob.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### GetBlobAsStream (Method) <a name="GetBlobAsStream"></a> 
 
  Receives a Blob as a InStream from a Container.
@@ -740,7 +858,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### GetBlobAsText (Method) <a name="GetBlobAsText"></a> 
 
  Receives a Blob as Text from a Container.
@@ -763,7 +881,7 @@ The result Text containg the content of the Blob.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### GetBlobAsText (Method) <a name="GetBlobAsText"></a> 
 
  Receives a Blob as Text from a Container.
@@ -790,7 +908,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### SetBlobExpiryRelativeToCreation (Method) <a name="SetBlobExpiryRelativeToCreation"></a> 
 
  The Set Blob Expiry operation sets an expiry time on an existing blob. This operation is only allowed on Hierarchical Namespace enabled accounts
@@ -814,7 +932,7 @@ Number if miliseconds (Integer) until the expiration.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### SetBlobExpiryRelativeToNow (Method) <a name="SetBlobExpiryRelativeToNow"></a> 
 
  The Set Blob Expiry operation sets an expiry time on an existing blob. This operation is only allowed on Hierarchical Namespace enabled accounts
@@ -838,7 +956,7 @@ Number if miliseconds (Integer) until the expiration.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### SetBlobExpiryAbsolute (Method) <a name="SetBlobExpiryAbsolute"></a> 
 
  The Set Blob Expiry operation sets an expiry time on an existing blob. This operation is only allowed on Hierarchical Namespace enabled accounts
@@ -862,7 +980,7 @@ Absolute DateTime for the expiration.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### SetBlobExpiryNever (Method) <a name="SetBlobExpiryNever"></a> 
 
  The Set Blob Expiry operation sets an expiry time on an existing blob. This operation is only allowed on Hierarchical Namespace enabled accounts
@@ -905,7 +1023,7 @@ A Dictionary of [Text, Text] which contains the Tags you want to set.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### DeleteBlob (Method) <a name="DeleteBlob"></a> 
 
  The Delete Blob operation marks the specified blob or snapshot for deletion. The blob is later deleted during garbage collection.
@@ -924,7 +1042,7 @@ The name of the blob.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### DeleteBlob (Method) <a name="DeleteBlob"></a> 
 
  The Delete Blob operation marks the specified blob or snapshot for deletion. The blob is later deleted during garbage collection.
@@ -947,7 +1065,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### UndeleteBlob (Method) <a name="UndeleteBlob"></a> 
 
  The Undelete Blob operation restores the contents and metadata of a soft deleted blob and any associated soft deleted snapshots (version 2017-07-29 or later)
@@ -966,7 +1084,7 @@ The name of the blob.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### UndeleteBlob (Method) <a name="UndeleteBlob"></a> 
 
  The Undelete Blob operation restores the contents and metadata of a soft deleted blob and any associated soft deleted snapshots (version 2017-07-29 or later)
@@ -989,7 +1107,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### CopyBlob (Method) <a name="CopyBlob"></a> 
 
  The Copy Blob operation copies a blob to a destination within the storage account.
@@ -1012,7 +1130,7 @@ Specifies the name of the source blob or file.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### CopyBlob (Method) <a name="CopyBlob"></a> 
 
  The Copy Blob operation copies a blob to a destination within the storage account.
@@ -1043,7 +1161,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### PutBlockList (Method) <a name="PutBlockList"></a> 
 
  The Put Block List operation writes a blob by specifying the list of block IDs that make up the blob.
@@ -1066,7 +1184,7 @@ Dictionary of [Text, Integer] containing the list of uncommited blocks that shou
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### PutBlockFromURL (Method) <a name="PutBlockFromURL"></a> 
 
  The Put Block From URL operation creates a new block to be committed as part of a blob where the contents are read from a URL.
@@ -1093,7 +1211,7 @@ Specifies the BlockId that should be put.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### PutBlockFromURL (Method) <a name="PutBlockFromURL"></a> 
 
  The Put Block From URL operation creates a new block to be committed as part of a blob where the contents are read from a URL.
@@ -1124,7 +1242,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 
 ## ABS Container Client (Codeunit 9052)
 
@@ -1208,7 +1326,7 @@ procedure ListContainers(var Containers: Record "ABS Container"): Codeunit "ABS 
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### ListContainers (Method) <a name="ListContainers"></a> 
 
  List all containers in specific Storage Account.
@@ -1231,7 +1349,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### CreateContainer (Method) <a name="CreateContainer"></a> 
 
  Creates a new container in the Storage Account.
@@ -1250,7 +1368,7 @@ The name of the container.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### CreateContainer (Method) <a name="CreateContainer"></a> 
 
  Creates a new container in the Storage Account.
@@ -1273,7 +1391,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### DeleteContainer (Method) <a name="DeleteContainer"></a> 
 
  Deletes a container from the Storage Account.
@@ -1292,7 +1410,7 @@ The name of the container.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 ### DeleteContainer (Method) <a name="DeleteContainer"></a> 
 
  Deletes a container from the Storage Account.
@@ -1315,7 +1433,7 @@ Optional parameters to pass.
 #### Return Value
 *[Codeunit "ABS Operation Response"]()*
 
-An operation reponse object
+An operation response object
 
 ## ABS Operation Response (Codeunit 9050)
 

--- a/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
@@ -55,7 +55,7 @@ codeunit 9053 "ABS Blob Client"
     /// see: https://go.microsoft.com/fwlink/?linkid=2210588
     /// </summary>    
     /// <param name="ABSContainerContent">Collection of the result (temporary record).</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure ListBlobs(var ABSContainerContent: Record "ABS Container Content"): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -69,7 +69,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>    
     /// <param name="ABSContainerContent">Collection of the result (temporary record).</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure ListBlobs(var ABSContainerContent: Record "ABS Container Content"; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.ListBlobs(ABSContainerContent, ABSOptionalParameters));
@@ -81,7 +81,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>    
     /// <param name="BlobList">Collection of the result (BlobList of [Text, XmlNode]).
     /// The key in the dictionary is the full blob path and the value is the complete blob xmlnode from the response</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure ListBlobs(var BlobList: Dictionary of [Text, XmlNode]): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -96,7 +96,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobList">Collection of the result (BlobList of [Text, XmlNode]).
     /// The key in the dictionary is the full blob path and the value is the complete blob xmlnode from the response</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure ListBlobs(var BlobList: Dictionary of [Text, XmlNode]; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.ListBlobs(BlobList, ABSOptionalParameters));
@@ -106,7 +106,7 @@ codeunit 9053 "ABS Blob Client"
     /// Uploads a file as a BlockBlob (with File Selection Dialog).
     /// see: https://go.microsoft.com/fwlink/?linkid=2210387
     /// </summary>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlobBlockBlobUI(): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -119,7 +119,7 @@ codeunit 9053 "ABS Blob Client"
     /// see: https://go.microsoft.com/fwlink/?linkid=2210387
     /// </summary>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlobBlockBlobUI(ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.PutBlobBlockBlobUI(ABSOptionalParameters));
@@ -131,12 +131,27 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="SourceInStream">The Content of the Blob as InStream.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlobBlockBlobStream(BlobName: Text; var SourceInStream: InStream): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(ABSClientImpl.PutBlobBlockBlobStream(BlobName, SourceInStream, ABSOptionalParameters));
+        exit(ABSClientImpl.PutBlobBlockBlobStream(BlobName, SourceInStream, '', ABSOptionalParameters));
+    end;
+
+    /// <summary>
+    /// Uploads the content of an InStream as a BlockBlob
+    /// see: https://go.microsoft.com/fwlink/?linkid=2210387
+    /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>
+    /// <param name="SourceInStream">The Content of the Blob as InStream.</param>
+    /// <param name="ContentType">Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')</param>
+    /// <returns>An operation response object</returns>
+    procedure PutBlobBlockBlobStream(BlobName: Text; var SourceInStream: InStream; ContentType: Text): Codeunit "ABS Operation Response"
+    var
+        ABSOptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(ABSClientImpl.PutBlobBlockBlobStream(BlobName, SourceInStream, ContentType, ABSOptionalParameters));
     end;
 
     /// <summary>
@@ -146,10 +161,24 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="SourceInStream">The Content of the Blob as InStream.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlobBlockBlobStream(BlobName: Text; var SourceInStream: InStream; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(ABSClientImpl.PutBlobBlockBlobStream(BlobName, SourceInStream, ABSOptionalParameters));
+        exit(ABSClientImpl.PutBlobBlockBlobStream(BlobName, SourceInStream, '', ABSOptionalParameters));
+    end;
+
+    /// <summary>
+    /// Uploads the content of an InStream as a BlockBlob.
+    /// see: https://go.microsoft.com/fwlink/?linkid=2210387
+    /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>
+    /// <param name="SourceInStream">The Content of the Blob as InStream.</param>
+    /// <param name="ContentType">Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')</param>
+    /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation response object</returns>
+    procedure PutBlobBlockBlobStream(BlobName: Text; var SourceInStream: InStream; ContentType: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(ABSClientImpl.PutBlobBlockBlobStream(BlobName, SourceInStream, '', ABSOptionalParameters));
     end;
 
     /// <summary>
@@ -158,12 +187,27 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="SourceText">The Content of the Blob as Text.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlobBlockBlobText(BlobName: Text; SourceText: Text): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
     begin
-        exit(ABSClientImpl.PutBlobBlockBlobText(BlobName, SourceText, ABSOptionalParameters));
+        exit(ABSClientImpl.PutBlobBlockBlobText(BlobName, SourceText, '', ABSOptionalParameters));
+    end;
+
+    /// <summary>
+    /// Uploads text as a BlockBlob.
+    /// see: https://go.microsoft.com/fwlink/?linkid=2210387
+    /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>
+    /// <param name="SourceText">The Content of the Blob as Text.</param>
+    /// <param name="ContentType">Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')</param>
+    /// <returns>An operation response object</returns>
+    procedure PutBlobBlockBlobText(BlobName: Text; SourceText: Text; ContentType: Text): Codeunit "ABS Operation Response"
+    var
+        ABSOptionalParameters: Codeunit "ABS Optional Parameters";
+    begin
+        exit(ABSClientImpl.PutBlobBlockBlobText(BlobName, SourceText, ContentType, ABSOptionalParameters));
     end;
 
     /// <summary>
@@ -173,10 +217,24 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="SourceText">The Content of the Blob as Text.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlobBlockBlobText(BlobName: Text; SourceText: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(ABSClientImpl.PutBlobBlockBlobText(BlobName, SourceText, ABSOptionalParameters));
+        exit(ABSClientImpl.PutBlobBlockBlobText(BlobName, SourceText, '', ABSOptionalParameters));
+    end;
+
+    /// <summary>
+    /// Uploads text as a BlockBlob.
+    /// see: https://go.microsoft.com/fwlink/?linkid=2210387
+    /// </summary>
+    /// <param name="BlobName">The name of the blob.</param>
+    /// <param name="SourceText">The Content of the Blob as Text.</param>
+    /// <param name="ContentType">Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')</param>
+    /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
+    /// <returns>An operation response object</returns>
+    procedure PutBlobBlockBlobText(BlobName: Text; SourceText: Text; ContentType: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    begin
+        exit(ABSClientImpl.PutBlobBlockBlobText(BlobName, SourceText, ContentType, ABSOptionalParameters));
     end;
 
     /// <summary>
@@ -185,7 +243,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ContentType">Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlobPageBlob(BlobName: Text; ContentType: Text): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -200,7 +258,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ContentType">Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlobPageBlob(BlobName: Text; ContentType: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.PutBlobPageBlob(BlobName, ContentType, ABSOptionalParameters));
@@ -212,7 +270,7 @@ codeunit 9053 "ABS Blob Client"
     /// Uses 'application/octet-stream' as Content-Type
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlobAppendBlobStream(BlobName: Text): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -227,7 +285,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlobAppendBlobStream(BlobName: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(PutBlobAppendBlob(BlobName, 'application/octet-stream', ABSOptionalParameters));
@@ -240,7 +298,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlobAppendBlobText(BlobName: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(PutBlobAppendBlob(BlobName, 'text/plain; charset=UTF-8', ABSOptionalParameters));
@@ -252,7 +310,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ContentType">Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlobAppendBlob(BlobName: Text; ContentType: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.PutBlobAppendBlob(BlobName, ContentType, ABSOptionalParameters));
@@ -265,7 +323,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ContentAsText">Text-variable containing the content that should be added to the Blob</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AppendBlockText(BlobName: Text; ContentAsText: Text): Codeunit "ABS Operation Response"
     begin
         exit(AppendBlockText(BlobName, ContentAsText, 'text/plain; charset=UTF-8'));
@@ -278,7 +336,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ContentAsText">Text-variable containing the content that should be added to the Blob</param>
     /// <param name="ContentType">Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AppendBlockText(BlobName: Text; ContentAsText: Text; ContentType: Text): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -294,7 +352,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="ContentAsText">Text-variable containing the content that should be added to the Blob</param>
     /// <param name="ContentType">Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AppendBlockText(BlobName: Text; ContentAsText: Text; ContentType: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(AppendBlock(BlobName, ContentType, ContentAsText, ABSOptionalParameters));
@@ -307,7 +365,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ContentAsInStream">InStream containing the content that should be added to the Blob</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AppendBlockStream(BlobName: Text; ContentAsInStream: InStream): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -322,7 +380,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ContentAsInStream">InStream containing the content that should be added to the Blob</param>
     /// <param name="ContentType">Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AppendBlockStream(BlobName: Text; ContentAsInStream: InStream; ContentType: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(AppendBlock(BlobName, ContentType, ContentAsInStream, ABSOptionalParameters));
@@ -336,7 +394,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="ContentType">Value for Content-Type HttpHeader (e.g. 'text/plain; charset=UTF-8')</param>
     /// <param name="SourceContentVariant">Variant containing the content that should be added to the Blob</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AppendBlock(BlobName: Text; ContentType: Text; SourceContentVariant: Variant; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.AppendBlock(BlobName, ContentType, SourceContentVariant, ABSOptionalParameters));
@@ -348,7 +406,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="SourceUri">Specifies the name of the source blob.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AppendBlockFromURL(BlobName: Text; SourceUri: Text): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -363,7 +421,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="SourceUri">Specifies the name of the source blob.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AppendBlockFromURL(BlobName: Text; SourceUri: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.AppendBlockFromURL(BlobName, SourceUri, ABSOptionalParameters));
@@ -374,7 +432,7 @@ codeunit 9053 "ABS Blob Client"
     /// see: https://go.microsoft.com/fwlink/?linkid=2210388
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure GetBlobAsFile(BlobName: Text): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -388,7 +446,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure GetBlobAsFile(BlobName: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.GetBlobAsFile(BlobName, ABSOptionalParameters));
@@ -400,7 +458,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="TargetInStream">The result InStream containg the content of the Blob.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure GetBlobAsStream(BlobName: Text; var TargetInStream: InStream): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -415,7 +473,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="TargetInStream">The result InStream containg the content of the Blob.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure GetBlobAsStream(BlobName: Text; var TargetInStream: InStream; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.GetBlobAsStream(BlobName, TargetInStream, ABSOptionalParameters));
@@ -427,7 +485,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="TargetText">The result Text containg the content of the Blob.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure GetBlobAsText(BlobName: Text; var TargetText: Text): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -442,7 +500,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="TargetText">The result Text containg the content of the Blob.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure GetBlobAsText(BlobName: Text; var TargetText: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.GetBlobAsText(BlobName, TargetText, ABSOptionalParameters));
@@ -455,7 +513,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>    
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ExpiryTime">Number if miliseconds (Integer) until the expiration.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure SetBlobExpiryRelativeToCreation(BlobName: Text; ExpiryTime: Integer): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.SetBlobExpiryRelativeToCreation(BlobName, ExpiryTime));
@@ -468,7 +526,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>    
     /// <param name="ExpiryTime">Number if miliseconds (Integer) until the expiration.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure SetBlobExpiryRelativeToNow(BlobName: Text; ExpiryTime: Integer): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.SetBlobExpiryRelativeToNow(BlobName, ExpiryTime));
@@ -481,7 +539,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>    
     /// <param name="ExpiryTime">Absolute DateTime for the expiration.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure SetBlobExpiryAbsolute(BlobName: Text; ExpiryTime: DateTime): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.SetBlobExpiryAbsolute(BlobName, ExpiryTime));
@@ -503,7 +561,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary> 
     /// <param name="BlobName">The name of the blob.</param>   
     /// <param name="Tags">A Dictionary of [Text, Text] which contains the Tags you want to set.</param>    
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure SetBlobTags(BlobName: Text; Tags: Dictionary of [Text, Text]): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.SetBlobTags(BlobName, Tags));
@@ -515,7 +573,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>   
     /// <param name="Tags">The result XmlDocument with blob tags.</param>    
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure GetBlobTags(BlobName: Text; var Tags: XmlDocument): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
@@ -530,7 +588,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>   
     /// <param name="Tags">The result XmlDocument with blob tags.</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param> 
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure GetBlobTags(BlobName: Text; var Tags: XmlDocument; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.GetBlobTags(BlobName, Tags, OptionalParameters))
@@ -542,7 +600,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>   
     /// <param name="Tags">The result Dictionary of [Text, Text] with blob tags.</param>    
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure GetBlobTags(BlobName: Text; var Tags: Dictionary of [Text, Text]): Codeunit "ABS Operation Response"
     var
         OptionalParameters: Codeunit "ABS Optional Parameters";
@@ -557,7 +615,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>   
     /// <param name="Tags">The result Dictionary of [Text, Text] with blob tags.</param>
     /// <param name="OptionalParameters">Optional parameters to pass.</param> 
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure GetBlobTags(BlobName: Text; var Tags: Dictionary of [Text, Text]; OptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.GetBlobTags(BlobName, Tags, OptionalParameters))
@@ -568,7 +626,7 @@ codeunit 9053 "ABS Blob Client"
     /// see: https://go.microsoft.com/fwlink/?linkid=2211408
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure DeleteBlob(BlobName: Text): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -582,7 +640,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure DeleteBlob(BlobName: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.DeleteBlob(BlobName, ABSOptionalParameters));
@@ -593,7 +651,7 @@ codeunit 9053 "ABS Blob Client"
     /// see: https://go.microsoft.com/fwlink/?linkid=2210390
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure UndeleteBlob(BlobName: Text): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -607,7 +665,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure UndeleteBlob(BlobName: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.UndeleteBlob(BlobName, ABSOptionalParameters));
@@ -619,7 +677,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="SourceName">Specifies the name of the source blob or file.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure CopyBlob(BlobName: Text; SourceName: Text): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -636,7 +694,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="SourceName">Specifies the name of the source blob or file.</param>
     /// <param name="LeaseId">Required if the destination blob has an active lease. The lease ID specified must match the lease ID of the destination blob.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure CopyBlob(BlobName: Text; SourceName: Text; LeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.CopyBlob(BlobName, SourceName, LeaseId, ABSOptionalParameters));
@@ -648,7 +706,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="CommitedBlocks">Dictionary of [Text, Integer] containing the list of commited blocks that should be put to the Blob</param>
     /// <param name="UncommitedBlocks">Dictionary of [Text, Integer] containing the list of uncommited blocks that should be put to the Blob</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlockList(CommitedBlocks: Dictionary of [Text, Integer]; UncommitedBlocks: Dictionary of [Text, Integer]): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.PutBlockList(CommitedBlocks, UncommitedBlocks));
@@ -661,7 +719,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="SourceUri">Specifies the name of the source block blob.</param>
     /// <param name="BlockId">Specifies the BlockId that should be put.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlockFromURL(BlobName: Text; SourceUri: Text; BlockId: Text): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -677,7 +735,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="SourceUri">Specifies the name of the source block blob.</param>
     /// <param name="BlockId">Specifies the BlockId that should be put.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure PutBlockFromURL(BlobName: Text; SourceUri: Text; BlockId: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.PutBlockFromURL(BlobName, SourceUri, BlockId, ABSOptionalParameters));
@@ -689,7 +747,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AcquireLease(BlobName: Text; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -705,7 +763,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AcquireLease(BlobName: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ProposedLeaseId: Guid;
@@ -720,7 +778,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AcquireLease(BlobName: Text; DurationSeconds: Integer; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -737,7 +795,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AcquireLease(BlobName: Text; DurationSeconds: Integer; ABSOptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ProposedLeaseId: Guid;
@@ -752,7 +810,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AcquireLease(BlobName: Text; ProposedLeaseId: Guid; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -768,7 +826,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AcquireLease(BlobName: Text; ProposedLeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.BlobAcquireLease(BlobName, ABSOptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, custom Guid
@@ -783,7 +841,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AcquireLease(BlobName: Text; DurationSeconds: Integer; ProposedLeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.BlobAcquireLease(BlobName, ABSOptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId));
@@ -795,7 +853,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be released</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure ReleaseLease(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -810,7 +868,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be released</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure ReleaseLease(BlobName: Text; LeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.BlobReleaseLease(BlobName, ABSOptionalParameters, LeaseId));
@@ -822,7 +880,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure RenewLease(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -837,7 +895,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure RenewLease(BlobName: Text; LeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.BlobRenewLease(BlobName, ABSOptionalParameters, LeaseId));
@@ -850,7 +908,7 @@ codeunit 9053 "ABS Blob Client"
     /// </summary>
     /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure BreakLease(BlobName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -865,7 +923,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
     /// <param name="LeaseBreakPeriod">The proposed duration the lease should continue before it is broken, in seconds, between 0 and 60.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure BreakLease(BlobName: Text; LeaseId: Guid; LeaseBreakPeriod: Integer): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -880,7 +938,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure BreakLease(BlobName: Text; LeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.BlobBreakLease(BlobName, ABSOptionalParameters, LeaseId, 0));
@@ -894,7 +952,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseBreakPeriod">The proposed duration the lease should continue before it is broken, in seconds, between 0 and 60.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure BreakLease(BlobName: Text; LeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"; LeaseBreakPeriod: Integer): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.BlobBreakLease(BlobName, ABSOptionalParameters, LeaseId, LeaseBreakPeriod));
@@ -907,7 +965,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="BlobName">The name of the blob.</param>  
     /// <param name="LeaseId">The Guid for the lease that should be changed. Will contain the updated Guid after successful operation.</param>
     /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure ChangeLease(BlobName: Text; var LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -923,7 +981,7 @@ codeunit 9053 "ABS Blob Client"
     /// <param name="LeaseId">The Guid for the lease that should be changed</param>
     /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure ChangeLease(BlobName: Text; LeaseId: Guid; ProposedLeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.BlobChangeLease(BlobName, ABSOptionalParameters, LeaseId, ProposedLeaseId));

--- a/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSBlobClient.Codeunit.al
@@ -178,7 +178,7 @@ codeunit 9053 "ABS Blob Client"
     /// <returns>An operation response object</returns>
     procedure PutBlobBlockBlobStream(BlobName: Text; var SourceInStream: InStream; ContentType: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
-        exit(ABSClientImpl.PutBlobBlockBlobStream(BlobName, SourceInStream, '', ABSOptionalParameters));
+        exit(ABSClientImpl.PutBlobBlockBlobStream(BlobName, SourceInStream, ContentType, ABSOptionalParameters));
     end;
 
     /// <summary>

--- a/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSClientImpl.Codeunit.al
@@ -204,32 +204,32 @@ codeunit 9051 "ABS Client Impl."
         SourceInStream: InStream;
     begin
         if UploadIntoStream('', '', '', FileName, SourceInStream) then
-            ABSOperationResponse := PutBlobBlockBlobStream(Filename, SourceInStream, ABSOptionalParameters);
+            ABSOperationResponse := PutBlobBlockBlobStream(Filename, SourceInStream, '', ABSOptionalParameters);
 
         exit(ABSOperationResponse);
     end;
 
-    procedure PutBlobBlockBlobStream(BlobName: Text; var SourceInStream: InStream; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure PutBlobBlockBlobStream(BlobName: Text; var SourceInStream: InStream; ContentType: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     var
         ABSOperationResponse: Codeunit "ABS Operation Response";
         SourceContentVariant: Variant;
     begin
         SourceContentVariant := SourceInStream;
-        ABSOperationResponse := PutBlobBlockBlob(BlobName, ABSOptionalParameters, SourceContentVariant);
+        ABSOperationResponse := PutBlobBlockBlob(BlobName, ContentType, ABSOptionalParameters, SourceContentVariant);
         exit(ABSOperationResponse);
     end;
 
-    procedure PutBlobBlockBlobText(BlobName: Text; SourceText: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
+    procedure PutBlobBlockBlobText(BlobName: Text; SourceText: Text; ContentType: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     var
         ABSOperationResponse: Codeunit "ABS Operation Response";
         SourceContentVariant: Variant;
     begin
         SourceContentVariant := SourceText;
-        ABSOperationResponse := PutBlobBlockBlob(BlobName, ABSOptionalParameters, SourceContentVariant);
+        ABSOperationResponse := PutBlobBlockBlob(BlobName, ContentType, ABSOptionalParameters, SourceContentVariant);
         exit(ABSOperationResponse);
     end;
 
-    local procedure PutBlobBlockBlob(BlobName: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"; var SourceContentVariant: Variant): Codeunit "ABS Operation Response"
+    local procedure PutBlobBlockBlob(BlobName: Text; ContentType: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"; var SourceContentVariant: Variant): Codeunit "ABS Operation Response"
     var
         ABSOperationResponse: Codeunit "ABS Operation Response";
         Operation: Enum "ABS Operation";
@@ -245,12 +245,12 @@ codeunit 9051 "ABS Client Impl."
             SourceContentVariant.IsInStream():
                 begin
                     SourceInStream := SourceContentVariant;
-                    ABSHttpContentHelper.AddBlobPutBlockBlobContentHeaders(HttpContent, ABSOperationPayload, SourceInStream);
+                    ABSHttpContentHelper.AddBlobPutBlockBlobContentHeaders(HttpContent, ABSOperationPayload, SourceInStream, ContentType);
                 end;
             SourceContentVariant.IsText():
                 begin
                     SourceText := SourceContentVariant;
-                    ABSHttpContentHelper.AddBlobPutBlockBlobContentHeaders(HttpContent, ABSOperationPayload, SourceText);
+                    ABSHttpContentHelper.AddBlobPutBlockBlobContentHeaders(HttpContent, ABSOperationPayload, SourceText, ContentType);
                 end;
         end;
 
@@ -335,12 +335,12 @@ codeunit 9051 "ABS Client Impl."
             SourceContentVariant.IsInStream():
                 begin
                     SourceInStream := SourceContentVariant;
-                    ABSHttpContentHelper.AddBlobPutBlockBlobContentHeaders(HttpContent, ABSOperationPayload, SourceInStream);
+                    ABSHttpContentHelper.AddBlobPutBlockBlobContentHeaders(HttpContent, ABSOperationPayload, SourceInStream, ContentType);
                 end;
             SourceContentVariant.IsText():
                 begin
                     SourceText := SourceContentVariant;
-                    ABSHttpContentHelper.AddBlobPutBlockBlobContentHeaders(HttpContent, ABSOperationPayload, SourceText);
+                    ABSHttpContentHelper.AddBlobPutBlockBlobContentHeaders(HttpContent, ABSOperationPayload, SourceText, ContentType);
                 end;
         end;
 
@@ -640,12 +640,12 @@ codeunit 9051 "ABS Client Impl."
             SourceContentVariant.IsInStream():
                 begin
                     SourceInStream := SourceContentVariant;
-                    ABSHttpContentHelper.AddBlobPutBlockBlobContentHeaders(HttpContent, ABSOperationPayload, SourceInStream);
+                    ABSHttpContentHelper.AddBlobPutBlockBlobContentHeaders(HttpContent, ABSOperationPayload, SourceInStream, '');
                 end;
             SourceContentVariant.IsText():
                 begin
                     SourceText := SourceContentVariant;
-                    ABSHttpContentHelper.AddBlobPutBlockBlobContentHeaders(HttpContent, ABSOperationPayload, SourceText);
+                    ABSHttpContentHelper.AddBlobPutBlockBlobContentHeaders(HttpContent, ABSOperationPayload, SourceText, '');
                 end;
         end;
 

--- a/Modules/System/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/ABSContainerClient.Codeunit.al
@@ -53,7 +53,7 @@ codeunit 9052 "ABS Container Client"
     /// see: https://go.microsoft.com/fwlink/?linkid=2211410
     /// </summary>
     /// <param name="Container">Collection of the result (temporary record).</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure ListContainers(var ABSContainers: Record "ABS Container"): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -67,7 +67,7 @@ codeunit 9052 "ABS Container Client"
     /// </summary>
     /// <param name="Container">Collection of the result (temporary record).</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure ListContainers(var ABSContainers: Record "ABS Container"; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.ListContainers(ABSContainers, ABSOptionalParameters));
@@ -78,7 +78,7 @@ codeunit 9052 "ABS Container Client"
     /// see: https://go.microsoft.com/fwlink/?linkid=2211411
     /// </summary>
     /// <param name="ContainerName">The name of the container.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure CreateContainer(ContainerName: Text): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -92,7 +92,7 @@ codeunit 9052 "ABS Container Client"
     /// </summary>
     /// <param name="ContainerName">The name of the container to create.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure CreateContainer(ContainerName: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.CreateContainer(ContainerName, ABSOptionalParameters));
@@ -103,7 +103,7 @@ codeunit 9052 "ABS Container Client"
     /// see: https://go.microsoft.com/fwlink/?linkid=2210393
     /// </summary>
     /// <param name="ContainerName">The name of the container.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure DeleteContainer(ContainerName: Text): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -117,7 +117,7 @@ codeunit 9052 "ABS Container Client"
     /// </summary>
     /// <param name="ContainerName">The name of the container to delete.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure DeleteContainer(ContainerName: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.DeleteContainer(ContainerName, ABSOptionalParameters));
@@ -129,7 +129,7 @@ codeunit 9052 "ABS Container Client"
     /// </summary>
     /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AcquireLease(ContainerName: Text; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -145,7 +145,7 @@ codeunit 9052 "ABS Container Client"
     /// <param name="ContainerName">The name of the container.</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AcquireLease(ContainerName: Text; ABSOptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ProposedLeaseId: Guid;
@@ -160,7 +160,7 @@ codeunit 9052 "ABS Container Client"
     /// <param name="ContainerName">The name of the container.</param>
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AcquireLease(ContainerName: Text; DurationSeconds: Integer; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -177,7 +177,7 @@ codeunit 9052 "ABS Container Client"
     /// <param name="DurationSeconds">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AcquireLease(ContainerName: Text; DurationSeconds: Integer; ABSOptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ProposedLeaseId: Guid;
@@ -192,7 +192,7 @@ codeunit 9052 "ABS Container Client"
     /// <param name="ContainerName">The name of the container.</param>
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AcquireLease(ContainerName: Text; ProposedLeaseId: Guid; var LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -208,7 +208,7 @@ codeunit 9052 "ABS Container Client"
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AcquireLease(ContainerName: Text; ProposedLeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.ContainerAcquireLease(ContainerName, ABSOptionalParameters, -1, ProposedLeaseId, LeaseId)); // Infinite duration, custom Guid
@@ -223,7 +223,7 @@ codeunit 9052 "ABS Container Client"
     /// <param name="ProposedLeaseId">Proposed lease ID, in a GUID string format</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseId">Guid containing the response value from x-ms-lease-id HttpHeader</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure AcquireLease(ContainerName: Text; DurationSeconds: Integer; ProposedLeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"; var LeaseId: Guid): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.ContainerAcquireLease(ContainerName, ABSOptionalParameters, DurationSeconds, ProposedLeaseId, LeaseId));
@@ -235,7 +235,7 @@ codeunit 9052 "ABS Container Client"
     /// </summary>
     /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be released</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure ReleaseLease(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -250,7 +250,7 @@ codeunit 9052 "ABS Container Client"
     /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be released</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure ReleaseLease(ContainerName: Text; LeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.ContainerReleaseLease(ContainerName, ABSOptionalParameters, LeaseId));
@@ -262,7 +262,7 @@ codeunit 9052 "ABS Container Client"
     /// </summary>
     /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure RenewLease(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -277,7 +277,7 @@ codeunit 9052 "ABS Container Client"
     /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be renewed</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure RenewLease(ContainerName: Text; LeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.ContainerRenewLease(ContainerName, ABSOptionalParameters, LeaseId));
@@ -289,7 +289,7 @@ codeunit 9052 "ABS Container Client"
     /// </summary>
     /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure BreakLease(ContainerName: Text; LeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -304,7 +304,7 @@ codeunit 9052 "ABS Container Client"
     /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
     /// <param name="LeaseBreakPeriod">The proposed duration the lease should continue before it is broken, in seconds, between 0 and 60.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure BreakLease(ContainerName: Text; LeaseId: Guid; LeaseBreakPeriod: Integer): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -319,7 +319,7 @@ codeunit 9052 "ABS Container Client"
     /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure BreakLease(ContainerName: Text; LeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.ContainerBreakLease(ContainerName, ABSOptionalParameters, LeaseId, 0));
@@ -333,7 +333,7 @@ codeunit 9052 "ABS Container Client"
     /// <param name="LeaseId">The Guid for the lease that should be broken</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
     /// <param name="LeaseBreakPeriod">The proposed duration the lease should continue before it is broken, in seconds, between 0 and 60.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure BreakLease(ContainerName: Text; LeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"; LeaseBreakPeriod: Integer): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.ContainerBreakLease(ContainerName, ABSOptionalParameters, LeaseId, LeaseBreakPeriod));
@@ -346,7 +346,7 @@ codeunit 9052 "ABS Container Client"
     /// <param name="ContainerName">The name of the container.</param>
     /// <param name="LeaseId">The Guid for the lease that should be changed. Will contain the updated Guid after successful operation.</param>
     /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure ChangeLease(ContainerName: Text; var LeaseId: Guid; ProposedLeaseId: Guid): Codeunit "ABS Operation Response"
     var
         ABSOptionalParameters: Codeunit "ABS Optional Parameters";
@@ -362,7 +362,7 @@ codeunit 9052 "ABS Container Client"
     /// <param name="LeaseId">The Guid for the lease that should be changed</param>
     /// <param name="ProposedLeaseId">The Guid that should be used in future</param>
     /// <param name="ABSOptionalParameters">Optional parameters to pass.</param>
-    /// <returns>An operation reponse object</returns>
+    /// <returns>An operation response object</returns>
     procedure ChangeLease(ContainerName: Text; LeaseId: Guid; ProposedLeaseId: Guid; ABSOptionalParameters: Codeunit "ABS Optional Parameters"): Codeunit "ABS Operation Response"
     begin
         exit(ABSClientImpl.ContainerChangeLease(ContainerName, ABSOptionalParameters, LeaseId, ProposedLeaseId));

--- a/Modules/System/Azure Blob Services API/src/Helper/ABSHttpContentHelper.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSHttpContentHelper.Codeunit.al
@@ -13,19 +13,19 @@ codeunit 9049 "ABS HttpContent Helper"
         ContentLengthLbl: Label '%1', Comment = '%1 = Length', Locked = true;
 
     [NonDebuggable]
-    procedure AddBlobPutBlockBlobContentHeaders(var HttpContent: HttpContent; ABSOperationPayload: Codeunit "ABS Operation Payload"; var SourceInStream: InStream)
+    procedure AddBlobPutBlockBlobContentHeaders(var HttpContent: HttpContent; ABSOperationPayload: Codeunit "ABS Operation Payload"; var SourceInStream: InStream; ContentType: Text)
     var
         BlobType: Enum "ABS Blob Type";
     begin
-        AddBlobPutContentHeaders(HttpContent, ABSOperationPayload, SourceInStream, BlobType::BlockBlob)
+        AddBlobPutContentHeaders(HttpContent, ABSOperationPayload, SourceInStream, BlobType::BlockBlob, ContentType)
     end;
 
     [NonDebuggable]
-    procedure AddBlobPutBlockBlobContentHeaders(var HttpContent: HttpContent; ABSOperationPayload: Codeunit "ABS Operation Payload"; SourceText: Text)
+    procedure AddBlobPutBlockBlobContentHeaders(var HttpContent: HttpContent; ABSOperationPayload: Codeunit "ABS Operation Payload"; SourceText: Text; ContentType: Text)
     var
         BlobType: Enum "ABS Blob Type";
     begin
-        AddBlobPutContentHeaders(HttpContent, ABSOperationPayload, SourceText, BlobType::BlockBlob)
+        AddBlobPutContentHeaders(HttpContent, ABSOperationPayload, SourceText, BlobType::BlockBlob, ContentType)
     end;
 
     [NonDebuggable]
@@ -49,7 +49,7 @@ codeunit 9049 "ABS HttpContent Helper"
     end;
 
     [NonDebuggable]
-    local procedure AddBlobPutContentHeaders(var HttpContent: HttpContent; ABSOperationPayload: Codeunit "ABS Operation Payload"; var SourceInStream: InStream; BlobType: Enum "ABS Blob Type")
+    local procedure AddBlobPutContentHeaders(var HttpContent: HttpContent; ABSOperationPayload: Codeunit "ABS Operation Payload"; var SourceInStream: InStream; BlobType: Enum "ABS Blob Type"; ContentType: Text)
     var
         Length: Integer;
     begin
@@ -58,11 +58,14 @@ codeunit 9049 "ABS HttpContent Helper"
 
         Length := GetContentLength(SourceInStream);
 
-        AddBlobPutContentHeaders(HttpContent, ABSOperationPayload, BlobType, Length, 'application/octet-stream');
+        if ContentType = '' then
+            ContentType := 'application/octet-stream';
+
+        AddBlobPutContentHeaders(HttpContent, ABSOperationPayload, BlobType, Length, ContentType);
     end;
 
     [NonDebuggable]
-    local procedure AddBlobPutContentHeaders(var HttpContent: HttpContent; ABSOperationPayload: Codeunit "ABS Operation Payload"; SourceText: Text; BlobType: Enum "ABS Blob Type")
+    local procedure AddBlobPutContentHeaders(var HttpContent: HttpContent; ABSOperationPayload: Codeunit "ABS Operation Payload"; SourceText: Text; BlobType: Enum "ABS Blob Type"; ContentType: Text)
     var
         Length: Integer;
     begin
@@ -70,7 +73,10 @@ codeunit 9049 "ABS HttpContent Helper"
 
         Length := GetContentLength(SourceText);
 
-        AddBlobPutContentHeaders(HttpContent, ABSOperationPayload, BlobType, Length, 'text/plain; charset=UTF-8');
+        if ContentType = '' then
+            ContentType := 'text/plain; charset=UTF-8';
+
+        AddBlobPutContentHeaders(HttpContent, ABSOperationPayload, BlobType, Length, ContentType);
     end;
 
     [NonDebuggable]


### PR DESCRIPTION
The intent of this change is to extend PutBlobBlockBlobStream and PutBlobBlockBlobText procedures with ContentType parameter.