### PR TITLE
Statistical Accounts

### DIFF
--- a/Apps/W1/StatisticalAccounts/app/src/StatAccFinReportingMgt.Codeunit.al
+++ b/Apps/W1/StatisticalAccounts/app/src/StatAccFinReportingMgt.Codeunit.al
@@ -93,12 +93,13 @@ codeunit 2622 "Stat. Acc. Fin Reporting Mgt"
         if ColumnLayout."Column Type" = ColumnLayout."Column Type"::Formula then
             exit(ColValue);
 
+        AccSchedLine.CopyFilters(SourceAccScheduleLine);
         if AccSchedName."Analysis View Name" = '' then begin
-            SetStatisticalAccountsLedgerEntryFilters(StatisticalAccount, StatisticalLedgerEntry, SourceAccScheduleLine, ColumnLayout, sender);
+            SetStatisticalAccountsLedgerEntryFilters(StatisticalAccount, StatisticalLedgerEntry, AccSchedLine, ColumnLayout, sender);
             StatisticalLedgerEntry.CalcSums(Amount);
             ColValue := StatisticalLedgerEntry.Amount;
         end else begin
-            SetStatisticalAccountAnalysisViewEntryFilters(StatisticalAccount, AnalysisViewEntry, SourceAccScheduleLine, ColumnLayout, AccSchedName);
+            SetStatisticalAccountAnalysisViewEntryFilters(StatisticalAccount, AnalysisViewEntry, AccSchedLine, ColumnLayout, AccSchedName);
             AnalysisViewEntry.CalcSums(Amount);
             ColValue := AnalysisViewEntry.Amount;
         end;

--- a/Apps/W1/StatisticalAccounts/app/src/StatAccReverseEntry.Codeunit.al
+++ b/Apps/W1/StatisticalAccounts/app/src/StatAccReverseEntry.Codeunit.al
@@ -16,8 +16,11 @@ codeunit 2630 "Stat. Acc. Reverse Entry"
 
         InsertReversalEntry(Number, TempReversalEntry, RevType);
         TempReversalEntry.SetCurrentKey("Document No.", "Posting Date", "Entry Type", "Entry No.");
-        StatAccReverseEntries.SetReversalEntries(TempReversalEntry);
-        StatAccReverseEntries.RunModal();
+        if not HideDialog then begin
+            StatAccReverseEntries.SetReversalEntries(TempReversalEntry);
+            StatAccReverseEntries.RunModal();
+        end else
+            PostReversal(TempReversalEntry);
     end;
 
     internal procedure PostReversal(ReversalEntry: Record "Reversal Entry")


### PR DESCRIPTION
- Correction for apply totaling dimensions filters:
The cell value calculation does not apply the totaling dimensions filters, however the drilldown shows the entries with the totaling dimensions filters.
- Allow to reverse entries with HideDialog option