### PR TITLE
[Shopify] Remove access internal from Payment tables

### DIFF
--- a/Apps/W1/Shopify/README.md
+++ b/Apps/W1/Shopify/README.md
@@ -91,10 +91,10 @@ Exposes the following integration events:
 - OnAfterCalculationStock(Item: Record Item; ShopifyShop: Record "Shpfy Shop"; LocationFilter: Text; var StockResult: Decimal)
 
 ### table 30124 "Shpfy Payout"
-Availability date: starting with version 22.0
+Availability date: starting with version 22.4
 
 ### table 30125 "Shpfy Payout"
-Availability date: starting with version 22.0
+Availability date: starting with version 22.4
 
 ### table 30118 "Shpfy Order Header"
 Availability date: starting with version 22.0

--- a/Apps/W1/Shopify/README.md
+++ b/Apps/W1/Shopify/README.md
@@ -90,7 +90,7 @@ Exposes the following integration events:
 
 - OnAfterCalculationStock(Item: Record Item; ShopifyShop: Record "Shpfy Shop"; LocationFilter: Text; var StockResult: Decimal)
 
-### table 30124 "Shpfy Payout"
+### table 30124 "Shpfy Payment Transaction"
 Availability date: starting with version 22.4
 
 ### table 30125 "Shpfy Payout"

--- a/Apps/W1/Shopify/README.md
+++ b/Apps/W1/Shopify/README.md
@@ -90,6 +90,11 @@ Exposes the following integration events:
 
 - OnAfterCalculationStock(Item: Record Item; ShopifyShop: Record "Shpfy Shop"; LocationFilter: Text; var StockResult: Decimal)
 
+### table 30124 "Shpfy Payout"
+Availability date: starting with version 22.0
+
+### table 30125 "Shpfy Payout"
+Availability date: starting with version 22.0
 
 ### table 30118 "Shpfy Order Header"
 Availability date: starting with version 22.0

--- a/Apps/W1/Shopify/app/src/Payments/Tables/ShpfyPaymentTransaction.Table.al
+++ b/Apps/W1/Shopify/app/src/Payments/Tables/ShpfyPaymentTransaction.Table.al
@@ -3,7 +3,6 @@
 /// </summary>
 table 30124 "Shpfy Payment Transaction"
 {
-    Access = Internal;
     Caption = 'Shopify Payment Transaction';
     DataClassification = CustomerContent;
 

--- a/Apps/W1/Shopify/app/src/Payments/Tables/ShpfyPayout.Table.al
+++ b/Apps/W1/Shopify/app/src/Payments/Tables/ShpfyPayout.Table.al
@@ -3,7 +3,6 @@
 /// </summary>
 table 30125 "Shpfy Payout"
 {
-    Access = Internal;
     Caption = 'Shopify Payout';
     DataClassification = CustomerContent;
 


### PR DESCRIPTION
Hi,

This change allows users / developers to develop their own code to apply the payouts directly to customer ledger entries.
Right now, payouts are for information purposes only, which is not ideal.

There is a function on the page (listpart 30124) which makes us able to throw the data out into Excel – but this seems rather problematic to make a function for this instead of directly getting the data from the table.

Just to make sure, i am currently talking about current tables:
- 30124
- 30125


