### PR TITLE
GP PO fixes - 2nd attempt

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOMigrator.codeunit.al
@@ -257,7 +257,7 @@ codeunit 40108 "GP PO Migrator"
             UnitOfMeasureRec.Insert(true);
         end;
 
-        if not GenProductPostingGroup.get(GPCodeTxt) then begin
+        if not GenProductPostingGroup.Get(GPCodeTxt) then begin
             GenProductPostingGroup.Code := GPCodeTxt;
             GenProductPostingGroup.Description := MigratedFromGPDescriptionTxt;
             GenProductPostingGroup.Insert();
@@ -397,7 +397,7 @@ codeunit 40108 "GP PO Migrator"
         GPPOPReceiptHist: Record GPPOPReceiptHist;
     begin
         GPPOPReceiptApply.SetRange(PONUMBER, PurchaseHeader."No.");
-        GPPOPReceiptApply.SetFilter(Status, '%1', GPPOPReceiptApply.Status::Posted);
+        GPPOPReceiptApply.SetRange(Status, GPPOPReceiptApply.Status::Posted);
         if GPPOPReceiptApply.FindFirst() then begin
             GPPOPReceiptHist.SetRange(POPRCTNM, GPPOPReceiptApply.POPRCTNM);
             GPPOPReceiptHist.SetFilter(VNDDOCNM, '<>%1', '');

--- a/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOMigrator.codeunit.al
@@ -384,11 +384,12 @@ codeunit 40108 "GP PO Migrator"
 
         Clear(ItemJournalLine);
         ItemJournalLine.SetRange("Journal Batch Name", ItemJournalBatchNameTxt);
-        if not ItemJournalLine.IsEmpty() then
+        if ItemJournalLine.Count() <= 1 then begin
             ItemJournalLine.DeleteAll();
 
-        ItemJournalBatch.SetRange("Name", ItemJournalBatchNameTxt);
-        ItemJournalBatch.DeleteAll();
+            ItemJournalBatch.SetRange("Name", ItemJournalBatchNameTxt);
+            ItemJournalBatch.DeleteAll();
+        end;
     end;
 
     local procedure SetVendorDocumentNo(var PurchaseHeader: Record "Purchase Header")


### PR DESCRIPTION
This change fixes multiple issues found while attempting to migrate open Purchase Orders during a GP migration.

Fixes

- Prevent migrating the PO if the Vendor Id is empty (bad data)
- Vendor Posting Group set by the Vendor, not hard coded to "GP".
- Better line over-receipt support
- Line count fixes
- Add the Vendor Invoice No. if available. 
- Post the Purchase Order with received lines, which creates Purchase Receipt and related posting records to prevent a failure when later manually posting the Purchase Order