### PR TITLE
Add new storage service API versions

### DIFF
--- a/Modules/System/Azure Storage Services Authorization/src/StorageServiceAPIVersion.Enum.al
+++ b/Modules/System/Azure Storage Services Authorization/src/StorageServiceAPIVersion.Enum.al
@@ -20,4 +20,32 @@ enum 9060 "Storage Service API Version"
     {
         Caption = '2020-12-06', Locked = true;
     }
+    value(2; "2021-02-12")
+    {
+        Caption = '2021-02-12', Locked = true;
+    }
+    value(3; "2021-04-10")
+    {
+        Caption = '2021-04-10', Locked = true;
+    }
+    value(4; "2021-06-08")
+    {
+        Caption = '2021-06-08', Locked = true;
+    }
+    value(5; "2021-08-06")
+    {
+        Caption = '2021-08-06', Locked = true;
+    }
+    value(6; "2021-10-04")
+    {
+        Caption = '2021-10-04', Locked = true;
+    }
+    value(7; "2021-12-02")
+    {
+        Caption = '2021-12-02', Locked = true;
+    }
+    value(8; "2022-11-02")
+    {
+        Caption = '2022-11-02', Locked = true;
+    }
 }


### PR DESCRIPTION
I'm recreating the pull request that was accepted some time ago (#23608) because the changes got wiped and I can no longer see them on the main branch. I mentioned this in an issue #24043.