### PR TITLE
Added x-ms-blob-content-type to "ABS Optional Parameters"

### DIFF
--- a/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
+++ b/Modules/System/Azure Blob Services API/src/Helper/ABSOptionalParameters.Codeunit.al
@@ -229,6 +229,15 @@ codeunit 9047 "ABS Optional Parameters"
     end;
 
     /// <summary>
+    /// Sets the value for 'x-ms-blob-content-type' HttpHeader for a request.
+    /// </summary>
+    /// <param name="Value">Text value specifying the HttpHeader value</param>
+    procedure BlobContentType("Value": Text)
+    begin
+        SetRequestHeader('x-ms-blob-content-type', "Value");
+    end;
+
+    /// <summary>
     /// Sets the value for 'x-ms-lease-action' HttpHeader for a request.
     /// </summary>
     /// <param name="Value">Enum "ABS Lease Action" value specifying the HttpHeader value</param>    


### PR DESCRIPTION
Make it possible to set the blob’s content type, releated to issue https://github.com/microsoft/ALAppExtensions/issues/22142.

![image](https://github.com/microsoft/ALAppExtensions/assets/44637996/89852d2a-ba5d-4e45-881d-29669f81b97c)
https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob?tabs=azure-ad#request-headers-all-blob-types