### PR TITLE
GP migration updates for July 2023

### DIFF
--- a/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
@@ -115,5 +115,6 @@ permissionset 4031 "HybridGP - Edit"
                     tabledata "GP Hist. Source Error" = IMD,
                     tabledata "GP POP10100" = IMD,
                     tabledata "GP POP10110" = IMD,
-                    tabledata "GP PM00204" = IMD;
+                    tabledata "GP PM00204" = IMD,
+                    tabledata "GP Known Countries" = IMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
@@ -145,5 +145,7 @@ permissionset 4029 "HybridGP - Objects"
                     table "GP POP10100" = X,
                     table "GP POP10110" = X,
                     table "GP PM00204" = X,
-                    table "GP Known Countries" = X;
+                    table "GP Known Countries" = X,
+                    page "GP Company Migration Settings" = X,
+                    query "GP Item Aggregate" = X;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
@@ -144,5 +144,6 @@ permissionset 4029 "HybridGP - Objects"
                     page "Hist. Migration Status Factbox" = X,
                     table "GP POP10100" = X,
                     table "GP POP10110" = X,
-                    table "GP PM00204" = X;
+                    table "GP PM00204" = X,
+                    table "GP Known Countries" = X;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
@@ -115,5 +115,6 @@ permissionset 4032 "HybridGP - Read"
                     tabledata "GP Hist. Source Error" = R,
                     tabledata "GP POP10100" = R,
                     tabledata "GP POP10110" = R,
-                    tabledata "GP PM00204" = R;
+                    tabledata "GP PM00204" = R,
+                    tabledata "GP Known Countries" = R;
 }

--- a/Apps/W1/HybridGP/app/Permissions/INTELLIGENTCLOUDHGP.PermissionSetExt.al
+++ b/Apps/W1/HybridGP/app/Permissions/INTELLIGENTCLOUDHGP.PermissionSetExt.al
@@ -104,5 +104,6 @@ permissionsetextension 4028 "INTELLIGENT CLOUD - HGP" extends "INTELLIGENT CLOUD
                   tabledata "GP Hist. Source Error" = RIMD,
                   tabledata "GP POP10100" = RIMD,
                   tabledata "GP POP10110" = RIMD,
-                  tabledata "GP PM00204" = RIMD;
+                  tabledata "GP PM00204" = RIMD,
+                  tabledata "GP Known Countries" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
@@ -104,5 +104,6 @@ permissionsetextension 4025 "D365 BASIC - HGP" extends "D365 BASIC"
                   tabledata "GP Hist. Source Error" = RIMD,
                   tabledata "GP POP10100" = RIMD,
                   tabledata "GP POP10110" = RIMD,
-                  tabledata "GP PM00204" = RIMD;
+                  tabledata "GP PM00204" = RIMD,
+                  tabledata "GP Known Countries" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
@@ -104,5 +104,6 @@ permissionsetextension 4026 "D365 BASIC ISV - HGP" extends "D365 BASIC ISV"
                   tabledata "GP Hist. Source Error" = RIMD,
                   tabledata "GP POP10100" = RIMD,
                   tabledata "GP POP10110" = RIMD,
-                  tabledata "GP PM00204" = RIMD;
+                  tabledata "GP PM00204" = RIMD,
+                  tabledata "GP Known Countries" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
@@ -104,5 +104,6 @@ permissionsetextension 4027 "D365 TEAM MEMBER - HGP" extends "D365 TEAM MEMBER"
                   tabledata "GP Hist. Source Error" = RIMD,
                   tabledata "GP POP10100" = RIMD,
                   tabledata "GP POP10110" = RIMD,
-                  tabledata "GP PM00204" = RIMD;
+                  tabledata "GP PM00204" = RIMD,
+                  tabledata "GP Known Countries" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/History/GPPopulateHistTables.Codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/History/GPPopulateHistTables.Codeunit.al
@@ -89,7 +89,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::"GP GL00105";
-
+        GPGL00105.SetLoadFields(DEX_ROW_ID, ACTINDX, ACTNUMST);
         GPGL00105.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPGL00105.SetCurrentKey(DEX_ROW_ID);
         GPGL00105.SetAscending(DEX_ROW_ID, true);
@@ -134,7 +134,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::"GP GL20000";
-
+        GPGL20000.SetLoadFields(DEX_ROW_ID, OPENYEAR, ACTINDX, SERIES, SOURCDOC, JRNENTRY, SEQNUMBR, TRXSORCE, TRXDATE, CURNCYID, DEBITAMT, ORDBTAMT, CRDTAMNT, ORCRDAMT, SOURCDOC, REFRENCE, DSCRIPTN, ORTRXSRC, USWHPSTD, User_Defined_Text01, User_Defined_Text02, ORDOCNUM, ORMSTRID, ORMSTRNM);
         GPGL20000.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPGL20000.SetCurrentKey(DEX_ROW_ID);
         GPGL20000.SetAscending(DEX_ROW_ID, true);
@@ -207,7 +207,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::"GP GL30000";
-
+        GPGL30000.SetLoadFields(DEX_ROW_ID, HSTYEAR, ACTINDX, SERIES, SOURCDOC, JRNENTRY, SEQNUMBR, TRXSORCE, TRXDATE, CURNCYID, DEBITAMT, ORDBTAMT, CRDTAMNT, ORCRDAMT, SOURCDOC, REFRENCE, DSCRIPTN, ORTRXSRC, USWHPSTD, User_Defined_Text01, User_Defined_Text02, ORDOCNUM, ORMSTRID, ORMSTRNM);
         GPGL30000.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPGL30000.SetCurrentKey(DEX_ROW_ID);
         GPGL30000.SetAscending(DEX_ROW_ID, true);
@@ -290,7 +290,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::GPSOPTrxHist;
-
+        GPSOPTrxHist.SetLoadFields(DEX_ROW_ID, DOCDATE, SOPNUMBE, CUSTNMBR, SOPTYPE, SOPSTATUS, CURNCYID, SUBTOTAL, TAXAMNT, TRDISAMT, FRTAMNT, MISCAMNT, PYMTRCVD, DISTKNAM, DOCAMNT, DUEDATE, ACTLSHIP, CUSTNAME, SHIPMTHD, PRSTADCD, ShipToName, ADDRESS1, ADDRESS2, CITY, STATE, ZIPCODE, COUNTRY, CNTCPRSN, SLPRSNID, SALSTERR, CSTPONBR, ORIGNUMB, TRXSORCE);
         GPSOPTrxHist.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPSOPTrxHist.SetCurrentKey(DEX_ROW_ID);
         GPSOPTrxHist.SetAscending(DEX_ROW_ID, true);
@@ -356,11 +356,12 @@ codeunit 40900 "GP Populate Hist. Tables"
         AfterProcessedSection(SourceTableId, LastSourceRecordId);
     end;
 
-    local procedure PopulateSalesTransactionLines(GPSOPTrxHist: Record GPSOPTrxHist; DocumentNo: Code[35])
+    local procedure PopulateSalesTransactionLines(var GPSOPTrxHist: Record GPSOPTrxHist; DocumentNo: Code[35])
     var
         GPSOPTrxAmountsHist: Record GPSOPTrxAmountsHist;
         HistSalesTrxLine: Record "Hist. Sales Trx. Line";
     begin
+        GPSOPTrxAmountsHist.SetLoadFields(DEX_ROW_ID, SOPTYPE, SOPNUMBE, LNITMSEQ, CMPNTSEQ, ITEMNMBR, ITEMDESC, UOFM, UNITCOST, UNITPRCE, QUANTITY, EXTDCOST, XTNDPRCE, TAXAMNT, LOCNCODE, ShipToName);
         GPSOPTrxAmountsHist.SetRange(SOPTYPE, GPSOPTrxHist.SOPTYPE);
         GPSOPTrxAmountsHist.SetRange(SOPNUMBE, GPSOPTrxHist.SOPNUMBE);
         if not GPSOPTrxAmountsHist.FindSet() then
@@ -408,7 +409,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::"GP RM20101";
-
+        GPRM20101.SetLoadFields(DEX_ROW_ID, DOCDATE, CUSTNMBR, DOCNUMBR, RMDTYPAL, BACHNUMB, BCHSOURC, TRXSORCE, TRXDSCRN, DUEDATE, POSTDATE, PSTUSRID, CURNCYID, ORTRXAMT, CURTRXAM, SLSAMNT, COSTAMNT, FRTAMNT, MISCAMNT, TAXAMNT, DISTKNAM, CSPORNBR, SLPRSNID, SLSTERCD, SHIPMTHD, SHIPMTHD, CASHAMNT, COMDLRAM, DINVPDOF, PYMTRMID, WROFAMNT);
         GPRM20101.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPRM20101.SetCurrentKey(DEX_ROW_ID);
         GPRM20101.SetAscending(DEX_ROW_ID, true);
@@ -483,7 +484,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::GPRMHist;
-
+        GPRMHist.SetLoadFields(DEX_ROW_ID, DOCDATE, CUSTNMBR, DOCNUMBR, RMDTYPAL, BACHNUMB, BCHSOURC, TRXSORCE, TRXDSCRN, DUEDATE, POSTDATE, PSTUSRID, CURNCYID, ORTRXAMT, CURTRXAM, SLSAMNT, COSTAMNT, FRTAMNT, MISCAMNT, TAXAMNT, DISTKNAM, CSPORNBR, SLPRSNID, SLSTERCD, SHIPMTHD, SHIPMTHD, CASHAMNT, COMDLRAM, DINVPDOF, PYMTRMID, WROFAMNT);
         GPRMHist.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPRMHist.SetCurrentKey(DEX_ROW_ID);
         GPRMHist.SetAscending(DEX_ROW_ID, true);
@@ -569,7 +570,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::"GP PM20000";
-
+        GPPM20000.SetLoadFields(DEX_ROW_ID, DOCDATE, VENDORID, DOCTYPE, DOCNUMBR, VCHRNMBR, DOCAMNT, CURNCYID, CURTRXAM, DISTKNAM, BCHSOURC, BACHNUMB, DUEDATE, PORDNMBR, TRXSORCE, TRXDSCRN, POSTEDDT, PTDUSRID, MSCCHAMT, FRTAMNT, TAXAMNT, TTLPYMTS, VOIDED, DINVPDOF, SHIPMTHD, TEN99AMNT, WROFAMNT, TRDISAMT, PYMTRMID, TEN99TYPE, TEN99BOXNUMBER, PONUMBER);
         GPPM20000.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPPM20000.SetCurrentKey(DEX_ROW_ID);
         GPPM20000.SetAscending(DEX_ROW_ID, true);
@@ -646,7 +647,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::GPPMHist;
-
+        GPPMHist.SetLoadFields(DEX_ROW_ID, DOCDATE, VENDORID, DOCTYPE, DOCNUMBR, VCHRNMBR, DOCAMNT, CURNCYID, CURTRXAM, DISTKNAM, BCHSOURC, BACHNUMB, DUEDATE, PORDNMBR, TRXSORCE, TRXDSCRN, POSTEDDT, PTDUSRID, MSCCHAMT, FRTAMNT, TAXAMNT, TTLPYMTS, VOIDED, DINVPDOF, SHIPMTHD, TEN99AMNT, WROFAMNT, TRDISAMT, PYMTRMID, TEN99TYPE, TEN99BOXNUMBER, PONUMBER);
         GPPMHist.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPPMHist.SetCurrentKey(DEX_ROW_ID);
         GPPMHist.SetAscending(DEX_ROW_ID, true);
@@ -725,7 +726,7 @@ codeunit 40900 "GP Populate Hist. Tables"
             exit;
 
         SourceTableId := Database::GPIVTrxHist;
-
+        GPIVTrxHist.SetLoadFields(DEX_ROW_ID, DOCDATE, TRXSORCE, IVDOCTYP, DOCDATE, BACHNUMB, BCHSOURC, GLPOSTDT, SRCRFRNCNMBR, SOURCEINDICATOR);
         GPIVTrxHist.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPIVTrxHist.SetCurrentKey(DEX_ROW_ID);
         GPIVTrxHist.SetAscending(DEX_ROW_ID, true);
@@ -775,6 +776,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         GPIVTrxAmountsHist: Record GPIVTrxAmountsHist;
         HistInventoryTrxLine: Record "Hist. Inventory Trx. Line";
     begin
+        GPIVTrxAmountsHist.SetLoadFields(DEX_ROW_ID, TRXSORCE, DOCNUMBR, ITEMNMBR, CUSTNMBR, DOCTYPE, LNSEQNBR, DOCDATE, HSTMODUL, UOFM, TRXQTY, UNITCOST, EXTDCOST, TRXLOCTN, TRNSTLOC, Reason_Code);
         GPIVTrxAmountsHist.SetRange(TRXSORCE, AuditCode);
         GPIVTrxAmountsHist.SetRange(DOCNUMBR, DocumentNo);
 
@@ -823,7 +825,7 @@ codeunit 40900 "GP Populate Hist. Tables"
             exit;
 
         SourceTableId := Database::"GP BM30200";
-
+        GPBM30200.SetLoadFields(DEX_ROW_ID, TRXDATE, TRX_ID, TRXSORCE, BACHNUMB, BCHSOURC, PSTGDATE, REFRENCE);
         GPBM30200.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPBM30200.SetCurrentKey(DEX_ROW_ID);
         GPBM30200.SetAscending(DEX_ROW_ID, true);
@@ -880,7 +882,7 @@ codeunit 40900 "GP Populate Hist. Tables"
             exit;
 
         SourceTableId := Database::GPPOPReceiptHist;
-
+        GPPOPReceiptHist.SetLoadFields(DEX_ROW_ID, receiptdate, POPRCTNM, VENDORID, VENDNAME, POPTYPE, VNDDOCNM, GLPOSTDT, ACTLSHIP, BACHNUMB, SUBTOTAL, TRDISAMT, FRTAMNT, MISCAMNT, TAXAMNT, TEN99AMNT, PYMTRMID, DSCPCTAM, DSCDLRAM, DISAVAMT, DISCDATE, DUEDATE, REFRENCE, VOIDSTTS, PTDUSRID, TRXSORCE, VCHRNMBR, CURNCYID, InvoiceReceiptDate, PrepaymentAmount);
         GPPOPReceiptHist.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPPOPReceiptHist.SetCurrentKey(DEX_ROW_ID);
         GPPOPReceiptHist.SetAscending(DEX_ROW_ID, true);
@@ -947,12 +949,13 @@ codeunit 40900 "GP Populate Hist. Tables"
         HistMigrationStatusMgmt.UpdateStepStatus("Hist. Migration Step Type"::"GP Purchase Receivables Trx.", true);
     end;
 
-    local procedure PopulatePurchaseRecvLines(GPPOPReceiptHist: Record GPPOPReceiptHist; ReceiptNo: Code[35])
+    local procedure PopulatePurchaseRecvLines(var GPPOPReceiptHist: Record GPPOPReceiptHist; ReceiptNo: Code[35])
     var
         GPPOPReceiptLineHist: Record GPPOPReceiptLineHist;
         GPPOPReceiptApply: Record GPPOPReceiptApply;
         HistPurchaseRecvLine: Record "Hist. Purchase Recv. Line";
     begin
+        GPPOPReceiptLineHist.SetLoadFields(DEX_ROW_ID, POPRCTNM, PONUMBER, ITEMNMBR, RCPTLNNM, ITEMDESC, VNDITNUM, VNDITDSC, UMQTYINB, ACTLSHIP, UOFM, UNITCOST, EXTDCOST, TAXAMNT, LOCNCODE, TRXSORCE, SHIPMTHD, ORUNTCST, OREXTCST, ORDISTKN, ORTDISAM, ORFRTAMT, ORMISCAMT);
         GPPOPReceiptLineHist.SetRange(POPRCTNM, GPPOPReceiptHist.POPRCTNM);
 
         if not GPPOPReceiptLineHist.FindSet() then
@@ -987,6 +990,7 @@ codeunit 40900 "GP Populate Hist. Tables"
             HistPurchaseRecvLine."Orig. Freight Amount" := GPPOPReceiptLineHist.ORFRTAMT;
             HistPurchaseRecvLine."Orig. Misc. Amount" := GPPOPReceiptLineHist.ORMISCAMT;
 
+            GPPOPReceiptApply.SetLoadFields(POPRCTNM, RCPTLNNM, QTYSHPPD, QTYINVCD);
             GPPOPReceiptApply.SetRange(POPRCTNM, GPPOPReceiptLineHist.POPRCTNM);
             GPPOPReceiptApply.SetRange(RCPTLNNM, GPPOPReceiptLineHist.RCPTLNNM);
             if GPPOPReceiptApply.FindFirst() then begin
@@ -1001,7 +1005,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         until GPPOPReceiptLineHist.Next() = 0;
     end;
 
-    local procedure PopulateGLOpenYearItemTransaction(GPGL20000: Record "GP GL20000")
+    local procedure PopulateGLOpenYearItemTransaction(var GPGL20000: Record "GP GL20000")
     var
         GPIVTrxAmountsHist: Record GPIVTrxAmountsHist;
         HistInventoryTrxHeader: Record "Hist. Inventory Trx. Header";
@@ -1020,6 +1024,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         DocumentNo := GPGL20000.REFRENCE.TrimEnd();
 #pragma warning restore AA0139
 
+        GPIVTrxAmountsHist.SetLoadFields(DEX_ROW_ID, TRXSORCE, DOCNUMBR, DOCTYPE);
         GPIVTrxAmountsHist.SetRange(TRXSORCE, GPGL20000.ORTRXSRC);
         GPIVTrxAmountsHist.SetRange(DOCNUMBR, DocumentNo);
         if not GPIVTrxAmountsHist.FindFirst() then
@@ -1047,7 +1052,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         AfterProcessedNextChildRecord();
     end;
 
-    local procedure PopulateGLHistoricalYearItemTransaction(GPGL30000: Record "GP GL30000")
+    local procedure PopulateGLHistoricalYearItemTransaction(var GPGL30000: Record "GP GL30000")
     var
         GPIVTrxAmountsHist: Record GPIVTrxAmountsHist;
         HistInventoryTrxHeader: Record "Hist. Inventory Trx. Header";
@@ -1066,6 +1071,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         DocumentNo := GPGL30000.REFRENCE.TrimEnd();
 #pragma warning restore AA0139
 
+        GPIVTrxAmountsHist.SetLoadFields(DEX_ROW_ID, TRXSORCE, DOCNUMBR, DOCTYPE);
         GPIVTrxAmountsHist.SetRange(TRXSORCE, GPGL30000.ORTRXSRC);
         GPIVTrxAmountsHist.SetRange(DOCNUMBR, DocumentNo);
         if not GPIVTrxAmountsHist.FindFirst() then
@@ -1093,7 +1099,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         AfterProcessedNextChildRecord();
     end;
 
-    local procedure PopulatePOPItemTransaction(GPPOPReceiptHist: Record GPPOPReceiptHist)
+    local procedure PopulatePOPItemTransaction(var GPPOPReceiptHist: Record GPPOPReceiptHist)
     var
         GPIVTrxAmountsHist: Record GPIVTrxAmountsHist;
         HistInventoryTrxHeader: Record "Hist. Inventory Trx. Header";
@@ -1102,6 +1108,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         if not GPCompanyAdditionalSettings.GetMigrateHistInvTrx() then
             exit;
 
+        GPIVTrxAmountsHist.SetLoadFields(TRXSORCE, DOCTYPE);
         GPIVTrxAmountsHist.SetRange(TRXSORCE, GPPOPReceiptHist.TRXSORCE);
 
         if not GPIVTrxAmountsHist.FindFirst() then
@@ -1127,7 +1134,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         AfterProcessedNextChildRecord();
     end;
 
-    local procedure PopulateSOPItemTransaction(GPSOPTrxHist: Record GPSOPTrxHist)
+    local procedure PopulateSOPItemTransaction(var GPSOPTrxHist: Record GPSOPTrxHist)
     var
         GPIVTrxAmountsHist: Record GPIVTrxAmountsHist;
         HistInventoryTrxHeader: Record "Hist. Inventory Trx. Header";
@@ -1136,6 +1143,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         if not GPCompanyAdditionalSettings.GetMigrateHistInvTrx() then
             exit;
 
+        GPIVTrxAmountsHist.SetLoadFields(DEX_ROW_ID, TRXSORCE, DOCTYPE);
         GPIVTrxAmountsHist.SetRange(TRXSORCE, GPSOPTrxHist.TRXSORCE);
 
         if not GPIVTrxAmountsHist.FindFirst() then

--- a/Apps/W1/HybridGP/app/src/Migration/Items/GPIV00101.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Items/GPIV00101.Table.al
@@ -29,6 +29,10 @@ table 40116 "GP IV00101"
         {
             DataClassification = CustomerContent;
         }
+        field(11; DECPLCUR; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
         field(14; IVIVINDX; Integer)
         {
             DataClassification = CustomerContent;
@@ -83,5 +87,23 @@ table 40116 "GP IV00101"
     procedure IsDiscontinued(): Boolean
     begin
         exit(Rec.ITEMTYPE = DiscontinuedItemTypeId());
+    end;
+
+    procedure GetRoundingPrecision(GPDecimalPlaceId: Integer): Decimal
+    begin
+        Case GPDecimalPlaceId of
+            6:
+                exit(0.00001);
+            5:
+                exit(0.0001);
+            4:
+                exit(0.001);
+            3:
+                exit(0.01);
+            2:
+                exit(0.1);
+            else
+                exit(0);
+        End;
     end;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Items/GPItemAggregate.Query.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Items/GPItemAggregate.Query.al
@@ -1,0 +1,15 @@
+query 40101 "GP Item Aggregate"
+{
+    QueryType = Normal;
+
+    elements
+    {
+        dataitem(GPIV00101; "GP IV00101")
+        {
+            column(DECPLCUR; DECPLCUR)
+            {
+                Method = Max;
+            }
+        }
+    }
+}

--- a/Apps/W1/HybridGP/app/src/Migration/Support/CheckBooks/GPCheckbookMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/CheckBooks/GPCheckbookMigrator.codeunit.al
@@ -57,6 +57,7 @@ codeunit 40025 "GP Checkbook Migrator"
     begin
         GPCheckbookTransactions.SetRange(CHEKBKID, CheckbookID);
         GPCheckbookTransactions.SetRange(Recond, false);
+        GPCheckbookTransactions.SetFilter(TRXAMNT, '<>%1', 0);
         if not GPCheckbookTransactions.FindSet() then
             exit;
 

--- a/Apps/W1/HybridGP/app/src/Migration/Support/WizardIntegration.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/WizardIntegration.codeunit.al
@@ -118,7 +118,7 @@ codeunit 4035 "Wizard Integration"
 
     local procedure GetDefaultGPHistoricalMigrationJobMaxAttempts(): Integer
     begin
-        exit(1);
+        exit(10);
     end;
 
     procedure StartGPHistoricalJobMigrationAction(JobNotRanNotification: Notification)

--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
@@ -629,7 +629,6 @@ codeunit 4022 "GP Vendor Migrator"
                 VendorBankAccount.Validate("Transit No.", GPSY06000.EFTTransitRoutingNo);
                 VendorBankAccount.Validate("IBAN", IBANCode);
                 VendorBankAccount.Validate("SWIFT Code", GPSY06000.SWIFTADDR);
-                VendorBankAccount.Validate("Use for Electronic Payments", true);
 
                 if GeneralLedgerSetup.Get() then
                     if GeneralLedgerSetup."LCY Code" <> CurrencyCode then

--- a/Apps/W1/HybridGP/app/src/codeunits/HybridGPWizard.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/codeunits/HybridGPWizard.codeunit.al
@@ -135,7 +135,9 @@ codeunit 4015 "Hybrid GP Wizard"
     var
         GPCompanyMigrationSettings: Record "GP Company Migration Settings";
         GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        HybridCompany: Record "Hybrid Company";
         HybridCompanyStatus: Record "Hybrid Company Status";
+        HybridReplicationDetail: Record "Hybrid Replication Detail";
     begin
         GPCompanyMigrationSettings.Reset();
         if GPCompanyMigrationSettings.FindSet() then
@@ -146,6 +148,41 @@ codeunit 4015 "Hybrid GP Wizard"
 
         if not HybridCompanyStatus.IsEmpty() then
             HybridCompanyStatus.DeleteAll();
+
+        if not HybridCompany.IsEmpty() then
+            HybridCompany.DeleteAll();
+
+        if not HybridReplicationDetail.IsEmpty() then
+            HybridReplicationDetail.DeleteAll();
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"Company", 'OnAfterDeleteEvent', '', false, false)]
+    local procedure CompanyOnAfterDelete(var Rec: Record Company; RunTrigger: Boolean)
+    var
+        GPCompanyMigrationSettings: Record "GP Company Migration Settings";
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        HybridCompany: Record "Hybrid Company";
+        HybridCompanyStatus: Record "Hybrid Company Status";
+        HybridReplicationDetail: Record "Hybrid Replication Detail";
+    begin
+        if Rec.IsTemporary() then
+            exit;
+
+        if (GPCompanyMigrationSettings.Get(Rec.Name)) then
+            GPCompanyMigrationSettings.Delete();
+
+        if (GPCompanyAdditionalSettings.Get(Rec.Name)) then
+            GPCompanyAdditionalSettings.Delete();
+
+        if (HybridCompanyStatus.Get(Rec.Name)) then
+            HybridCompanyStatus.Delete();
+
+        if (HybridCompany.Get(Rec.Name)) then
+            HybridCompany.Delete();
+
+        HybridReplicationDetail.SetRange("Company Name", Rec.Name);
+        if not HybridReplicationDetail.IsEmpty() then
+            HybridReplicationDetail.DeleteAll();
     end;
 
     local procedure ProcessesAreRunning(): Boolean

--- a/Apps/W1/HybridGP/app/src/pages/GPCompanyAddSettingsList.Page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPCompanyAddSettingsList.Page.al
@@ -152,39 +152,63 @@ page 4051 "GP Company Add. Settings List"
                 }
                 field("Oldest Hist. Year to Migrate"; Rec."Oldest Hist. Year to Migrate")
                 {
-                    Caption = 'Oldest Hist. Year';
-                    ToolTip = 'Specify the oldest historical year to be migrated for GL summary information and historical snapshot records.';
+                    Caption = 'Oldest Snapshot year';
+                    ToolTip = 'Specify the oldest historical year to be migrated for snapshot records.';
                     Width = 4;
                     ApplicationArea = All;
                 }
                 field("Migrate Hist. GL Trx."; Rec."Migrate Hist. GL Trx.")
                 {
-                    Caption = 'Hist. GL Trx.';
+                    Caption = 'Snapshot GL Trx.';
                     ToolTip = 'Specify whether to migrate historical GL transactions.';
                     ApplicationArea = All;
                 }
                 field("Migrate Hist. AR Trx."; Rec."Migrate Hist. AR Trx.")
                 {
-                    Caption = 'Hist. AR Trx.';
+                    Caption = 'Snapshot AR Trx.';
                     ToolTip = 'Specify whether to migrate historical AR transactions.';
                     ApplicationArea = All;
                 }
                 field("Migrate Hist. AP Trx."; Rec."Migrate Hist. AP Trx.")
                 {
-                    Caption = 'Hist. AP Trx.';
+                    Caption = 'Snapshot AP Trx.';
                     ToolTip = 'Specify whether to migrate historical AP transactions.';
                     ApplicationArea = All;
                 }
                 field("Migrate Hist. Inv. Trx."; Rec."Migrate Hist. Inv. Trx.")
                 {
-                    Caption = 'Hist. Inv. Trx.';
+                    Caption = 'Snapshot Inv. Trx.';
                     ToolTip = 'Specify whether to migrate historical inventory transactions.';
                     ApplicationArea = All;
                 }
                 field("Migrate Hist. Purch. Trx."; Rec."Migrate Hist. Purch. Trx.")
                 {
-                    Caption = 'Hist. Purch. Trx.';
+                    Caption = 'Snapshot Purch. Trx.';
                     ToolTip = 'Specify whether to migrate historical Purchase receivable transactions.';
+                    ApplicationArea = All;
+                }
+                field("Skip Posting Account Batches"; Rec."Skip Posting Account Batches")
+                {
+                    Caption = 'Skip Posting Account Trx.';
+                    ToolTip = 'Specify whether to disable auto posting Account batches.';
+                    ApplicationArea = All;
+                }
+                field("Skip Posting Customer Batches"; Rec."Skip Posting Customer Batches")
+                {
+                    Caption = 'Skip Posting Customer Trx.';
+                    ToolTip = 'Specify whether to disable auto posting Customer batches.';
+                    ApplicationArea = All;
+                }
+                field("Skip Posting Vendor Batches"; Rec."Skip Posting Vendor Batches")
+                {
+                    Caption = 'Skip Posting Vendor Trx.';
+                    ToolTip = 'Specify whether to disable auto posting Vendor batches.';
+                    ApplicationArea = All;
+                }
+                field("Skip Posting Bank Batches"; Rec."Skip Posting Bank Batches")
+                {
+                    Caption = 'Skip Posting Bank Trx.';
+                    ToolTip = 'Specify whether to disable auto posting Bank batches.';
                     ApplicationArea = All;
                 }
             }

--- a/Apps/W1/HybridGP/app/src/pages/GPCompanyMigrationSettings.Page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPCompanyMigrationSettings.Page.al
@@ -1,0 +1,155 @@
+page 40056 "GP Company Migration Settings"
+{
+    ApplicationArea = All;
+    Caption = 'GP Company Migration Settings';
+    PageType = List;
+    SourceTable = "GP Company Additional Settings";
+    SourceTableView = sorting(Name) where("Name" = filter(<> ''));
+    UsageCategory = Lists;
+    Editable = true;
+    DeleteAllowed = false;
+    InsertAllowed = false;
+    ModifyAllowed = true;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(General)
+            {
+                field(Name; Rec.Name)
+                {
+                    ToolTip = 'Specify the name of the Company.';
+                }
+                field("Global Dimension 1"; Rec."Global Dimension 1")
+                {
+                    ToolTip = 'Specify the segment from Dynamics GP you would like as the first global dimension in Business Central.';
+                }
+                field("Global Dimension 2"; Rec."Global Dimension 2")
+                {
+                    ToolTip = 'Specify the segment from Dynamics GP you would like as the second global dimension in Business Central.';
+                }
+                field("Migrate Bank Module"; Rec."Migrate Bank Module")
+                {
+                    ToolTip = 'Specify whether to migrate the Bank module.';
+                }
+                field("Migrate Customer Classes"; Rec."Migrate Customer Classes")
+                {
+                    ToolTip = 'Specify whether to migrate customer classes.';
+                }
+                field("Migrate Discontinued Items"; Rec."Migrate Discontinued Items")
+                {
+                    ToolTip = 'Specify whether to migrate discontinued items.';
+                }
+                field("Migrate Hist. AP Trx."; Rec."Migrate Hist. AP Trx.")
+                {
+                    ToolTip = 'Specify whether to migrate historical AP transactions.';
+                }
+                field("Migrate Hist. AR Trx."; Rec."Migrate Hist. AR Trx.")
+                {
+                    ToolTip = 'Specify whether to migrate historical AR transactions.';
+                }
+                field("Migrate Hist. GL Trx."; Rec."Migrate Hist. GL Trx.")
+                {
+                    ToolTip = 'Specify whether to migrate historical GL transactions.';
+                }
+                field("Migrate Hist. Inv. Trx."; Rec."Migrate Hist. Inv. Trx.")
+                {
+                    ToolTip = 'Specify whether to migrate historical inventory transactions.';
+                }
+                field("Migrate Hist. Purch. Trx."; Rec."Migrate Hist. Purch. Trx.")
+                {
+                    ToolTip = 'Specify whether to migrate historical Purchase receivable transactions.';
+                }
+                field("Migrate Inactive Checkbooks"; Rec."Migrate Inactive Checkbooks")
+                {
+                    ToolTip = 'Specify whether to migrate inactive checkbooks.';
+                }
+                field("Migrate Inactive Customers"; Rec."Migrate Inactive Customers")
+                {
+                    ToolTip = 'Specify whether to migrate inactive customers.';
+                }
+                field("Migrate Inactive Items"; Rec."Migrate Inactive Items")
+                {
+                    ToolTip = 'Specify whether to migrate inactive items.';
+                }
+                field("Migrate Inactive Vendors"; Rec."Migrate Inactive Vendors")
+                {
+                    ToolTip = 'Specify whether to migrate inactive vendors.';
+                }
+                field("Migrate Inventory Module"; Rec."Migrate Inventory Module")
+                {
+                    ToolTip = 'Specify whether to migrate the Inventory module.';
+                }
+                field("Migrate Item Classes"; Rec."Migrate Item Classes")
+                {
+                    ToolTip = 'Specify whether to migrate item classes.';
+                }
+                field("Migrate Only Bank Master"; Rec."Migrate Only Bank Master")
+                {
+                    ToolTip = 'Specify whether to migrate Bank master data only.';
+                }
+                field("Migrate Only GL Master"; Rec."Migrate Only GL Master")
+                {
+                    ToolTip = 'Specify whether to migrate GL master data only.';
+                }
+                field("Migrate Only Inventory Master"; Rec."Migrate Only Inventory Master")
+                {
+                    ToolTip = 'Specify whether to migrate Inventory master data only.';
+                }
+                field("Migrate Only Payables Master"; Rec."Migrate Only Payables Master")
+                {
+                    ToolTip = 'Specify whether to migrate Payables master data only.';
+                }
+                field("Migrate Only Rec. Master"; Rec."Migrate Only Rec. Master")
+                {
+                    ToolTip = 'Specify whether to migrate Receivables master data only.';
+                }
+                field("Migrate Open POs"; Rec."Migrate Open POs")
+                {
+                    ToolTip = 'Specify whether to migrate open Purchase Orders.';
+                }
+                field("Migrate Payables Module"; Rec."Migrate Payables Module")
+                {
+                    ToolTip = 'Specify whether to migrate the Payables module.';
+                }
+                field("Migrate Receivables Module"; Rec."Migrate Receivables Module")
+                {
+                    ToolTip = 'Specify whether to migrate the Receivables module.';
+                }
+                field("Migrate Vendor Classes"; Rec."Migrate Vendor Classes")
+                {
+                    ToolTip = 'Specify whether to migrate vendor classes.';
+                }
+                field("Migration Completed"; Rec."Migration Completed")
+                {
+                    ToolTip = 'Specifies the value of the Migration Completed field.';
+                }
+                field("Oldest GL Year to Migrate"; Rec."Oldest GL Year to Migrate")
+                {
+                    ToolTip = 'Specify the oldest General Ledger year to be migrated. The year selected and all future years will be migrated to Business Central.';
+                }
+                field("Oldest Hist. Year to Migrate"; Rec."Oldest Hist. Year to Migrate")
+                {
+                    ToolTip = 'Specify the oldest historical year to be migrated for snapshot records.';
+                }
+                field("Skip Posting Account Batches"; Rec."Skip Posting Account Batches")
+                {
+                    ToolTip = 'Specify whether to disable auto posting Account batches.';
+                }
+                field("Skip Posting Bank Batches"; Rec."Skip Posting Bank Batches")
+                {
+                    ToolTip = 'Specify whether to disable auto posting Bank batches.';
+                }
+                field("Skip Posting Customer Batches"; Rec."Skip Posting Customer Batches")
+                {
+                    ToolTip = 'Specify whether to disable auto posting Customer batches.';
+                }
+                field("Skip Posting Vendor Batches"; Rec."Skip Posting Vendor Batches")
+                {
+                    ToolTip = 'Specify whether to disable auto posting Vendor batches.';
+                }
+            }
+        }
+    }
+}

--- a/Apps/W1/HybridGP/app/src/pages/GPCompanyMigrationSettings.Page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPCompanyMigrationSettings.Page.al
@@ -2,7 +2,7 @@ page 40056 "GP Company Migration Settings"
 {
     ApplicationArea = All;
     Caption = 'GP Company Migration Settings';
-    PageType = List;
+    PageType = Worksheet;
     SourceTable = "GP Company Additional Settings";
     SourceTableView = sorting(Name) where("Name" = filter(<> ''));
     UsageCategory = Lists;
@@ -19,6 +19,7 @@ page 40056 "GP Company Migration Settings"
             {
                 field(Name; Rec.Name)
                 {
+                    Editable = false;
                     ToolTip = 'Specify the name of the Company.';
                 }
                 field("Global Dimension 1"; Rec."Global Dimension 1")

--- a/Apps/W1/HybridGP/app/src/pages/GPMigrationConfiguration.Page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPMigrationConfiguration.Page.al
@@ -209,6 +209,73 @@ page 4050 "GP Migration Configuration"
                 }
             }
 
+            group(SkipPosting)
+            {
+                Caption = 'Disable Auto Posting';
+                InstructionalText = 'Select whether migrated transactions should be posted automatically during the migration process. By disabling auto posting, you will have the flexibility to adjust transactions in Business Central before posting.';
+
+                field("Skip Posting Account Batches"; Rec."Skip Posting Account Batches")
+                {
+                    Caption = 'Account Batches';
+                    ToolTip = 'Specify whether to disable auto posting Account batches.';
+                    ApplicationArea = All;
+
+                    trigger OnValidate()
+                    begin
+                        if PrepSettingsForFieldUpdate() then
+                            repeat
+                                GPCompanyAdditionalSettings.Validate("Skip Posting Account Batches", Rec."Skip Posting Account Batches");
+                                GPCompanyAdditionalSettings.Modify();
+                            until GPCompanyAdditionalSettings.Next() = 0;
+                    end;
+                }
+                field("Skip Posting Customer Batches"; Rec."Skip Posting Customer Batches")
+                {
+                    Caption = 'Customer Batches';
+                    ToolTip = 'Specify whether to disable auto posting Customer batches.';
+                    ApplicationArea = All;
+
+                    trigger OnValidate()
+                    begin
+                        if PrepSettingsForFieldUpdate() then
+                            repeat
+                                GPCompanyAdditionalSettings.Validate("Skip Posting Customer Batches", Rec."Skip Posting Customer Batches");
+                                GPCompanyAdditionalSettings.Modify();
+                            until GPCompanyAdditionalSettings.Next() = 0;
+                    end;
+                }
+                field("Skip Posting Vendor Batches"; Rec."Skip Posting Vendor Batches")
+                {
+                    Caption = 'Vendor Batches';
+                    ToolTip = 'Specify whether to disable auto posting Vendor batches.';
+                    ApplicationArea = All;
+
+                    trigger OnValidate()
+                    begin
+                        if PrepSettingsForFieldUpdate() then
+                            repeat
+                                GPCompanyAdditionalSettings.Validate("Skip Posting Vendor Batches", Rec."Skip Posting Vendor Batches");
+                                GPCompanyAdditionalSettings.Modify();
+                            until GPCompanyAdditionalSettings.Next() = 0;
+                    end;
+                }
+                field("Skip Posting Bank Batches"; Rec."Skip Posting Bank Batches")
+                {
+                    Caption = 'Bank Batches';
+                    ToolTip = 'Specify whether to disable auto posting Bank batches.';
+                    ApplicationArea = All;
+
+                    trigger OnValidate()
+                    begin
+                        if PrepSettingsForFieldUpdate() then
+                            repeat
+                                GPCompanyAdditionalSettings.Validate("Skip Posting Bank Batches", Rec."Skip Posting Bank Batches");
+                                GPCompanyAdditionalSettings.Modify();
+                            until GPCompanyAdditionalSettings.Next() = 0;
+                    end;
+                }
+            }
+
             group(Inactives)
             {
                 Caption = 'Inactive Records';
@@ -592,6 +659,10 @@ page 4050 "GP Migration Configuration"
                     GPCompanyAdditionalSettingsEachCompany.Validate("Migrate Hist. AP Trx.", Rec."Migrate Hist. AP Trx.");
                     GPCompanyAdditionalSettingsEachCompany.Validate("Migrate Hist. Inv. Trx.", Rec."Migrate Hist. Inv. Trx.");
                     GPCompanyAdditionalSettingsEachCompany.Validate("Migrate Hist. Purch. Trx.", Rec."Migrate Hist. Purch. Trx.");
+                    GPCompanyAdditionalSettingsEachCompany.Validate("Skip Posting Account Batches", Rec."Skip Posting Account Batches");
+                    GPCompanyAdditionalSettingsEachCompany.Validate("Skip Posting Bank Batches", Rec."Skip Posting Bank Batches");
+                    GPCompanyAdditionalSettingsEachCompany.Validate("Skip Posting Customer Batches", Rec."Skip Posting Customer Batches");
+                    GPCompanyAdditionalSettingsEachCompany.Validate("Skip Posting Vendor Batches", Rec."Skip Posting Vendor Batches");
 
                     GPCompanyAdditionalSettingsEachCompany.Insert(true);
                 end;
@@ -650,6 +721,10 @@ page 4050 "GP Migration Configuration"
         Rec.Validate("Migrate Hist. AP Trx.", GPCompanyAdditionalSettingsInit."Migrate Hist. AP Trx.");
         Rec.Validate("Migrate Hist. Inv. Trx.", GPCompanyAdditionalSettingsInit."Migrate Hist. Inv. Trx.");
         Rec.Validate("Migrate Hist. Purch. Trx.", GPCompanyAdditionalSettingsInit."Migrate Hist. Purch. Trx.");
+        Rec.Validate("Skip Posting Account Batches", GPCompanyAdditionalSettingsInit."Skip Posting Account Batches");
+        Rec.Validate("Skip Posting Bank Batches", GPCompanyAdditionalSettingsInit."Skip Posting Bank Batches");
+        Rec.Validate("Skip Posting Customer Batches", GPCompanyAdditionalSettingsInit."Skip Posting Customer Batches");
+        Rec.Validate("Skip Posting Vendor Batches", GPCompanyAdditionalSettingsInit."Skip Posting Vendor Batches");
 
         EnableDisableAllHistTrx := Rec."Migrate Hist. GL Trx." and
                                                         Rec."Migrate Hist. AR Trx." and

--- a/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
+++ b/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
@@ -325,6 +325,27 @@ table 40105 "GP Company Additional Settings"
             FieldClass = FlowField;
             CalcFormula = exist("Hybrid Company Status" where("Name" = field(Name), "Upgrade Status" = const("Completed")));
         }
+
+        field(36; "Skip Posting Account Batches"; Boolean)
+        {
+            DataClassification = SystemMetadata;
+            InitValue = false;
+        }
+        field(37; "Skip Posting Customer Batches"; Boolean)
+        {
+            DataClassification = SystemMetadata;
+            InitValue = false;
+        }
+        field(38; "Skip Posting Vendor Batches"; Boolean)
+        {
+            DataClassification = SystemMetadata;
+            InitValue = false;
+        }
+        field(39; "Skip Posting Bank Batches"; Boolean)
+        {
+            DataClassification = SystemMetadata;
+            InitValue = false;
+        }
     }
 
     keys
@@ -456,6 +477,40 @@ table 40105 "GP Company Additional Settings"
     begin
         GetSingleInstance();
         exit(Rec."Migrate Only Inventory Master");
+    end;
+
+    // Posting
+    procedure GetSkipAllPosting(): Boolean
+    begin
+        GetSingleInstance();
+        exit(Rec."Skip Posting Account Batches" and
+             Rec."Skip Posting Customer Batches" and
+             Rec."Skip Posting Vendor Batches" and
+             Rec."Skip Posting Bank Batches");
+    end;
+
+    procedure GetSkipPostingAccountBatches(): Boolean
+    begin
+        GetSingleInstance();
+        exit(Rec."Skip Posting Account Batches");
+    end;
+
+    procedure GetSkipPostingCustomerBatches(): Boolean
+    begin
+        GetSingleInstance();
+        exit(Rec."Skip Posting Customer Batches");
+    end;
+
+    procedure GetSkipPostingVendorBatches(): Boolean
+    begin
+        GetSingleInstance();
+        exit(Rec."Skip Posting Vendor Batches");
+    end;
+
+    procedure GetSkipPostingBankBatches(): Boolean
+    begin
+        GetSingleInstance();
+        exit(Rec."Skip Posting Bank Batches");
     end;
 
     // Other

--- a/Apps/W1/HybridGP/app/src/tables/GPKnownCountries.Table.al
+++ b/Apps/W1/HybridGP/app/src/tables/GPKnownCountries.Table.al
@@ -1,0 +1,344 @@
+table 40140 "GP Known Countries"
+{
+    Caption = 'GP Known Countries';
+    DataClassification = SystemMetadata;
+    DataPerCompany = false;
+
+    fields
+    {
+        field(1; ISO3; Code[3])
+        {
+            Caption = 'ISO3';
+        }
+        field(2; ISO2; Code[2])
+        {
+            Caption = 'ISO2';
+        }
+        field(3; Name; Text[50])
+        {
+            Caption = 'Name';
+        }
+    }
+    keys
+    {
+        key(PK; ISO3)
+        {
+            Clustered = true;
+        }
+        key(K2; ISO2)
+        {
+        }
+        key(K3; Name)
+        {
+        }
+    }
+
+    local procedure EnsureData()
+    begin
+        Clear(Rec);
+        if Rec.IsEmpty() then begin
+            AddKnownCountry('ABW', 'AW', 'Aruba');
+            AddKnownCountry('AFG', 'AF', 'Afghanistan');
+            AddKnownCountry('AGO', 'AO', 'Angola');
+            AddKnownCountry('AIA', 'AI', 'Anguilla');
+            AddKnownCountry('ALA', 'AX', 'Aland Islands');
+            AddKnownCountry('ALB', 'AL', 'Albania');
+            AddKnownCountry('AND', 'AD', 'Andorra');
+            AddKnownCountry('ARE', 'AE', 'United Arab Emirates');
+            AddKnownCountry('ARG', 'AR', 'Argentina');
+            AddKnownCountry('ARM', 'AM', 'Armenia');
+            AddKnownCountry('ASM', 'AS', 'American Samoa');
+            AddKnownCountry('ATA', 'AQ', 'Antarctica');
+            AddKnownCountry('ATF', 'TF', 'French Southern Territories');
+            AddKnownCountry('ATG', 'AG', 'Antigua And Barbuda');
+            AddKnownCountry('AUS', 'AU', 'Australia');
+            AddKnownCountry('AUT', 'AT', 'Austria');
+            AddKnownCountry('AZE', 'AZ', 'Azerbaijan');
+            AddKnownCountry('BDI', 'BI', 'Burundi');
+            AddKnownCountry('BEL', 'BE', 'Belgium');
+            AddKnownCountry('BEN', 'BJ', 'Benin');
+            AddKnownCountry('BES', 'BQ', 'Bonaire, Sint Eustatius and Saba');
+            AddKnownCountry('BFA', 'BF', 'Burkina Faso');
+            AddKnownCountry('BGD', 'BD', 'Bangladesh');
+            AddKnownCountry('BGR', 'BG', 'Bulgaria');
+            AddKnownCountry('BHR', 'BH', 'Bahrain');
+            AddKnownCountry('BHS', 'BS', 'The Bahamas');
+            AddKnownCountry('BIH', 'BA', 'Bosnia and Herzegovina');
+            AddKnownCountry('BLM', 'BL', 'Saint-Barthelemy');
+            AddKnownCountry('BLR', 'BY', 'Belarus');
+            AddKnownCountry('BLZ', 'BZ', 'Belize');
+            AddKnownCountry('BMU', 'BM', 'Bermuda');
+            AddKnownCountry('BOL', 'BO', 'Bolivia');
+            AddKnownCountry('BRA', 'BR', 'Brazil');
+            AddKnownCountry('BRB', 'BB', 'Barbados');
+            AddKnownCountry('BRN', 'BN', 'Brunei');
+            AddKnownCountry('BTN', 'BT', 'Bhutan');
+            AddKnownCountry('BVT', 'BV', 'Bouvet Island');
+            AddKnownCountry('BWA', 'BW', 'Botswana');
+            AddKnownCountry('CAF', 'CF', 'Central African Republic');
+            AddKnownCountry('CAN', 'CA', 'Canada');
+            AddKnownCountry('CCK', 'CC', 'Cocos (Keeling) Islands');
+            AddKnownCountry('CHE', 'CH', 'Switzerland');
+            AddKnownCountry('CHL', 'CL', 'Chile');
+            AddKnownCountry('CHN', 'CN', 'China');
+            AddKnownCountry('CIV', 'CI', 'Cote d''Ivoire');
+            AddKnownCountry('CMR', 'CM', 'Cameroon');
+            AddKnownCountry('COD', 'CD', 'Democratic Republic of the Congo');
+            AddKnownCountry('COG', 'CG', 'Congo');
+            AddKnownCountry('COK', 'CK', 'Cook Islands');
+            AddKnownCountry('COL', 'CO', 'Colombia');
+            AddKnownCountry('COM', 'KM', 'Comoros');
+            AddKnownCountry('CPV', 'CV', 'Cape Verde');
+            AddKnownCountry('CRI', 'CR', 'Costa Rica');
+            AddKnownCountry('CUB', 'CU', 'Cuba');
+            AddKnownCountry('CUW', 'CW', 'Curacao');
+            AddKnownCountry('CXR', 'CX', 'Christmas Island');
+            AddKnownCountry('CYM', 'KY', 'Cayman Islands');
+            AddKnownCountry('CYP', 'CY', 'Cyprus');
+            AddKnownCountry('CZE', 'CZ', 'Czech Republic');
+            AddKnownCountry('DEU', 'DE', 'Germany');
+            AddKnownCountry('DJI', 'DJ', 'Djibouti');
+            AddKnownCountry('DMA', 'DM', 'Dominica');
+            AddKnownCountry('DNK', 'DK', 'Denmark');
+            AddKnownCountry('DOM', 'DO', 'Dominican Republic');
+            AddKnownCountry('DZA', 'DZ', 'Algeria');
+            AddKnownCountry('ECU', 'EC', 'Ecuador');
+            AddKnownCountry('EGY', 'EG', 'Egypt');
+            AddKnownCountry('ERI', 'ER', 'Eritrea');
+            AddKnownCountry('ESH', 'EH', 'Western Sahara');
+            AddKnownCountry('ESP', 'ES', 'Spain');
+            AddKnownCountry('EST', 'EE', 'Estonia');
+            AddKnownCountry('ETH', 'ET', 'Ethiopia');
+            AddKnownCountry('FIN', 'FI', 'Finland');
+            AddKnownCountry('FJI', 'FJ', 'Fiji Islands');
+            AddKnownCountry('FLK', 'FK', 'Falkland Islands');
+            AddKnownCountry('FRA', 'FR', 'France');
+            AddKnownCountry('FRO', 'FO', 'Faroe Islands');
+            AddKnownCountry('FSM', 'FM', 'Micronesia');
+            AddKnownCountry('GAB', 'GA', 'Gabon');
+            AddKnownCountry('GBR', 'GB', 'United Kingdom');
+            AddKnownCountry('GEO', 'GE', 'Georgia');
+            AddKnownCountry('GGY', 'GG', 'Guernsey and Alderney');
+            AddKnownCountry('GHA', 'GH', 'Ghana');
+            AddKnownCountry('GIB', 'GI', 'Gibraltar');
+            AddKnownCountry('GIN', 'GN', 'Guinea');
+            AddKnownCountry('GLP', 'GP', 'Guadeloupe');
+            AddKnownCountry('GMB', 'GM', 'Gambia The');
+            AddKnownCountry('GNB', 'GW', 'Guinea-Bissau');
+            AddKnownCountry('GNQ', 'GQ', 'Equatorial Guinea');
+            AddKnownCountry('GRC', 'GR', 'Greece');
+            AddKnownCountry('GRD', 'GD', 'Grenada');
+            AddKnownCountry('GRL', 'GL', 'Greenland');
+            AddKnownCountry('GTM', 'GT', 'Guatemala');
+            AddKnownCountry('GUF', 'GF', 'French Guiana');
+            AddKnownCountry('GUM', 'GU', 'Guam');
+            AddKnownCountry('GUY', 'GY', 'Guyana');
+            AddKnownCountry('HKG', 'HK', 'Hong Kong (SAR)');
+            AddKnownCountry('HMD', 'HM', 'Heard Island and McDonald Islands');
+            AddKnownCountry('HND', 'HN', 'Honduras');
+            AddKnownCountry('HRV', 'HR', 'Croatia');
+            AddKnownCountry('HTI', 'HT', 'Haiti');
+            AddKnownCountry('HUN', 'HU', 'Hungary');
+            AddKnownCountry('IDN', 'ID', 'Indonesia');
+            AddKnownCountry('IMN', 'IM', 'Isle of Man');
+            AddKnownCountry('IND', 'IN', 'India');
+            AddKnownCountry('IOT', 'IO', 'British Indian Ocean Territory');
+            AddKnownCountry('IRL', 'IE', 'Ireland');
+            AddKnownCountry('IRN', 'IR', 'Iran');
+            AddKnownCountry('IRQ', 'IQ', 'Iraq');
+            AddKnownCountry('ISL', 'IS', 'Iceland');
+            AddKnownCountry('ISR', 'IL', 'Israel');
+            AddKnownCountry('ITA', 'IT', 'Italy');
+            AddKnownCountry('JAM', 'JM', 'Jamaica');
+            AddKnownCountry('JEY', 'JE', 'Jersey');
+            AddKnownCountry('JOR', 'JO', 'Jordan');
+            AddKnownCountry('JPN', 'JP', 'Japan');
+            AddKnownCountry('KAZ', 'KZ', 'Kazakhstan');
+            AddKnownCountry('KEN', 'KE', 'Kenya');
+            AddKnownCountry('KGZ', 'KG', 'Kyrgyzstan');
+            AddKnownCountry('KHM', 'KH', 'Cambodia');
+            AddKnownCountry('KIR', 'KI', 'Kiribati');
+            AddKnownCountry('KNA', 'KN', 'Saint Kitts And Nevis');
+            AddKnownCountry('KOR', 'KR', 'South Korea');
+            AddKnownCountry('KWT', 'KW', 'Kuwait');
+            AddKnownCountry('LAO', 'LA', 'Laos');
+            AddKnownCountry('LBN', 'LB', 'Lebanon');
+            AddKnownCountry('LBR', 'LR', 'Liberia');
+            AddKnownCountry('LBY', 'LY', 'Libya');
+            AddKnownCountry('LCA', 'LC', 'Saint Lucia');
+            AddKnownCountry('LIE', 'LI', 'Liechtenstein');
+            AddKnownCountry('LKA', 'LK', 'Sri Lanka');
+            AddKnownCountry('LSO', 'LS', 'Lesotho');
+            AddKnownCountry('LTU', 'LT', 'Lithuania');
+            AddKnownCountry('LUX', 'LU', 'Luxembourg');
+            AddKnownCountry('LVA', 'LV', 'Latvia');
+            AddKnownCountry('MAC', 'MO', 'Macau (SAR)');
+            AddKnownCountry('MAF', 'MF', 'Saint-Martin (French part)');
+            AddKnownCountry('MAR', 'MA', 'Morocco');
+            AddKnownCountry('MCO', 'MC', 'Monaco');
+            AddKnownCountry('MDA', 'MD', 'Moldova');
+            AddKnownCountry('MDG', 'MG', 'Madagascar');
+            AddKnownCountry('MDV', 'MV', 'Maldives');
+            AddKnownCountry('MEX', 'MX', 'Mexico');
+            AddKnownCountry('MHL', 'MH', 'Marshall Islands');
+            AddKnownCountry('MKD', 'MK', 'North Macedonia');
+            AddKnownCountry('MLI', 'ML', 'Mali');
+            AddKnownCountry('MLT', 'MT', 'Malta');
+            AddKnownCountry('MMR', 'MM', 'Myanmar');
+            AddKnownCountry('MNE', 'ME', 'Montenegro');
+            AddKnownCountry('MNG', 'MN', 'Mongolia');
+            AddKnownCountry('MNP', 'MP', 'Northern Mariana Islands');
+            AddKnownCountry('MOZ', 'MZ', 'Mozambique');
+            AddKnownCountry('MRT', 'MR', 'Mauritania');
+            AddKnownCountry('MSR', 'MS', 'Montserrat');
+            AddKnownCountry('MTQ', 'MQ', 'Martinique');
+            AddKnownCountry('MUS', 'MU', 'Mauritius');
+            AddKnownCountry('MWI', 'MW', 'Malawi');
+            AddKnownCountry('MYS', 'MY', 'Malaysia');
+            AddKnownCountry('MYT', 'YT', 'Mayotte');
+            AddKnownCountry('NAM', 'NA', 'Namibia');
+            AddKnownCountry('NCL', 'NC', 'New Caledonia');
+            AddKnownCountry('NER', 'NE', 'Niger');
+            AddKnownCountry('NFK', 'NF', 'Norfolk Island');
+            AddKnownCountry('NGA', 'NG', 'Nigeria');
+            AddKnownCountry('NIC', 'NI', 'Nicaragua');
+            AddKnownCountry('NIU', 'NU', 'Niue');
+            AddKnownCountry('NLD', 'NL', 'Netherlands');
+            AddKnownCountry('NOR', 'NO', 'Norway');
+            AddKnownCountry('NPL', 'NP', 'Nepal');
+            AddKnownCountry('NRU', 'NR', 'Nauru');
+            AddKnownCountry('NZL', 'NZ', 'New Zealand');
+            AddKnownCountry('OMN', 'OM', 'Oman');
+            AddKnownCountry('PAK', 'PK', 'Pakistan');
+            AddKnownCountry('PAN', 'PA', 'Panama');
+            AddKnownCountry('PCN', 'PN', 'Pitcairn Island');
+            AddKnownCountry('PER', 'PE', 'Peru');
+            AddKnownCountry('PHL', 'PH', 'Philippines');
+            AddKnownCountry('PLW', 'PW', 'Palau');
+            AddKnownCountry('PNG', 'PG', 'Papua new Guinea');
+            AddKnownCountry('POL', 'PL', 'Poland');
+            AddKnownCountry('PRI', 'PR', 'Puerto Rico');
+            AddKnownCountry('PRK', 'KP', 'North Korea');
+            AddKnownCountry('PRT', 'PT', 'Portugal');
+            AddKnownCountry('PRY', 'PY', 'Paraguay');
+            AddKnownCountry('PSE', 'PS', 'Palestinian Territory Occupied');
+            AddKnownCountry('PYF', 'PF', 'French Polynesia');
+            AddKnownCountry('QAT', 'QA', 'Qatar');
+            AddKnownCountry('REU', 'RE', 'Reunion');
+            AddKnownCountry('ROU', 'RO', 'Romania');
+            AddKnownCountry('RUS', 'RU', 'Russia');
+            AddKnownCountry('RWA', 'RW', 'Rwanda');
+            AddKnownCountry('SAU', 'SA', 'Saudi Arabia');
+            AddKnownCountry('SDN', 'SD', 'Sudan');
+            AddKnownCountry('SEN', 'SN', 'Senegal');
+            AddKnownCountry('SGP', 'SG', 'Singapore');
+            AddKnownCountry('SGS', 'GS', 'South Georgia');
+            AddKnownCountry('SHN', 'SH', 'Saint Helena');
+            AddKnownCountry('SJM', 'SJ', 'Svalbard and Jan Mayen');
+            AddKnownCountry('SLB', 'SB', 'Solomon Islands');
+            AddKnownCountry('SLE', 'SL', 'Sierra Leone');
+            AddKnownCountry('SLV', 'SV', 'El Salvador');
+            AddKnownCountry('SMR', 'SM', 'San Marino');
+            AddKnownCountry('SOM', 'SO', 'Somalia');
+            AddKnownCountry('SPM', 'PM', 'Saint Pierre and Miquelon');
+            AddKnownCountry('SRB', 'RS', 'Serbia');
+            AddKnownCountry('STP', 'ST', 'Sao Tome and Principe');
+            AddKnownCountry('SUR', 'SR', 'Suriname');
+            AddKnownCountry('SVK', 'SK', 'Slovakia');
+            AddKnownCountry('SVN', 'SI', 'Slovenia');
+            AddKnownCountry('SWE', 'SE', 'Sweden');
+            AddKnownCountry('SWZ', 'SZ', 'Swaziland');
+            AddKnownCountry('SXM', 'SX', 'Sint Maarten');
+            AddKnownCountry('SYC', 'SC', 'Seychelles');
+            AddKnownCountry('SYR', 'SY', 'Syria');
+            AddKnownCountry('TCA', 'TC', 'Turks And Caicos Islands');
+            AddKnownCountry('TCD', 'TD', 'Chad');
+            AddKnownCountry('TGO', 'TG', 'Togo');
+            AddKnownCountry('THA', 'TH', 'Thailand');
+            AddKnownCountry('TJK', 'TJ', 'Tajikistan');
+            AddKnownCountry('TKL', 'TK', 'Tokelau');
+            AddKnownCountry('TKM', 'TM', 'Turkmenistan');
+            AddKnownCountry('TLS', 'TL', 'East Timor');
+            AddKnownCountry('TON', 'TO', 'Tonga');
+            AddKnownCountry('TTO', 'TT', 'Trinidad And Tobago');
+            AddKnownCountry('TUN', 'TN', 'Tunisia');
+            AddKnownCountry('TUR', 'TR', 'Turkey');
+            AddKnownCountry('TUV', 'TV', 'Tuvalu');
+            AddKnownCountry('TWN', 'TW', 'Taiwan');
+            AddKnownCountry('TZA', 'TZ', 'Tanzania');
+            AddKnownCountry('UGA', 'UG', 'Uganda');
+            AddKnownCountry('UKR', 'UA', 'Ukraine');
+            AddKnownCountry('UMI', 'UM', 'U.S. Minor Outlying Islands');
+            AddKnownCountry('URY', 'UY', 'Uruguay');
+            AddKnownCountry('USA', 'US', 'United States');
+            AddKnownCountry('UZB', 'UZ', 'Uzbekistan');
+            AddKnownCountry('VAT', 'VA', 'Holy See (Vatican City)');
+            AddKnownCountry('VCT', 'VC', 'Saint Vincent And The Grenadines');
+            AddKnownCountry('VEN', 'VE', 'Venezuela');
+            AddKnownCountry('VGB', 'VG', 'British Virgin Islands');
+            AddKnownCountry('VIR', 'VI', 'U.S. Virgin Islands');
+            AddKnownCountry('VNM', 'VN', 'Vietnam');
+            AddKnownCountry('VUT', 'VU', 'Vanuatu');
+            AddKnownCountry('WLF', 'WF', 'Wallis and Futuna');
+            AddKnownCountry('WSM', 'WS', 'Samoa');
+            AddKnownCountry('YEM', 'YE', 'Yemen');
+            AddKnownCountry('ZAF', 'ZA', 'South Africa');
+            AddKnownCountry('ZMB', 'ZM', 'Zambia');
+            AddKnownCountry('ZWE', 'ZW', 'Zimbabwe');
+        end;
+    end;
+
+    local procedure AddKnownCountry(ISO3Code: Code[3]; ISO2Code: Code[2]; CountryName: Text[50])
+    begin
+        Clear(Rec);
+        Rec.ISO3 := ISO3Code;
+        Rec.ISO2 := ISO2Code;
+        Rec.Name := CountryName;
+        Rec.Insert();
+    end;
+
+    procedure SearchKnownCountry(SearchString: Text[75]; var Found: Boolean; var ResultISO2: Code[2]; var ResultCountryName: Text[50])
+    var
+        TrimmedSearchString: Text[75];
+    begin
+        EnsureData();
+        Clear(Found);
+        Clear(ResultISO2);
+        Clear(ResultCountryName);
+
+        TrimmedSearchString := CopyStr(SearchString.Trim(), 1, MaxStrLen(TrimmedSearchString));
+        if TrimmedSearchString = '' then
+            exit;
+
+        Rec.Reset();
+        if StrLen(TrimmedSearchString) = 2 then begin
+            Rec.SetRange(ISO2, TrimmedSearchString);
+            Found := Rec.FindFirst();
+            if Found then begin
+                ResultISO2 := Rec.ISO2;
+                ResultCountryName := Rec.Name;
+                exit;
+            end;
+        end;
+
+        Rec.Reset();
+        if StrLen(TrimmedSearchString) = 3 then begin
+            Rec.SetRange(ISO3, TrimmedSearchString);
+            Found := Rec.FindFirst();
+            if Found then begin
+                ResultISO2 := Rec.ISO2;
+                ResultCountryName := Rec.Name;
+                exit;
+            end;
+        end;
+
+        Rec.Reset();
+        Rec.SetFilter(Name, '@' + TrimmedSearchString + '*');
+        Found := Rec.FindFirst();
+        if Found then begin
+            ResultISO2 := Rec.ISO2;
+            ResultCountryName := Rec.Name;
+            exit;
+        end;
+    end;
+}

--- a/Apps/W1/HybridGP/test/src/GPDataMigrationTests.codeunit.al
+++ b/Apps/W1/HybridGP/test/src/GPDataMigrationTests.codeunit.al
@@ -35,6 +35,7 @@ codeunit 139664 "GP Data Migration Tests"
         VendorIdWithBankStr2Txt: Label 'VENDOR002', Comment = 'Vendor Id with bank account information', Locked = true;
         VendorIdWithBankStr3Txt: Label 'VENDOR003', Comment = 'Vendor Id with bank account information', Locked = true;
         VendorIdWithBankStr4Txt: Label 'VENDOR004', Comment = 'Vendor Id with bank account information', Locked = true;
+        VendorIdWithBankStr5Txt: Label 'VENDOR005', Comment = 'Vendor Id with bank account information', Locked = true;
         ValidSwiftCodeStrTxt: Label 'BOFAUS3N', Comment = 'Valid SWIFT Code', Locked = true;
 #pragma warning disable AA0240
         ValidIBANStrTxt: Label 'GB33BUKB20201555555555', Comment = 'Valid IBAN code', Locked = true;
@@ -50,6 +51,55 @@ codeunit 139664 "GP Data Migration Tests"
         PONumberTxt: Label 'PO001', Comment = 'PO number for Migrate Open POs setting tests', Locked = true;
         PostingGroupCodeTxt: Label 'GP', Locked = true;
         TestMoneyCurrencyCodeTxt: Label 'TESTMONEY', Locked = true;
+
+    [Test]
+    procedure TestKnownCountries()
+    var
+        GPKnownCountries: Record "GP Known Countries";
+        FoundKnownCountry: Boolean;
+        CountryCodeISO2: Code[2];
+        CountryName: Text[50];
+    begin
+        GPKnownCountries.SearchKnownCountry('UniteD STATES', FoundKnownCountry, CountryCodeISO2, CountryName);
+        Assert.AreEqual(true, FoundKnownCountry, 'Country was not found.');
+        Assert.AreEqual('US', CountryCodeISO2, 'ISO2 code is incorrect.');
+        Assert.AreEqual('United States', CountryName, 'Found country name is incorrect.');
+
+        GPKnownCountries.SearchKnownCountry('USA', FoundKnownCountry, CountryCodeISO2, CountryName);
+        Assert.AreEqual(true, FoundKnownCountry, 'Country was not found.');
+        Assert.AreEqual('US', CountryCodeISO2, 'ISO2 code is incorrect.');
+        Assert.AreEqual('United States', CountryName, 'Found country name is incorrect.');
+
+        GPKnownCountries.SearchKnownCountry('US', FoundKnownCountry, CountryCodeISO2, CountryName);
+        Assert.AreEqual(true, FoundKnownCountry, 'Country was not found.');
+        Assert.AreEqual('US', CountryCodeISO2, 'ISO2 code is incorrect.');
+        Assert.AreEqual('United States', CountryName, 'Found country name is incorrect.');
+
+        GPKnownCountries.SearchKnownCountry('CaNAda', FoundKnownCountry, CountryCodeISO2, CountryName);
+        Assert.AreEqual(true, FoundKnownCountry, 'Country was not found.');
+        Assert.AreEqual('CA', CountryCodeISO2, 'ISO2 code is incorrect.');
+        Assert.AreEqual('Canada', CountryName, 'Found country name is incorrect.');
+
+        GPKnownCountries.SearchKnownCountry('CAN', FoundKnownCountry, CountryCodeISO2, CountryName);
+        Assert.AreEqual(true, FoundKnownCountry, 'Country was not found.');
+        Assert.AreEqual('CA', CountryCodeISO2, 'ISO2 code is incorrect.');
+        Assert.AreEqual('Canada', CountryName, 'Found country name is incorrect.');
+
+        GPKnownCountries.SearchKnownCountry('CA', FoundKnownCountry, CountryCodeISO2, CountryName);
+        Assert.AreEqual(true, FoundKnownCountry, 'Country was not found.');
+        Assert.AreEqual('CA', CountryCodeISO2, 'ISO2 code is incorrect.');
+        Assert.AreEqual('Canada', CountryName, 'Found country name is incorrect.');
+
+        GPKnownCountries.SearchKnownCountry('', FoundKnownCountry, CountryCodeISO2, CountryName);
+        Assert.AreEqual(false, FoundKnownCountry, 'Country was not found.');
+        Assert.AreEqual('', CountryCodeISO2, 'ISO2 code is incorrect.');
+        Assert.AreEqual('', CountryName, 'Found country name is incorrect.');
+
+        GPKnownCountries.SearchKnownCountry('SATURN', FoundKnownCountry, CountryCodeISO2, CountryName);
+        Assert.AreEqual(false, FoundKnownCountry, 'Country was not found.');
+        Assert.AreEqual('', CountryCodeISO2, 'ISO2 code is incorrect.');
+        Assert.AreEqual('', CountryName, 'Found country name is incorrect.');
+    end;
 
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
@@ -132,7 +182,7 @@ codeunit 139664 "GP Data Migration Tests"
         Assert.AreEqual('Toyota Land', Customer."Address 2", 'Address2 of Migrated Customer is wrong');
         Assert.AreEqual('!What a city!', Customer.City, 'City of Migrated Customer is wrong');
         Assert.AreEqual('84953', Customer."Post Code", 'Post Code of Migrated Customer is wrong');
-        Assert.AreEqual('USA', Customer."Country/Region Code", 'Country/Region of Migrated Customer is wrong');
+        Assert.AreEqual('US', Customer."Country/Region Code", 'Country/Region of Migrated Customer is wrong');
         Assert.AreEqual('KNOBL-CHUCK-001', Customer."Salesperson Code", 'Salesperson Code of Migrated Customer is wrong');
         Assert.AreEqual('MAIL', Customer."Shipment Method Code", 'Shipment Method Code of Migrated Customer is wrong');
         Assert.AreEqual(true, Customer."Print Statements", 'Print Statements of Migrated Customer is wrong');
@@ -162,19 +212,19 @@ codeunit 139664 "GP Data Migration Tests"
         // [WHEN] Customer classes are migrated
         Assert.AreEqual('100', HelperFunctions.GetPostingAccountNumber('ReceivablesAccount'), 'Default Receivables account is incorrect.');
 
-        // [THEN] The class Receivables account will be used for transactions when an account is configured for the class
+        // [THEN] The class Receivables account will be used for transactions when an account is configured for the class with an account number
         Clear(GenJournalLine);
         GenJournalLine.SetRange("Account Type", "Gen. Journal Account Type"::Customer);
         GenJournalLine.SetRange("Account No.", '!WOW!');
         Assert.IsTrue(GenJournalLine.FindFirst(), 'Could not locate Gen. Journal Line.');
         Assert.AreEqual('TEST987', GenJournalLine."Bal. Account No.", 'Incorrect Bal. Account No. on Gen. Journal Line.');
 
-        // [THEN] No account will be set for the Bal. Account No. where class has no account configured
+        // [THEN] The default account will be set for the Bal. Account No. where class has no account configured
         Clear(GenJournalLine);
         GenJournalLine.SetRange("Account Type", "Gen. Journal Account Type"::Customer);
         GenJournalLine.SetRange("Account No.", '#1');
         Assert.IsTrue(GenJournalLine.FindFirst(), 'Could not locate Gen. Journal Line.');
-        Assert.AreEqual('', GenJournalLine."Bal. Account No.", 'Incorrect Bal. Account No. on Gen. Journal Line.');
+        Assert.AreEqual(HelperFunctions.GetPostingAccountNumber('ReceivablesAccount'), GenJournalLine."Bal. Account No.", 'Incorrect Bal. Account No. on Gen. Journal Line.');
 
 
         // [WHEN] Customer addresses are migrated
@@ -271,7 +321,7 @@ codeunit 139664 "GP Data Migration Tests"
         Assert.AreEqual('Toyota Land', Customer."Address 2", 'Address2 of Migrated Customer is wrong');
         Assert.AreEqual('!What a city!', Customer.City, 'City of Migrated Customer is wrong');
         Assert.AreEqual('84953', Customer."Post Code", 'Post Code of Migrated Customer is wrong');
-        Assert.AreEqual('USA', Customer."Country/Region Code", 'Country/Region of Migrated Customer is wrong');
+        Assert.AreEqual('US', Customer."Country/Region Code", 'Country/Region of Migrated Customer is wrong');
         Assert.AreEqual('KNOBL-CHUCK-001', Customer."Salesperson Code", 'Salesperson Code of Migrated Customer is wrong');
         Assert.AreEqual('MAIL', Customer."Shipment Method Code", 'Shipment Method Code of Migrated Customer is wrong');
         Assert.AreEqual(true, Customer."Print Statements", 'Print Statements of Migrated Customer is wrong');
@@ -297,6 +347,53 @@ codeunit 139664 "GP Data Migration Tests"
 
         // [THEN] Transactions will NOT be created
         Assert.RecordCount(GenJournalLine, InitialGenJournalLineCount);
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestReceivablesSkipPosting()
+    var
+        Customer: Record "Customer";
+        GenJournalLine: Record "Gen. Journal Line";
+        CustomerCount: Integer;
+    begin
+        // [SCENARIO] All Customers are queried from GP
+
+        // [GIVEN] GP data
+        Initialize();
+        GPTestHelperFunctions.CreateConfigurationSettings();
+
+        // Enable Receivables Module setting
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPCompanyAdditionalSettings.Validate("Migrate Receivables Module", true);
+        GPCompanyAdditionalSettings.Validate("Migrate Only Rec. Master", false);
+        GPCompanyAdditionalSettings.Validate("Skip Posting Customer Batches", true);
+        GPCompanyAdditionalSettings.Modify();
+
+        // When adding Customers, update the expected count here
+        CustomerCount := 3;
+
+        // [WHEN] Data is imported
+        CreateCustomerData();
+        CreateCustomerClassData();
+        CreateCustomerTrx();
+
+        GPTestHelperFunctions.InitializeMigration();
+
+        Assert.AreEqual(CustomerCount, GPCustomer.Count(), 'Wrong number of Customers read');
+
+        // [WHEN] Data is migrated
+        Customer.DeleteAll();
+        GPCustomer.Reset();
+        MigrateCustomers(GPCustomer);
+
+        // [then] Then the correct number of Customers are applied
+        Assert.AreEqual(CustomerCount, Customer.Count(), 'Wrong number of Migrated Customers read');
+
+        // [THEN] The GL Batch is created but not posted
+        Clear(GenJournalLine);
+        GenJournalLine.SetRange("Journal Batch Name", 'GPCUST');
+        Assert.AreEqual(false, GenJournalLine.IsEmpty(), 'Could not locate the account batch.');
     end;
 
     [Test]
@@ -541,7 +638,7 @@ codeunit 139664 "GP Data Migration Tests"
         GenJournalLine.SetRange("Account Type", "Gen. Journal Account Type"::Vendor);
         GenJournalLine.SetRange("Account No.", 'V3130');
         Assert.IsTrue(GenJournalLine.FindFirst(), 'Could not locate Gen. Journal Line.');
-        Assert.AreEqual('1', GenJournalLine."Bal. Account No.", 'Incorrect Bal. Account No. on Gen. Journal Line.');
+        Assert.AreEqual(HelperFunctions.GetPostingAccountNumber('PayablesAccount'), GenJournalLine."Bal. Account No.", 'Incorrect Bal. Account No. on Gen. Journal Line.');
 
         // [WHEN] Vendor addresses are migrated
         // [THEN] Email addresses are included with the addresses when they are valid
@@ -682,6 +779,55 @@ codeunit 139664 "GP Data Migration Tests"
 
         // [THEN] Vendor transactions will NOT be created
         Assert.RecordCount(GenJournalLine, InitialGenJournalLineCount);
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPayablesSkipPosting()
+    var
+        Vendor: Record Vendor;
+        GenJournalLine: Record "Gen. Journal Line";
+        VendorCount: Integer;
+    begin
+        // [SCENARIO] All Vendor are queried from GP
+        // [GIVEN] GP data
+        Initialize();
+        GPTestHelperFunctions.CreateConfigurationSettings();
+
+        // Enable Payables Module setting
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPCompanyAdditionalSettings.Validate("Migrate Payables Module", true);
+        GPCompanyAdditionalSettings.Validate("Migrate Only Payables Master", false);
+        GPCompanyAdditionalSettings.Validate("Skip Posting Vendor Batches", true);
+        GPCompanyAdditionalSettings.Modify();
+
+        // [WHEN] Data is imported
+        CreateVendorData();
+        CreateVendorClassData();
+        CreateVendorTrx();
+
+        GPTestHelperFunctions.InitializeMigration();
+
+        // [WHEN] adding Vendors, update the expected count here
+        VendorCount := 54;
+
+        Clear(GPVendor);
+        Clear(Vendor);
+
+        // [THEN] Then the correct number of Vendors are imported
+        Assert.AreEqual(VendorCount, GPVendor.Count(), 'Wrong number of Vendor read');
+
+        // [WHEN] data is migrated
+        Vendor.DeleteAll();
+        MigrateVendors(GPVendor);
+
+        // [THEN] Then the correct number of Vendors are applied
+        Assert.AreEqual(VendorCount, Vendor.Count(), 'Wrong number of Migrated Vendors read');
+
+        // [THEN] The GL Batch is created but not posted
+        Clear(GenJournalLine);
+        GenJournalLine.SetRange("Journal Batch Name", 'GPVEND');
+        Assert.AreEqual(false, GenJournalLine.IsEmpty(), 'Could not locate the account batch.');
     end;
 
     [Test]
@@ -964,9 +1110,10 @@ codeunit 139664 "GP Data Migration Tests"
         Currency: Record Currency;
         VendorBankAccountCount: Integer;
         ActiveVendorBankAccountCount: Integer;
+        BankAccountCounter: Integer;
     begin
-        VendorBankAccountCount := 10;
-        ActiveVendorBankAccountCount := 9;
+        VendorBankAccountCount := 13;
+        ActiveVendorBankAccountCount := 12;
 
         // [SCENARIO] Vendors and their bank account information are queried from GP
         // [GIVEN] GP data
@@ -1006,7 +1153,7 @@ codeunit 139664 "GP Data Migration Tests"
 
         // [WHEN] Data is migrated
         Clear(GPVendor);
-        GPVendor.SetFilter(VENDORID, '%1|%2|%3|%4', VendorIdWithBankStr1Txt, VendorIdWithBankStr2Txt, VendorIdWithBankStr3Txt, VendorIdWithBankStr4Txt);
+        GPVendor.SetFilter(VENDORID, '%1|%2|%3|%4|%5', VendorIdWithBankStr1Txt, VendorIdWithBankStr2Txt, VendorIdWithBankStr3Txt, VendorIdWithBankStr4Txt, VendorIdWithBankStr5Txt);
         MigrateVendors(GPVendor);
         RunPostMigration();
 
@@ -1017,7 +1164,7 @@ codeunit 139664 "GP Data Migration Tests"
 
         // [THEN] The correct number of Vendor Bank Accounts are imported
         Clear(VendorBankAccount);
-        VendorBankAccount.SetFilter("Vendor No.", '%1|%2|%3|%4', VendorIdWithBankStr1Txt, VendorIdWithBankStr2Txt, VendorIdWithBankStr3Txt, VendorIdWithBankStr4Txt);
+        VendorBankAccount.SetFilter("Vendor No.", '%1|%2|%3|%4|%5', VendorIdWithBankStr1Txt, VendorIdWithBankStr2Txt, VendorIdWithBankStr3Txt, VendorIdWithBankStr4Txt, VendorIdWithBankStr5Txt);
         Assert.AreEqual(ActiveVendorBankAccountCount, VendorBankAccount.Count(), 'Wrong number of migrated Vendor Bank Accounts read');
 
         // [THEN] The fields for Vendors 1 are correctly applied
@@ -1110,6 +1257,18 @@ codeunit 139664 "GP Data Migration Tests"
         Assert.AreEqual(VendorIdWithBankStr3Txt, VendorBankAccount."Vendor No.", 'Vendor No. of VendorBankAccount is wrong.');
         Assert.AreEqual('V03_OTHER', VendorBankAccount.Code, 'Code of VendorBankAccount is wrong.');
         Assert.AreEqual(ValidIBANStrTxt, VendorBankAccount.IBAN, 'IBAN of VendorBankAccount is wrong. V03_OTHER');
+
+        // Vendor 5
+        Clear(VendorBankAccount);
+        Clear(BankAccountCounter);
+        VendorBankAccount.SetCurrentKey("Vendor No.", Code);
+        VendorBankAccount.SetRange("Vendor No.", VendorIdWithBankStr5Txt);
+        Assert.IsTrue(VendorBankAccount.FindSet(), 'Vendor 5 bank accounts were not created.');
+
+        repeat
+            BankAccountCounter := BankAccountCounter + 1;
+            Assert.AreEqual(VendorIdWithBankStr5Txt + '-' + Format(BankAccountCounter), VendorBankAccount.Code, 'Bank account code is not correct.');
+        until VendorBankAccount.Next() = 0;
     end;
 
     [Test]
@@ -1191,7 +1350,7 @@ codeunit 139664 "GP Data Migration Tests"
         VendorPostingGroup.Get('USA-US-M');
         Assert.AreEqual('USA-US-M', VendorPostingGroup.Code, 'Code of VendorPostingGroup is incorrect.');
         Assert.AreEqual('U.S. Vendors-Misc. Expenses', VendorPostingGroup.Description, 'Description of VendorPostingGroup is incorrect.');
-        Assert.AreEqual('', VendorPostingGroup."Payables Account", 'Payables Account of VendorPostingGroup is incorrect.');
+        Assert.AreEqual('1', VendorPostingGroup."Payables Account", 'Payables Account of VendorPostingGroup is incorrect.');
         Assert.AreEqual('', VendorPostingGroup."Service Charge Acc.", 'Service Charge Acc. of VendorPostingGroup is incorrect.');
         Assert.AreEqual('', VendorPostingGroup."Payment Disc. Debit Acc.", 'Payment Disc. Debit Acc. of VendorPostingGroup is incorrect.');
         Assert.AreEqual('', VendorPostingGroup."Payment Disc. Credit Acc.", 'Payment Disc. Credit Acc. of VendorPostingGroup is incorrect.');
@@ -1276,7 +1435,7 @@ codeunit 139664 "GP Data Migration Tests"
         CustomerPostingGroup.Get('USA-TEST-2');
         Assert.AreEqual('USA-TEST-2', CustomerPostingGroup.Code, 'Code of CustomerPostingGroup is incorrect.');
         Assert.AreEqual('Test cust class 2', CustomerPostingGroup.Description, 'Description of CustomerPostingGroup is incorrect.');
-        Assert.AreEqual('', CustomerPostingGroup."Receivables Account", 'Receivables Account of CustomerPostingGroup is incorrect.');
+        Assert.AreEqual('100', CustomerPostingGroup."Receivables Account", 'Receivables Account of CustomerPostingGroup is incorrect.');
         Assert.AreEqual('', CustomerPostingGroup."Payment Disc. Debit Acc.", 'Payment Disc. Debit Acc. of CustomerPostingGroup is incorrect.');
         Assert.AreEqual('', CustomerPostingGroup."Additional Fee Account", 'Additional Fee Account of CustomerPostingGroup is incorrect.');
         Assert.AreEqual('', CustomerPostingGroup."Payment Disc. Credit Acc.", 'Payment Disc. Credit Acc. of CustomerPostingGroup is incorrect.');
@@ -3286,19 +3445,19 @@ codeunit 139664 "GP Data Migration Tests"
         SwiftCode: Record "SWIFT Code";
     begin
         GPVendorAddress.Reset();
-        GPVendorAddress.SetFilter(VENDORID, '%1|%2|%3|%4', VendorIdWithBankStr1Txt, VendorIdWithBankStr2Txt, VendorIdWithBankStr3Txt, VendorIdWithBankStr4Txt);
+        GPVendorAddress.SetFilter(VENDORID, '%1|%2|%3|%4|%5', VendorIdWithBankStr1Txt, VendorIdWithBankStr2Txt, VendorIdWithBankStr3Txt, VendorIdWithBankStr4Txt, VendorIdWithBankStr5Txt);
         GPVendorAddress.DeleteAll();
 
         GPVendor.Reset();
-        GPVendor.SetFilter(VENDORID, '%1|%2|%3|%4', VendorIdWithBankStr1Txt, VendorIdWithBankStr2Txt, VendorIdWithBankStr3Txt, VendorIdWithBankStr4Txt);
+        GPVendor.SetFilter(VENDORID, '%1|%2|%3|%4|%5', VendorIdWithBankStr1Txt, VendorIdWithBankStr2Txt, VendorIdWithBankStr3Txt, VendorIdWithBankStr4Txt, VendorIdWithBankStr5Txt);
         GPVendor.DeleteAll();
 
         VendorBankAccount.Reset();
-        VendorBankAccount.SetFilter("Vendor No.", '%1|%2|%3|%4', VendorIdWithBankStr1Txt, VendorIdWithBankStr2Txt, VendorIdWithBankStr3Txt, VendorIdWithBankStr4Txt);
+        VendorBankAccount.SetFilter("Vendor No.", '%1|%2|%3|%4|%5', VendorIdWithBankStr1Txt, VendorIdWithBankStr2Txt, VendorIdWithBankStr3Txt, VendorIdWithBankStr4Txt, VendorIdWithBankStr5Txt);
         VendorBankAccount.DeleteAll();
 
         Vendor.Reset();
-        Vendor.SetFilter("No.", '%1|%2|%3|%4', VendorIdWithBankStr1Txt, VendorIdWithBankStr2Txt, VendorIdWithBankStr3Txt, VendorIdWithBankStr4Txt);
+        Vendor.SetFilter("No.", '%1|%2|%3|%4|%5', VendorIdWithBankStr1Txt, VendorIdWithBankStr2Txt, VendorIdWithBankStr3Txt, VendorIdWithBankStr4Txt, VendorIdWithBankStr5Txt);
         Vendor.DeleteAll();
 
         SwiftCode.Reset();
@@ -3637,6 +3796,65 @@ codeunit 139664 "GP Data Migration Tests"
         GPPM00200.VADDCDPR := AddressCodePrimaryTxt;
         GPPM00200.VADCDTRO := AddressCodeRemitToTxt;
         GPPM00200.Insert();
+
+        // Vendor 5
+        Clear(GPVendor);
+        GPVendor.VENDORID := VendorIdWithBankStr5Txt;
+        GPVendor.VENDNAME := 'Vendor with bank account 5';
+        GPVendor.SEARCHNAME := GPVendor.VENDNAME;
+        GPVendor.VNDCHKNM := GPVendor.VENDNAME;
+        GPVendor.ADDRESS1 := '127 Main Street';
+        GPVendor.ADDRESS2 := '';
+        GPVendor.CITY := 'Orlando';
+        GPVendor.VNDCNTCT := 'Tester Testerson II';
+        GPVendor.PHNUMBR1 := '00000000000000';
+        GPVendor.PYMTRMID := 'Net 30';
+        GPVendor.SHIPMTHD := 'OVERNIGHT';
+        GPVendor.COUNTRY := 'USA';
+        GPVendor.PYMNTPRI := '1';
+        GPVendor.AMOUNT := 0;
+        GPVendor.FAXNUMBR := '00000000000000';
+        GPVendor.ZIPCODE := '32830';
+        GPVendor.STATE := 'FL';
+        GPVendor.INET1 := '';
+        GPVendor.INET2 := ' ';
+        GPVendor.TAXSCHID := 'P-T-TXB-%PT%P*2';
+        GPVendor.UPSZONE := '';
+        GPVendor.TXIDNMBR := '';
+        GPVendor.Insert();
+
+        Clear(GPSY06000);
+        GPSY06000.CustomerVendor_ID := GPVendor.VENDORID;
+        GPSY06000.ADRSCODE := AddressCodePrimaryTxt;
+        GPSY06000.EFTBankCode := '';
+        GPSY06000.BANKNAME := 'Bank Name 1';
+        GPSY06000.EFTBankBranchCode := '01234';
+        GPSY06000.EFTBankAcct := '56789078';
+        GPSY06000.EFTTransitRoutingNo := '123456789';
+        GPSY06000.CURNCYID := CurrencyCodeUSTxt;
+        GPSY06000.Insert();
+
+        Clear(GPSY06000);
+        GPSY06000.CustomerVendor_ID := GPVendor.VENDORID;
+        GPSY06000.ADRSCODE := AddressCodeRemitToTxt;
+        GPSY06000.EFTBankCode := '';
+        GPSY06000.BANKNAME := 'Bank Name 2';
+        GPSY06000.EFTBankBranchCode := '01234';
+        GPSY06000.EFTBankAcct := '56789078';
+        GPSY06000.EFTTransitRoutingNo := '123456789';
+        GPSY06000.CURNCYID := CurrencyCodeUSTxt;
+        GPSY06000.Insert();
+
+        Clear(GPSY06000);
+        GPSY06000.CustomerVendor_ID := GPVendor.VENDORID;
+        GPSY06000.ADRSCODE := AddressCodeOtherTxt;
+        GPSY06000.EFTBankCode := '';
+        GPSY06000.BANKNAME := 'Bank Name 3';
+        GPSY06000.EFTBankBranchCode := '01234';
+        GPSY06000.EFTBankAcct := '56789078';
+        GPSY06000.EFTTransitRoutingNo := '123456789';
+        GPSY06000.CURNCYID := CurrencyCodeUSTxt;
+        GPSY06000.Insert();
 #pragma warning restore AA0139
     end;
 

--- a/Apps/W1/HybridGP/test/src/GPSettingsTests.codeunit.al
+++ b/Apps/W1/HybridGP/test/src/GPSettingsTests.codeunit.al
@@ -488,6 +488,450 @@ codeunit 139681 "GP Settings Tests"
         Assert.IsTrue(GPConfiguration.IsAllPostMigrationDataCreated(), 'Should return true because all of the entries should be created.');
     end;
 
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicNotMasterGLOnly()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPGLTransactions: Record "GP GLTransactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Not migrating only GL master
+        GPCompanyAdditionalSettings.Validate("Migrate Only GL Master", false);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] Records should be created in the GP GLTransactions combined staging table
+        Assert.AreEqual(1, GPGLTransactions.Count(), 'Transaction records should have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicMasterGLOnly()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPGLTransactions: Record "GP GLTransactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Migrating only GL master
+        GPCompanyAdditionalSettings.Validate("Migrate Only GL Master", true);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] No records should be created in the GP GLTransactions combined staging table
+        Assert.AreEqual(0, GPGLTransactions.Count(), 'Transaction records should not have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicReceivablesModuleEnabledMasterDataOnlyDisabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPCustomer: Record "GP Customer";
+        GPCustomerTransactions: Record "GP Customer Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Receivables module enabled, and not migrating only Receivables master data
+        GPCompanyAdditionalSettings.Validate("Migrate Receivables Module", true);
+        GPCompanyAdditionalSettings.Validate("Migrate Only Rec. Master", false);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] Both GP Customer and GP Customer Transaction records will be created
+        Assert.AreEqual(1, GPCustomer.Count(), 'Customer records should have been created.');
+        Assert.AreEqual(1, GPCustomerTransactions.Count(), 'Customer Transaction records should have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicReceivablesModuleEnabledMasterDataOnlyEnabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPCustomer: Record "GP Customer";
+        GPCustomerTransactions: Record "GP Customer Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Migrating only Receivables master data
+        GPCompanyAdditionalSettings.Validate("Migrate Receivables Module", true);
+        GPCompanyAdditionalSettings.Validate("Migrate Only Rec. Master", true);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] GP Customer will be created, but not GP Customer Transactions
+        Assert.AreEqual(1, GPCustomer.Count(), 'Customer records should have been created.');
+        Assert.AreEqual(0, GPCustomerTransactions.Count(), 'Customer Transaction records should not have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicReceivablesModuleDisabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPCustomer: Record "GP Customer";
+        GPCustomerTransactions: Record "GP Customer Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Receivables module disabled
+        GPCompanyAdditionalSettings.Validate("Migrate Receivables Module", false);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] No GP Customer or GP Customer Transaction records will be created
+        Assert.AreEqual(0, GPCustomer.Count(), 'Customer records should not have been created.');
+        Assert.AreEqual(0, GPCustomerTransactions.Count(), 'Customer Transaction records should not have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicPayablesModuleEnabledMasterDataOnlyDisabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPVendor: Record "GP Vendor";
+        GPVendorTransactions: Record "GP Vendor Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Payables module enabled, and not migrating only Payables master data
+        GPCompanyAdditionalSettings.Validate("Migrate Payables Module", true);
+        GPCompanyAdditionalSettings.Validate("Migrate Only Payables Master", false);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] Both GP Vendor and GP Vendor Transaction records will be created
+        Assert.AreEqual(1, GPVendor.Count(), 'Vendor records should have been created.');
+        Assert.AreEqual(1, GPVendorTransactions.Count(), 'Vendor Transaction records should have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicPayablesModuleEnabledMasterDataOnlyEnabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPVendor: Record "GP Vendor";
+        GPVendorTransactions: Record "GP Vendor Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Migrating only Payables master data
+        GPCompanyAdditionalSettings.Validate("Migrate Payables Module", true);
+        GPCompanyAdditionalSettings.Validate("Migrate Only Payables Master", true);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] GP Vendor will be created, but not GP Vendor Transactions
+        Assert.AreEqual(1, GPVendor.Count(), 'Vendor records should have been created.');
+        Assert.AreEqual(0, GPVendorTransactions.Count(), 'Vendor Transaction records should not have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicPayablesModuleDisabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPVendor: Record "GP Vendor";
+        GPVendorTransactions: Record "GP Vendor Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Payables module disabled
+        GPCompanyAdditionalSettings.Validate("Migrate Payables Module", false);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] No GP Vendor or GP Vendor Transaction records will be created
+        Assert.AreEqual(0, GPVendor.Count(), 'Vendor records should not have been created.');
+        Assert.AreEqual(0, GPVendorTransactions.Count(), 'Vendor Transaction records should not have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicInventoryModuleEnabledMasterDataOnlyDisabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPItem: Record "GP Item";
+        GPItemTransactions: Record "GP Item Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Inventory module enabled, and not migrating only Inventory master data
+        GPCompanyAdditionalSettings.Validate("Migrate Inventory Module", true);
+        GPCompanyAdditionalSettings.Validate("Migrate Only Inventory Master", false);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] Both GP Item and GP Item Transaction records will be created
+        Assert.AreEqual(1, GPItem.Count(), 'Item records should have been created.');
+        Assert.AreEqual(1, GPItemTransactions.Count(), 'Item Transaction records should have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicInventoryModuleEnabledMasterDataOnlyEnabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPItem: Record "GP Item";
+        GPItemTransactions: Record "GP Item Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Migrating only Inventory master data
+        GPCompanyAdditionalSettings.Validate("Migrate Inventory Module", true);
+        GPCompanyAdditionalSettings.Validate("Migrate Only Inventory Master", true);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] GP Items will be created, but not GP Item Transactions
+        Assert.AreEqual(1, GPItem.Count(), 'Item records should have been created.');
+        Assert.AreEqual(0, GPItemTransactions.Count(), 'Item Transaction records should not have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicInventoryModuleDisabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPItem: Record "GP Item";
+        GPItemTransactions: Record "GP Item Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Inventory module disabled
+        GPCompanyAdditionalSettings.Validate("Migrate Inventory Module", false);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] No GP Item or GP Item Transaction records will be created
+        Assert.AreEqual(0, GPItem.Count(), 'Item records should not have been created.');
+        Assert.AreEqual(0, GPItemTransactions.Count(), 'Item Transaction records should not have been created.');
+    end;
+
+    local procedure CreateReplicatedData()
+    var
+        GPGL00100: Record "GP GL00100";
+        GPGL40200: Record "GP GL40200";
+        GPSY00300: Record "GP SY00300";
+        GPGL10110: Record "GP GL10110";
+        GPGL10111: Record "GP GL10111";
+        GPSY40100: Record "GP SY40100";
+        GPSY40101: Record "GP SY40101";
+        GPRM00101: Record "GP RM00101";
+        GPRM20101: Record "GP RM20101";
+        GPPM00200: Record "GP PM00200";
+        GPPM20000: Record "GP PM20000";
+        GPIV00101: Record "GP IV00101";
+        GPIV10200: Record "GP IV10200";
+    begin
+        if not GPSY00300.IsEmpty() then
+            GPSY00300.DeleteAll();
+
+        if not GPGL10110.IsEmpty() then
+            GPGL10110.DeleteAll();
+
+        if not GPGL10111.IsEmpty() then
+            GPGL10111.DeleteAll();
+
+        if not GPGL00100.IsEmpty() then
+            GPGL00100.DeleteAll();
+
+        if not GPSY40100.IsEmpty() then
+            GPSY40100.DeleteAll();
+
+        if not GPSY40101.IsEmpty() then
+            GPSY40101.DeleteAll();
+
+        if not GPGL40200.IsEmpty() then
+            GPGL40200.DeleteAll();
+
+        if not GPRM00101.IsEmpty() then
+            GPRM00101.DeleteAll();
+
+        if not GPRM20101.IsEmpty() then
+            GPRM20101.DeleteAll();
+
+        if not GPPM00200.IsEmpty() then
+            GPPM00200.DeleteAll();
+
+        if not GPPM20000.IsEmpty() then
+            GPPM20000.DeleteAll();
+
+        if not GPIV00101.IsEmpty() then
+            GPIV00101.DeleteAll();
+
+        if not GPIV10200.IsEmpty() then
+            GPIV10200.DeleteAll();
+
+        // GL
+        GPSY00300.MNSEGIND := true;
+        GPSY00300.SGMTNUMB := 1;
+        GPSY00300.Insert();
+
+        GPGL00100.ACTINDX := 1;
+        GPGL00100.ACTNUMBR_1 := '1200';
+        GPGL00100.ACCTTYPE := 1;
+        GPGL00100.ACTDESCR := 'Test account';
+        GPGL00100.Insert();
+
+        GPGL10110.PERDBLNC := 1;
+        GPGL10110.GL00100ACCTYPE1Exist := true;
+        GPGL10110.YEAR1 := 2023;
+        GPGL10110.PERIODID := 1;
+        GPGL10110.ACTNUMBR_1 := GPGL00100.ACTNUMBR_1;
+        GPGL10110.ACTINDX := 1;
+        GPGL10110.CRDTAMNT := 100;
+        GPGL10110.Insert();
+
+        GPSY40101.YEAR1 := 2023;
+        GPSY40101.Insert();
+
+        GPSY40100.PERIODID := 1;
+        GPSY40100.SERIES := 0;
+        GPSY40100.YEAR1 := 2023;
+        GPSY40100.PERIODDT := CurrentDateTime();
+        GPSY40100.PERDENDT := CurrentDateTime();
+        GPSY40100.Insert();
+
+        // Receivables
+        GPRM00101.CUSTNMBR := 'CUST1';
+        GPRM00101.CUSTNAME := 'Customer name';
+        GPRM00101.CITY := 'Fargo';
+        GPRM00101.STATE := 'ND';
+        GPRM00101.ZIP := '58103-3342';
+        GPRM00101.TAXSCHID := 'S-T-NO-%AD%S';
+        GPRM00101.UPSZONE := 'P3';
+        GPRM00101.Insert();
+
+        GPRM20101.RMDTYPAL := 1;
+        GPRM20101.CURTRXAM := 100;
+        GPRM20101.VOIDSTTS := 0;
+        GPRM20101.CUSTNMBR := GPRM00101.CUSTNMBR;
+        GPRM20101.DOCNUMBR := 'DOC123';
+        GPRM20101.DOCDATE := Today();
+        GPRM20101.SLPRSNID := 'Somebody';
+        GPRM20101.PYMTRMID := '2.5% EOM/EOM';
+        GPRM20101.Insert();
+
+        // Payables
+        GPPM00200.VENDORID := 'V3130';
+        GPPM00200.VENDSTTS := 1;
+        GPPM00200.VENDNAME := 'Lmd Telecom, Inc.';
+        GPPM00200.VNDCHKNM := 'Lmd Telecom, Inc.';
+        GPPM00200.ADDRESS1 := 'P.O. Box10158';
+        GPPM00200.CITY := 'Fort Worth';
+        GPPM00200.PYMTRMID := '3% 15th/Net 30';
+        GPPM00200.SHIPMTHD := 'UPS BLUE';
+        GPPM00200.ZIPCODE := '76114';
+        GPPM00200.STATE := 'TX';
+        GPPM00200.TAXSCHID := 'P-T-TXB-%PT%P*4';
+        GPPM00200.UPSZONE := 'F4';
+        GPPM00200.TXIDNMBR := '45-0029728';
+        GPPM00200.Insert();
+
+        GPPM20000.VENDORID := GPPM00200.VENDORID;
+        GPPM20000.DOCNUMBR := 'DOC01';
+        GPPM20000.DOCTYPE := 1;
+        GPPM20000.DOCDATE := Today();
+        GPPM20000.DUEDATE := Today();
+        GPPM20000.CURTRXAM := 100;
+        GPPM20000.PYMTRMID := GPPM00200.PYMTRMID;
+        GPPM20000.Insert();
+
+        // Inventory
+        GPIV00101.ITEMTYPE := 1;
+        GPIV00101.ITEMNMBR := 'Item1';
+        GPIV00101.ITEMDESC := 'Item description';
+        GPIV00101.VCTNMTHD := 1;
+        GPIV00101.CURRCOST := 1;
+        GPIV00101.STNDCOST := 1;
+        GPIV00101.SELNGUOM := 'EACH';
+        GPIV00101.PRCHSUOM := 'EACH';
+        GPIV00101.ITMTRKOP := 2;
+        GPIV00101.ITEMSHWT := 500;
+        GPIV00101.ITMTRKOP := 1;
+        GPIV00101.Insert();
+
+        GPIV10200.ITEMNMBR := GPIV00101.ITEMNMBR;
+        GPIV10200.TRXLOCTN := 'WAREHOUSE';
+        GPIV10200.UNITCOST := 1;
+        GPIV10200.RCTSEQNM := 1;
+        GPIV10200.RCPTNMBR := 'R101';
+        GPIV10200.DATERECD := Today();
+        GPIV10200.RCPTSOLD := false;
+        GPIV10200.QTYRECVD := 1;
+        GPIV10200.QTYTYPE := 1;
+        GPIV10200.Insert();
+    end;
+
     local procedure CreateSettingsTableEntries()
     var
         GPCompanyMigrationSettings: Record "GP Company Migration Settings";
@@ -540,6 +984,10 @@ codeunit 139681 "GP Settings Tests"
         GPCompanyAdditionalSettings.Validate("Migrate Only Inventory Master", true);
         GPCompanyAdditionalSettings.Validate("Migrate Only Payables Master", true);
         GPCompanyAdditionalSettings.Validate("Migrate Only Rec. Master", true);
+        GPCompanyAdditionalSettings.Validate("Skip Posting Account Batches", true);
+        GPCompanyAdditionalSettings.Validate("Skip Posting Customer Batches", true);
+        GPCompanyAdditionalSettings.Validate("Skip Posting Vendor Batches", true);
+        GPCompanyAdditionalSettings.Validate("Skip Posting Bank Batches", true);
         GPCompanyAdditionalSettings.Modify();
     end;
 }


### PR DESCRIPTION
This PR includes July 2023 updates to the GP migration.

**General Performance**
- Don't perform the staging combine step if the module is not configured to migrate. An initial step for a migration is the combining of multiple staging tables into a single table for later processing (replacement of the SQL queries). This area of the code is now optimized to only perform this operation when configured to and skip otherwise. If configured to migrate less data, this would reduce both the time a migration would take, and the amount of space used by the staging tables.

**Posting enhancements**
- Allow skip posting. Added 'skip posting' config settings and incorporated them in the posting code to give the ability to skip auto posting of Account, Customer, Bank, and/or Vendor batches.
- Posting Group account number now defaults to Posting Setup account when the Posting Group account number is empty.

**AR/AP**
- Prevent $0 transactions that cause posting to fail.
- Enhancements to Vendor Bank Account migrations. If the Vendor has more than 1 bank account, then the Code field will be appended with a number after the Vendor ID. For example: ACETRAVEL-1, ACETRAVEL-2. All Bank Account records migrated will set the Use for Electronic Payments field = true.
- Remove appended BC doc number to External Document No. field in AP and AR documents. This area of the code was appending the Document No. that is assigned to the migrated AP and AR transactions to the end of the External Doc. No. field. Feedback has been provided by Partners and Customers that this causes confusion, is unnecessary and can break integrations.
- Correct how Countries/Regions are created during migration. The migration now has the ability to perform a search on known countries, obtained by GP's list of known countries.

**Item**
- Support GP Rounding Precision For Item Unit Cost. This change updates the General Ledger Setup record "Unit-Amount Rounding Precision" value to match the greatest number of decimal places supported by a GP Item.

**Historical Snapshot improvements**
- Restart GP Snapshot if it times out (Increased the Max Attempts property).
- Snapshot performance enhancements.

**Other**
- OnResetAllCloudData() and CompanyOnAfterDelete() now cleans up necessary tables.
- Ablity to update Company migration settings and rerun the Snapshot with the changed settings.
- Added a page to add the ability to remove a Hybrid Company Status record