### PR TITLE
[Shopify] Shpfy Order Transaction: removed Access Internal

### DIFF
--- a/Apps/W1/Shopify/app/src/Transactions/Tables/ShpfyOrderTransaction.Table.al
+++ b/Apps/W1/Shopify/app/src/Transactions/Tables/ShpfyOrderTransaction.Table.al
@@ -86,30 +86,35 @@ table 30133 "Shpfy Order Transaction"
             Caption = 'Source Name';
             DataClassification = SystemMetadata;
             Editable = false;
+            Access = Internal;
         }
         field(16; "Credit Card Bin"; Code[10])
         {
             Caption = 'Credit Card Bin';
             DataClassification = SystemMetadata;
             Editable = false;
+            Access = Internal;
         }
         field(17; "AVS Result Code"; Code[1])
         {
             Caption = 'AVS Result Code'; //http://www.emsecommerce.net/avs_cvv2_response_codes.htm
             DataClassification = SystemMetadata;
             Editable = false;
+            Access = Internal;
         }
         field(18; "CVV Result Code"; Code[1])
         {
             Caption = 'CVV Result Code'; //http://www.emsecommerce.net/avs_cvv2_response_codes.htm
             DataClassification = SystemMetadata;
             Editable = false;
+            Access = Internal;
         }
         field(19; "Credit Card Number"; Text[30])
         {
             Caption = 'Credit Card Number';
             DataClassification = SystemMetadata;
             Editable = false;
+            Access = Internal;
         }
         field(20; "Credit Card Company"; Text[50])
         {
@@ -136,7 +141,6 @@ table 30133 "Shpfy Order Transaction"
             FieldClass = FlowField;
             CalcFormula = lookup("Sales Header"."No." where("Shpfy Order Id" = field("Shopify Order Id")));
         }
-
         field(102; "Posted Invoice No."; Code[20])
         {
             Caption = 'Posted Invoice No.';
@@ -189,7 +193,7 @@ table 30133 "Shpfy Order Transaction"
         DataCapture.SetCurrentKey("Linked To Table", "Linked To Id");
         DataCapture.SetRange("Linked To Table", Database::"Shpfy Order Transaction");
         DataCapture.SetRange("Linked To Id", Rec.SystemId);
-        if not DataCapture.IsEmpty then
+        if not DataCapture.IsEmpty() then
             DataCapture.DeleteAll(false);
     end;
 }

--- a/Apps/W1/Shopify/app/src/Transactions/Tables/ShpfyOrderTransaction.Table.al
+++ b/Apps/W1/Shopify/app/src/Transactions/Tables/ShpfyOrderTransaction.Table.al
@@ -3,7 +3,6 @@
 /// </summary>
 table 30133 "Shpfy Order Transaction"
 {
-    Access = Internal;
     Caption = 'Shopify Order Transaction';
     DataClassification = SystemMetadata;
     LookupPageID = "Shpfy Order Transactions";


### PR DESCRIPTION
Hi,

For Paypal transactions (indeed anything other than the standard Shopify Gateway) we need to get access to the Authorization field which is currently sat on “Shpfy Order Transaction", however this table is flagged as Internal.
Basically we drop this on to the External Document No. field in a Sales Order to enable it to flow through to the Bank Ledger Entries.
The change will allow to access the data directly from the table.

Since the table contains sensitive information a list of fields marked as Internal:
        field(15; "Source Name"; Code[20])
        field(16; "Credit Card Bin"; Code[10])
        field(17; "AVS Result Code"; Code[1])
        field(18; "CVV Result Code"; Code[1])
        field(19; "Credit Card Number"; Text[30])