### PR TITLE
Add Procedure to Delete E-Mail Accounts

### DIFF
--- a/Modules/System Tests/Email/src/EmailAccountsTest.Codeunit.al
+++ b/Modules/System Tests/Email/src/EmailAccountsTest.Codeunit.al
@@ -11,8 +11,8 @@ codeunit 134686 "Email Accounts Test"
     var
         Assert: Codeunit "Library Assert";
         PermissionsMock: Codeunit "Permissions Mock";
-        AccountNameLbl: Label '%1 (%2)', Locked = true;
         AccountToSelect: Guid;
+        AccountNameLbl: Label '%1 (%2)', Locked = true;
 
     [Test]
     [Scope('OnPrem')]
@@ -203,8 +203,8 @@ codeunit 134686 "Email Accounts Test"
     procedure GetAllAccountsTest()
     var
         EmailAccountBuffer, EmailAccounts : Record "Email Account";
-        EmailAccount: Codeunit "Email Account";
         ConnectorMock: Codeunit "Connector Mock";
+        EmailAccount: Codeunit "Email Account";
     begin
         // [SCENARIO] GetAllAccounts retrieves all the registered accounts
 
@@ -237,8 +237,8 @@ codeunit 134686 "Email Accounts Test"
     [Test]
     procedure IsAnyAccountRegisteredTest()
     var
-        EmailAccount: Codeunit "Email Account";
         ConnectorMock: Codeunit "Connector Mock";
+        EmailAccount: Codeunit "Email Account";
         AccountId: Guid;
     begin
         // [SCENARIO] Email Account Exists works as expected
@@ -266,8 +266,8 @@ codeunit 134686 "Email Accounts Test"
     var
         ConnectorMock: Codeunit "Connector Mock";
         EmailAccountsSelectionMock: Codeunit "Email Accounts Selection Mock";
-        EmailAccountsTestPage: TestPage "Email Accounts";
         FirstAccountId, SecondAccountId, ThirdAccountId : Guid;
+        EmailAccountsTestPage: TestPage "Email Accounts";
     begin
         // [SCENARIO] When all accounts are deleted, the Email Accounts page is empty
         PermissionsMock.Set('Email Admin');
@@ -300,8 +300,8 @@ codeunit 134686 "Email Accounts Test"
     var
         ConnectorMock: Codeunit "Connector Mock";
         EmailAccountsSelectionMock: Codeunit "Email Accounts Selection Mock";
-        EmailAccountsTestPage: TestPage "Email Accounts";
         FirstAccountId, SecondAccountId, ThirdAccountId : Guid;
+        EmailAccountsTestPage: TestPage "Email Accounts";
     begin
         // [SCENARIO] When all accounts are about to be deleted but the action in canceled, the Email Accounts page contains all of them.
         PermissionsMock.Set('Email Admin');
@@ -336,8 +336,8 @@ codeunit 134686 "Email Accounts Test"
     var
         ConnectorMock: Codeunit "Connector Mock";
         EmailAccountsSelectionMock: Codeunit "Email Accounts Selection Mock";
-        EmailAccountsTestPage: TestPage "Email Accounts";
         FirstAccountId, SecondAccountId, ThirdAccountId : Guid;
+        EmailAccountsTestPage: TestPage "Email Accounts";
     begin
         // [SCENARIO] When some accounts are deleted, they cannot be found on the page
         PermissionsMock.Set('Email Admin');
@@ -373,8 +373,8 @@ codeunit 134686 "Email Accounts Test"
         ConnectorMock: Codeunit "Connector Mock";
         EmailAccountsSelectionMock: Codeunit "Email Accounts Selection Mock";
         EmailScenario: Codeunit "Email Scenario";
-        EmailAccountsTestPage: TestPage "Email Accounts";
         FirstAccountId, ThirdAccountId : Guid;
+        EmailAccountsTestPage: TestPage "Email Accounts";
     begin
         // [SCENARIO] When the a non default account is deleted, the user is not prompted to choose a new default account.
         PermissionsMock.Set('Email Admin');
@@ -416,8 +416,8 @@ codeunit 134686 "Email Accounts Test"
         ConnectorMock: Codeunit "Connector Mock";
         EmailAccountsSelectionMock: Codeunit "Email Accounts Selection Mock";
         EmailScenario: Codeunit "Email Scenario";
-        EmailAccountsTestPage: TestPage "Email Accounts";
         FirstAccountId, ThirdAccountId : Guid;
+        EmailAccountsTestPage: TestPage "Email Accounts";
     begin
         // [SCENARIO] When the default account is deleted, the user is not prompted to choose a new default account if there's only one account left
         PermissionsMock.Set('Email Admin');
@@ -458,8 +458,8 @@ codeunit 134686 "Email Accounts Test"
         ConnectorMock: Codeunit "Connector Mock";
         EmailAccountsSelectionMock: Codeunit "Email Accounts Selection Mock";
         EmailScenario: Codeunit "Email Scenario";
-        EmailAccountsTestPage: TestPage "Email Accounts";
         FirstAccountId, ThirdAccountId : Guid;
+        EmailAccountsTestPage: TestPage "Email Accounts";
     begin
         // [SCENARIO] When the default account is deleted, the user is prompted to choose a new default account but they cancel.
         PermissionsMock.Set('Email Admin');
@@ -502,8 +502,8 @@ codeunit 134686 "Email Accounts Test"
         ConnectorMock: Codeunit "Connector Mock";
         EmailAccountsSelectionMock: Codeunit "Email Accounts Selection Mock";
         EmailScenario: Codeunit "Email Scenario";
-        EmailAccountsTestPage: TestPage "Email Accounts";
         FirstAccountId, ThirdAccountId : Guid;
+        EmailAccountsTestPage: TestPage "Email Accounts";
     begin
         // [SCENARIO] When the default account is deleted, the user is prompted to choose a new default account
         PermissionsMock.Set('Email Admin');
@@ -538,6 +538,35 @@ codeunit 134686 "Email Accounts Test"
         Assert.IsTrue(GetDefaultFieldValueAsBoolean(EmailAccountsTestPage.DefaultField.Value), 'The third account should be marked as default');
     end;
 
+    [Test]
+    procedure DeleteAllAccountsWithoutUITest()
+    var
+        TempEmailAccount: Record "Email Account" temporary;
+        TempEmailAccountToDelete: Record "Email Account" temporary;
+        ConnectorMock: Codeunit "Connector Mock";
+        EmailAccount: Codeunit "Email Account";
+        FirstAccountId, SecondAccountId : Guid;
+    begin
+        // [SCENARIO] When all accounts are deleted, the Email Accounts page is empty
+        PermissionsMock.Set('Email Admin');
+
+        // [GIVEN] A connector is installed and two account are added
+        ConnectorMock.Initialize();
+        ConnectorMock.AddAccount(FirstAccountId);
+        ConnectorMock.AddAccount(SecondAccountId);
+
+        // [GIVEN] Mark first account for deletion
+        EmailAccount.GetAllAccounts(TempEmailAccountToDelete);
+        TempEmailAccountToDelete.SetRange("Account Id", FirstAccountId);
+
+        // [WHEN] Email Accounts are deleted
+        EmailAccount.DeleteAccounts(TempEmailAccountToDelete, true);
+
+        // [THEN] Verify second account still exists
+        EmailAccount.GetAllAccounts(TempEmailAccount);
+        TempEmailAccount.FindFirst();
+        Assert.AreEqual(SecondAccountId, TempEmailAccount."Account Id", 'The second email account should still exist.');
+    end;
 
     [ModalPageHandler]
     procedure AddAccountModalPageHandler(var AccountWizardTestPage: TestPage "Email Account Wizard")

--- a/Modules/System/Email/src/Account/EmailAccount.Codeunit.al
+++ b/Modules/System/Email/src/Account/EmailAccount.Codeunit.al
@@ -39,6 +39,17 @@ codeunit 8894 "Email Account"
     end;
 
     /// <summary>
+    /// Deletes all selected email accounts.
+    /// </summary>
+    /// <param name="TempEmailAccountsToDelete">Holding the selected email accounts to delete.</param>
+    /// <param name="HideDialog">Hides any confirmation or interaction that involves a UI.</param>
+    /// <error>Your user account does not give you permission to set up email. Please contact your administrator.</error>
+    procedure DeleteAccounts(var TempEmailAccountsToDelete: Record "Email Account" temporary; HideDialog: Boolean)
+    begin
+        EmailAccountImpl.DeleteAccounts(TempEmailAccountsToDelete, HideDialog);
+    end;
+
+    /// <summary>
     /// Validates an email address and throws an error if it is invalid.
     /// </summary>
     /// <remarks>If the provided email address is an empty string, the function will do nothing.</remarks>

--- a/Modules/System/Email/src/Account/EmailAccountImpl.Codeunit.al
+++ b/Modules/System/Email/src/Account/EmailAccountImpl.Codeunit.al
@@ -15,8 +15,8 @@ codeunit 8889 "Email Account Impl."
     procedure GetAllAccounts(LoadLogos: Boolean; var TempEmailAccount: Record "Email Account" temporary)
     var
         EmailAccounts: Record "Email Account";
-        IEmailConnector: Interface "Email Connector";
         Connector: Enum "Email Connector";
+        IEmailConnector: Interface "Email Connector";
     begin
         TempEmailAccount.Reset();
         TempEmailAccount.DeleteAll();
@@ -62,8 +62,8 @@ codeunit 8889 "Email Account Impl."
         CheckPermissions();
 
         if not HideDialog then
-        if not ConfirmManagement.GetResponseOrDefault(ConfirmDeleteQst, true) then
-            exit;
+            if not ConfirmManagement.GetResponseOrDefault(ConfirmDeleteQst, true) then
+                exit;
 
         if not EmailAccountsToDelete.FindSet() then
             exit;
@@ -110,7 +110,7 @@ codeunit 8889 "Email Account Impl."
 
         NewDefaultEmailAccountSelected := false;
         if not HideDialog then begin
-        Commit();  // Commit the accounts deletion in order to prompt for new default account
+            Commit();  // Commit the accounts deletion in order to prompt for new default account
             NewDefaultEmailAccountSelected := PromptNewDefaultAccountChoice(NewDefaultEmailAccount);
         end;
         if NewDefaultEmailAccountSelected then
@@ -137,12 +137,12 @@ codeunit 8889 "Email Account Impl."
     local procedure ImportLogo(var EmailAccount: Record "Email Account"; Connector: Interface "Email Connector")
     var
         EmailConnectorLogo: Record "Email Connector Logo";
-        TempBlob: Codeunit "Temp Blob";
         Base64Convert: Codeunit "Base64 Convert";
-        ConnectorLogoBase64: Text;
-        OutStream: Outstream;
+        TempBlob: Codeunit "Temp Blob";
         InStream: InStream;
         ConnectorLogoDescriptionTxt: Label '%1 Logo', Locked = true;
+        OutStream: Outstream;
+        ConnectorLogoBase64: Text;
     begin
         ConnectorLogoBase64 := Connector.GetLogoAsBase64();
 
@@ -178,10 +178,10 @@ codeunit 8889 "Email Account Impl."
     procedure FindAllConnectors(var EmailConnector: Record "Email Connector")
     var
         Base64Convert: Codeunit "Base64 Convert";
-        ConnectorInterface: Interface "Email Connector";
         Connector: Enum "Email Connector";
-        ConnectorLogoBase64: Text;
+        ConnectorInterface: Interface "Email Connector";
         OutStream: Outstream;
+        ConnectorLogoBase64: Text;
     begin
         foreach Connector in Enum::"Email Connector".Ordinals() do begin
             ConnectorInterface := Connector;
@@ -222,8 +222,8 @@ codeunit 8889 "Email Account Impl."
     local procedure ImportLogoBlob(var EmailAccount: Record "Email Account"; Connector: Interface "Email Connector")
     var
         Base64Convert: Codeunit "Base64 Convert";
-        ConnectorLogoBase64: Text;
         OutStream: Outstream;
+        ConnectorLogoBase64: Text;
     begin
         ConnectorLogoBase64 := Connector.GetLogoAsBase64();
 
@@ -280,9 +280,9 @@ codeunit 8889 "Email Account Impl."
     end;
 
     var
-        ConfirmDeleteQst: Label 'Go ahead and delete?';
-        ChooseNewDefaultTxt: Label 'Choose a Default Account';
-        InvalidEmailAddressErr: Label 'The email address "%1" is not valid.', Comment = '%1=The email address';
-        EmptyEmailAddressErr: Label 'The email address cannot be empty.';
         CannotManageSetupErr: Label 'Your user account does not give you permission to set up email. Please contact your administrator.';
+        ChooseNewDefaultTxt: Label 'Choose a Default Account';
+        ConfirmDeleteQst: Label 'Go ahead and delete?';
+        EmptyEmailAddressErr: Label 'The email address cannot be empty.';
+        InvalidEmailAddressErr: Label 'The email address "%1" is not valid.', Comment = '%1=The email address';
 }


### PR DESCRIPTION
This PR adds a new method to delete Accounts without UI.
Currently it isn't possible to delete E-Mail Accounts.
With this PR I want to provide the ability to delete e-Mail Accounts via code that we can clean this table On Test/Dev Environments when working with customer data to avoid accidently sending an e-Mail.

Espcecially in OnPrem where we aren't able to trigger the Cleanup Environment triggers.