### PR TITLE
#24604: Add new "IsZip" method and "ExtractEntry" overload

### DIFF
--- a/Modules/System Tests/Data Compression/src/DataCompressionTests.Codeunit.al
+++ b/Modules/System Tests/Data Compression/src/DataCompressionTests.Codeunit.al
@@ -403,7 +403,6 @@ codeunit 139036 "Data Compression Tests"
     var
         TempBlob: array[2] of Codeunit "Temp Blob";
         TempBlobZipCompressed: Codeunit "Temp Blob";
-        Any: Codeunit Any;
         ShortContentInStream, ContentInStream : InStream;
         ContentOutStream: OutStream;
         ZipCompressedInStream: InStream;
@@ -413,7 +412,7 @@ codeunit 139036 "Data Compression Tests"
 
         // [GIVEN] create stream with text content
         TempBlob[1].CreateOutStream(ContentOutStream);
-        ContentOutStream.WriteText(Any.AlphabeticText(20));
+        ContentOutStream.WriteText('Any.AlphabeticText(20) would be nice to have here.');
         TempBlob[1].CreateInStream(ContentInStream);
 
         TempBlob[2].CreateOutStream(ContentOutStream);

--- a/Modules/System Tests/Data Compression/src/DataCompressionTests.Codeunit.al
+++ b/Modules/System Tests/Data Compression/src/DataCompressionTests.Codeunit.al
@@ -360,9 +360,9 @@ codeunit 139036 "Data Compression Tests"
     [Scope('OnPrem')]
     procedure TestIsGZip()
     var
-        TempBlob: Codeunit "Temp Blob";
+        TempBlob: array[2] of Codeunit "Temp Blob";
         TempBlobGZipCompressed: Codeunit "Temp Blob";
-        ContentInStream: InStream;
+        ShortContentInStream, ContentInStream : InStream;
         ContentOutStream: OutStream;
         GZipCompressedInStream: InStream;
         GZipCompressedOutStream: OutStream;
@@ -372,9 +372,14 @@ codeunit 139036 "Data Compression Tests"
 
         // [GIVEN] create stream with text content
         StreamContent := 'VerifyGZipStreamAdd10';
-        TempBlob.CreateOutStream(ContentOutStream);
+        TempBlob[1].CreateOutStream(ContentOutStream);
         ContentOutStream.WriteText(StreamContent);
-        TempBlob.CreateInStream(ContentInStream);
+        TempBlob[1].CreateInStream(ContentInStream);
+
+        StreamContent := '_';
+        TempBlob[2].CreateOutStream(ContentOutStream);
+        ContentOutStream.WriteText(StreamContent);
+        TempBlob[2].CreateInStream(ShortContentInStream);
 
         // [WHEN] compress the the stream with GZip
         TempBlobGZipCompressed.CreateOutStream(GZipCompressedOutStream);
@@ -382,6 +387,8 @@ codeunit 139036 "Data Compression Tests"
         TempBlobGZipCompressed.CreateInStream(GZipCompressedInStream);
 
         // [THEN] verify that IsGZip returns true for compressed stream and false for the uncompressed stream
+        Assert.IsTrue((ShortContentInStream.Length > 0) and (ShortContentInStream.Length < 2), 'ShortContentInStream should be less than 2 bytes long, but never zero.');
+        Assert.IsFalse(DataCompression.IsGZip(ShortContentInStream), 'Stream with less bytes than the header must not fail.');
         Assert.IsTrue(DataCompression.IsGZip(GZipCompressedInStream), 'IsGzip should have returned true for the GZip compressed stream.');
         Assert.IsFalse(DataCompression.IsGZip(ContentInStream), 'IsGzip should have returned false for the uncompressed stream.');
         Assert.IsFalse(GZipCompressedInStream.EOS(), 'IsGzip should not have moved the input stream to EOS.');

--- a/Modules/System/Data Compression/src/DataCompression.Codeunit.al
+++ b/Modules/System/Data Compression/src/DataCompression.Codeunit.al
@@ -113,6 +113,22 @@ codeunit 425 "Data Compression"
     end;
 
     /// <summary>
+    /// Extracts an entry from the ZipArchive to a TempBlob instance.
+    /// </summary>
+    /// <param name="EntryName">The name of the ZipArchive entry to be extracted.</param>
+    /// <param name="TempBlob">The TempBlob the uncompressed binary data will be written to.</param>
+    procedure ExtractEntry(EntryName: Text; var TempBlob: Codeunit "Temp Blob"): Integer
+    var
+        os: OutStream;
+        EntryLength: Integer;
+    begin
+        Clear(TempBlob);
+        TempBlob.CreateOutStream(os);
+        DataCompressionImpl.ExtractEntry(EntryName, os, EntryLength);
+        exit(EntryLength);
+    end;
+
+    /// <summary>
     /// Adds an entry to the ZipArchive.
     /// </summary>
     /// <param name="InStreamToAdd">The InStream that contains the binary content that should be added as an entry in the ZipArchive.</param>
@@ -140,6 +156,16 @@ codeunit 425 "Data Compression"
     procedure IsGZip(InStream: InStream): Boolean
     begin
         EXIT(DataCompressionImpl.IsGZip(InStream));
+    end;
+
+    /// <summary>
+    /// Determines whether the given InStream is compressed with Zip.
+    /// </summary>
+    /// <param name="InStream">An InStream that contains binary content.</param>
+    /// <returns>Returns true if and only if the given InStream is compressed with Zip</returns>
+    procedure IsZip(InStream: InStream): Boolean
+    begin
+        exit(DataCompressionImpl.IsZip(InStream));
     end;
 
     /// <summary>

--- a/Modules/System/Data Compression/src/DataCompression.Codeunit.al
+++ b/Modules/System/Data Compression/src/DataCompression.Codeunit.al
@@ -118,14 +118,8 @@ codeunit 425 "Data Compression"
     /// <param name="EntryName">The name of the ZipArchive entry to be extracted.</param>
     /// <param name="TempBlob">The TempBlob the uncompressed binary data will be written to.</param>
     procedure ExtractEntry(EntryName: Text; var TempBlob: Codeunit "Temp Blob"): Integer
-    var
-        os: OutStream;
-        EntryLength: Integer;
     begin
-        Clear(TempBlob);
-        TempBlob.CreateOutStream(os);
-        DataCompressionImpl.ExtractEntry(EntryName, os, EntryLength);
-        exit(EntryLength);
+        exit(DataCompressionImpl.ExtractEntry(EntryName, TempBlob));
     end;
 
     /// <summary>

--- a/Modules/System/Data Compression/src/DataCompressionImpl.Codeunit.al
+++ b/Modules/System/Data Compression/src/DataCompressionImpl.Codeunit.al
@@ -110,7 +110,6 @@ codeunit 421 "Data Compression Impl."
 
     procedure IsZip(InputInStream: InStream): Boolean
     var
-        impl2: Codeunit "Data Compression Impl.";
         OriginalStream: DotNet Stream;
         Header: array[4] of Byte;
         HeaderIsValid: Boolean;

--- a/Modules/System/Data Compression/src/DataCompressionImpl.Codeunit.al
+++ b/Modules/System/Data Compression/src/DataCompressionImpl.Codeunit.al
@@ -174,6 +174,17 @@ codeunit 421 "Data Compression Impl."
         ZipArchiveEntryStream.Close();
     end;
 
+    procedure ExtractEntry(EntryName: Text; var TempBlob: Codeunit "Temp Blob"): Integer
+    var
+        os: OutStream;
+        EntryLength: Integer;
+    begin
+        Clear(TempBlob);
+        TempBlob.CreateOutStream(os);
+        ExtractEntry(EntryName, os, EntryLength);
+        exit(EntryLength);
+    end;
+
     procedure AddEntry(InStreamToAdd: InStream; PathInArchive: Text)
     var
         ZipArchiveEntry: DotNet ZipArchiveEntry;

--- a/Modules/System/Data Compression/src/DataCompressionImpl.Codeunit.al
+++ b/Modules/System/Data Compression/src/DataCompressionImpl.Codeunit.al
@@ -108,16 +108,25 @@ codeunit 421 "Data Compression Impl."
         end;
     end;
 
-    [TryFunction]
-    procedure IsZip(InputInStream: InStream)
+    procedure IsZip(InputInStream: InStream): Boolean
     var
         impl2: Codeunit "Data Compression Impl.";
         OriginalStream: DotNet Stream;
+        Header: array[4] of Byte;
+        HeaderIsValid: Boolean;
     begin
+        if (InputInStream.Length < 4) then exit(false);
+
         OriginalStream := InputInStream;
-        impl2.OpenZipArchive(InputInStream, false);
-        impl2.CloseZipArchive();
+        InputInStream.Read(Header[1]);
+        InputInStream.Read(Header[2]);
+        InputInStream.Read(Header[3]);
+        InputInStream.Read(Header[4]);
+        // check against ZIP magic header defined as P K 0x03 0x04
+        HeaderIsValid := (Header[1] = 'P') and (Header[2] = 'K') and (Header[3] = 3) and (Header[4] = 4);
+
         InputInStream := OriginalStream;
+        exit(HeaderIsValid);
     end;
 
     procedure IsGZip(InputInStream: InStream): Boolean

--- a/Modules/System/Data Compression/src/DataCompressionImpl.Codeunit.al
+++ b/Modules/System/Data Compression/src/DataCompressionImpl.Codeunit.al
@@ -125,6 +125,7 @@ codeunit 421 "Data Compression Impl."
         // check against ZIP magic header defined as P K 0x03 0x04
         HeaderIsValid := (Header[1] = 'P') and (Header[2] = 'K') and (Header[3] = 3) and (Header[4] = 4);
 
+        OriginalStream.Position := 0;
         InputInStream := OriginalStream;
         exit(HeaderIsValid);
     end;

--- a/Modules/System/Data Compression/src/DataCompressionImpl.Codeunit.al
+++ b/Modules/System/Data Compression/src/DataCompressionImpl.Codeunit.al
@@ -134,6 +134,8 @@ codeunit 421 "Data Compression Impl."
         OriginalStream: DotNet Stream;
         ID: array[2] of Byte;
     begin
+        if (InputInStream.Length < 2) then exit(false);
+
         OriginalStream := InputInStream;
         InputInStream.Read(ID[1]);
         InputInStream.Read(ID[2]);

--- a/Modules/System/Data Compression/src/DataCompressionImpl.Codeunit.al
+++ b/Modules/System/Data Compression/src/DataCompressionImpl.Codeunit.al
@@ -108,6 +108,18 @@ codeunit 421 "Data Compression Impl."
         end;
     end;
 
+    [TryFunction]
+    procedure IsZip(InputInStream: InStream)
+    var
+        impl2: Codeunit "Data Compression Impl.";
+        OriginalStream: DotNet Stream;
+    begin
+        OriginalStream := InputInStream;
+        impl2.OpenZipArchive(InputInStream, false);
+        impl2.CloseZipArchive();
+        InputInStream := OriginalStream;
+    end;
+
     procedure IsGZip(InputInStream: InStream): Boolean
     var
         OriginalStream: DotNet Stream;


### PR DESCRIPTION
Add new "IsZip" method and new overload for "ExtractEntry". 

@pri-kise haven't got the chance to really test this in the context of the System Application (copied somewhat from another app of mine where I implemented this). Not exactly sure, but I'm having a lot of issues with getting `System.Drawing` (among others) to load properly in this repo, following the getting started guide. Any idea?