### PR TITLE
GP - Hotfix to correct previous merge issue

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Accounts/GPAccountMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Accounts/GPAccountMigrator.codeunit.al
@@ -20,12 +20,8 @@ codeunit 4017 "GP Account Migrator"
 #endif
     var
         GPAccount: Record "GP Account";
-        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
     begin
         if RecordIdToMigrate.TableNo() <> Database::"GP Account" then
-            exit;
-
-        if GPCompanyAdditionalSettings.GetMigrateOnlyGLMaster() then
             exit;
 
         GPAccount.Get(RecordIdToMigrate);
@@ -118,8 +114,12 @@ codeunit 4017 "GP Account Migrator"
 #endif
     var
         GPAccount: Record "GP Account";
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
     begin
         if RecordIdToMigrate.TableNo() <> Database::"GP Account" then
+            exit;
+
+        if GPCompanyAdditionalSettings.GetMigrateOnlyGLMaster() then
             exit;
 
         GPAccount.Get(RecordIdToMigrate);


### PR DESCRIPTION
A previous merge placed code in the wrong procedure, which prevented accounts from being created when the migration was configured to only migrate GL master data.