### PR TITLE
Add metadata to Sharepoint connector

### DIFF
--- a/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
+++ b/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
@@ -358,13 +358,13 @@ codeunit 9101 "SharePoint Client Impl."
         SharePointUriBuilder.SetObject('lists');
 
         Metadata.Add('type', 'SP.List');
-        SharepointEvents.OnAfterAddListMetaData(Metadata);
         Request.Add('__metadata', Metadata);
         Request.Add('AllowContentTypes', true);
         Request.Add('BaseTemplate', 100);
         Request.Add('ContentTypesEnabled', true);
         Request.Add('Description', ListDescription);
         Request.Add('Title', ListTitle);
+        SharepointEvents.OnAfterAddListMetaData(Request);
 
         SharePointHttpContent.FromJson(Request);
         SharePointHttpContent.SetRequestDigest(GetRequestDigest(SharePointUriBuilder.GetHost()));
@@ -392,9 +392,9 @@ codeunit 9101 "SharePoint Client Impl."
         SharePointUriBuilder.SetObject('items');
 
         Metadata.Add('type', ListItemEntityTypeFullName);
-        SharepointEvents.OnAfterAddListItemMetaData(Metadata);
         Request.Add('__metadata', Metadata);
         Request.Add('Title', ListItemTitle);
+        SharepointEvents.OnAfterAddListItemMetaData(Request);
 
         SharePointHttpContent.FromJson(Request);
         SharePointHttpContent.SetRequestDigest(GetRequestDigest(SharePointUriBuilder.GetHost()));
@@ -421,9 +421,9 @@ codeunit 9101 "SharePoint Client Impl."
         SharePointUriBuilder.SetObject('items');
 
         Metadata.Add('type', ListItemEntityTypeFullName);
-        SharepointEvents.OnAfterAddListItemMetaData(Metadata);
         Request.Add('__metadata', Metadata);
         Request.Add('Title', ListItemTitle);
+        SharepointEvents.OnAfterAddListItemMetaData(Request);
 
         SharePointHttpContent.FromJson(Request);
         SharePointHttpContent.SetRequestDigest(GetRequestDigest(SharePointUriBuilder.GetHost()));
@@ -613,9 +613,9 @@ codeunit 9101 "SharePoint Client Impl."
         SharePointUriBuilder.SetObject('folders');
 
         Metadata.Add('type', 'SP.Folder');
-        SharepointEvents.OnAfterAddFolderMetaData(Metadata);
         Request.Add('__metadata', Metadata);
         Request.Add('ServerRelativeUrl', ServerRelativeUrl);
+        SharepointEvents.OnAfterAddFolderMetaData(Request);
 
         SharePointHttpContent.FromJson(Request);
         SharePointHttpContent.SetRequestDigest(GetRequestDigest(SharePointUriBuilder.GetHost()));

--- a/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
+++ b/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
@@ -358,7 +358,7 @@ codeunit 9101 "SharePoint Client Impl."
         SharePointUriBuilder.SetObject('lists');
 
         Metadata.Add('type', 'SP.List');
-        OnAfterAddListMetaData(Metadata);
+        SharepointEvents.OnAfterAddListMetaData(Metadata);
         Request.Add('__metadata', Metadata);
         Request.Add('AllowContentTypes', true);
         Request.Add('BaseTemplate', 100);
@@ -392,7 +392,7 @@ codeunit 9101 "SharePoint Client Impl."
         SharePointUriBuilder.SetObject('items');
 
         Metadata.Add('type', ListItemEntityTypeFullName);
-        OnAfterAddListItemMetaData(Metadata);
+        SharepointEvents.OnAfterAddListItemMetaData(Metadata);
         Request.Add('__metadata', Metadata);
         Request.Add('Title', ListItemTitle);
 
@@ -421,7 +421,7 @@ codeunit 9101 "SharePoint Client Impl."
         SharePointUriBuilder.SetObject('items');
 
         Metadata.Add('type', ListItemEntityTypeFullName);
-        OnAfterAddListItemMetaData(Metadata);
+        SharepointEvents.OnAfterAddListItemMetaData(Metadata);
         Request.Add('__metadata', Metadata);
         Request.Add('Title', ListItemTitle);
 
@@ -613,7 +613,7 @@ codeunit 9101 "SharePoint Client Impl."
         SharePointUriBuilder.SetObject('folders');
 
         Metadata.Add('type', 'SP.Folder');
-        OnAfterAddFolderMetaData(Metadata);
+        SharepointEvents.OnAfterAddFolderMetaData(Metadata);
         Request.Add('__metadata', Metadata);
         Request.Add('ServerRelativeUrl', ServerRelativeUrl);
 
@@ -709,18 +709,6 @@ codeunit 9101 "SharePoint Client Impl."
     end;
     #endregion
 
-    [IntegrationEvent(false, false)]
-    local procedure OnAfterAddListItemMetaData(var Metadata: JsonObject)
-    begin
-    end;
-
-    [IntegrationEvent(false, false)]
-    local procedure OnAfterAddListMetaData(var Metadata: JsonObject)
-    begin
-    end;
-
-    [IntegrationEvent(false, false)]
-    local procedure OnAfterAddFolderMetaData(var Metadata: JsonObject)
-    begin
-    end;
+    var
+        SharepointEvents: Codeunit "Sharepoint Events";
 }

--- a/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
+++ b/Modules/System/SharePoint/src/SharePointClientImpl.Codeunit.al
@@ -358,6 +358,7 @@ codeunit 9101 "SharePoint Client Impl."
         SharePointUriBuilder.SetObject('lists');
 
         Metadata.Add('type', 'SP.List');
+        OnAfterAddListMetaData(Metadata);
         Request.Add('__metadata', Metadata);
         Request.Add('AllowContentTypes', true);
         Request.Add('BaseTemplate', 100);
@@ -391,6 +392,7 @@ codeunit 9101 "SharePoint Client Impl."
         SharePointUriBuilder.SetObject('items');
 
         Metadata.Add('type', ListItemEntityTypeFullName);
+        OnAfterAddListItemMetaData(Metadata);
         Request.Add('__metadata', Metadata);
         Request.Add('Title', ListItemTitle);
 
@@ -419,6 +421,7 @@ codeunit 9101 "SharePoint Client Impl."
         SharePointUriBuilder.SetObject('items');
 
         Metadata.Add('type', ListItemEntityTypeFullName);
+        OnAfterAddListItemMetaData(Metadata);
         Request.Add('__metadata', Metadata);
         Request.Add('Title', ListItemTitle);
 
@@ -610,6 +613,7 @@ codeunit 9101 "SharePoint Client Impl."
         SharePointUriBuilder.SetObject('folders');
 
         Metadata.Add('type', 'SP.Folder');
+        OnAfterAddFolderMetaData(Metadata);
         Request.Add('__metadata', Metadata);
         Request.Add('ServerRelativeUrl', ServerRelativeUrl);
 
@@ -704,4 +708,19 @@ codeunit 9101 "SharePoint Client Impl."
         exit(true);
     end;
     #endregion
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterAddListItemMetaData(var Metadata: JsonObject)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterAddListMetaData(var Metadata: JsonObject)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterAddFolderMetaData(var Metadata: JsonObject)
+    begin
+    end;
 }

--- a/Modules/System/SharePoint/src/SharepointEvents.al
+++ b/Modules/System/SharePoint/src/SharepointEvents.al
@@ -21,17 +21,17 @@ codeunit 9112 "Sharepoint Events"
     end;
 
     [IntegrationEvent(false, false)]
-    procedure OnAfterAddListItemMetaData(var Metadata: JsonObject)
+    procedure OnAfterAddListItemMetaData(var Request: JsonObject)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    procedure OnAfterAddListMetaData(var Metadata: JsonObject)
+    procedure OnAfterAddListMetaData(var Request: JsonObject)
     begin
     end;
 
     [IntegrationEvent(false, false)]
-    procedure OnAfterAddFolderMetaData(var Metadata: JsonObject)
+    procedure OnAfterAddFolderMetaData(var Request: JsonObject)
     begin
     end;
 }

--- a/Modules/System/SharePoint/src/SharepointEvents.al
+++ b/Modules/System/SharePoint/src/SharepointEvents.al
@@ -1,0 +1,37 @@
+codeunit 9112 "Sharepoint Events"
+{
+    [IntegrationEvent(false, false)]
+    procedure OnAfterApplySharepointFolderMetadata(JToken: JsonToken; var SharePointFolder: Record "SharePoint Folder" temporary)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    procedure OnAfterApplySharepointListMetadata(JToken: JsonToken; var SharePointList: Record "SharePoint List" temporary)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    procedure OnAfterApplySharepointListItemMetadata(JToken: JsonToken; var SharePointListItem: Record "SharePoint List Item" temporary)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    procedure OnAfterApplySharePointListItemAttachmentMetadata(JToken: JsonToken; var SharePointListItemAttachment: Record "SharePoint List Item Atch" temporary)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    procedure OnAfterAddListItemMetaData(var Metadata: JsonObject)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    procedure OnAfterAddListMetaData(var Metadata: JsonObject)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    procedure OnAfterAddFolderMetaData(var Metadata: JsonObject)
+    begin
+    end;
+}

--- a/Modules/System/SharePoint/src/model/file/SharePointFile.Codeunit.al
+++ b/Modules/System/SharePoint/src/model/file/SharePointFile.Codeunit.al
@@ -101,6 +101,13 @@ codeunit 9106 "SharePoint File"
 
             if Payload.Get('type', JToken) then
                 SharePointFile.OdataType := CopyStr(JToken.AsValue().AsText(), 1, MaxStrLen(SharePointFile.OdataType));
+
+            OnAfterApplyMetadata(JToken, SharePointFile);
         end;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterApplyMetadata(JToken: JsonToken; var SharePointFile: Record "SharePoint File" temporary)
+    begin
     end;
 }

--- a/Modules/System/SharePoint/src/model/file/SharePointFile.Table.al
+++ b/Modules/System/SharePoint/src/model/file/SharePointFile.Table.al
@@ -14,7 +14,6 @@ table 9100 "SharePoint File"
     DataClassification = SystemMetadata; // Data classification is SystemMetadata as the table is temporary
     Caption = 'SharePoint File';
     TableType = Temporary;
-    Extensible = false;
 
     fields
     {

--- a/Modules/System/SharePoint/src/model/folder/SharePointFolder.Codeunit.al
+++ b/Modules/System/SharePoint/src/model/folder/SharePointFolder.Codeunit.al
@@ -99,6 +99,13 @@ codeunit 9105 "SharePoint Folder"
 
             if Payload.Get('type', JToken) then
                 SharePointFolder.OdataType := CopyStr(JToken.AsValue().AsText(), 1, MaxStrLen(SharePointFolder.OdataType));
+
+            OnAfterApplyMetadata(JToken, SharePointFolder);
         end;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterApplyMetadata(JToken: JsonToken; var SharePointFolder: Record "SharePoint Folder" temporary)
+    begin
     end;
 }

--- a/Modules/System/SharePoint/src/model/folder/SharePointFolder.Codeunit.al
+++ b/Modules/System/SharePoint/src/model/folder/SharePointFolder.Codeunit.al
@@ -100,12 +100,10 @@ codeunit 9105 "SharePoint Folder"
             if Payload.Get('type', JToken) then
                 SharePointFolder.OdataType := CopyStr(JToken.AsValue().AsText(), 1, MaxStrLen(SharePointFolder.OdataType));
 
-            OnAfterApplyMetadata(JToken, SharePointFolder);
+            SharepointEvents.OnAfterApplySharepointFolderMetadata(JToken, SharePointFolder);
         end;
     end;
 
-    [IntegrationEvent(false, false)]
-    local procedure OnAfterApplyMetadata(JToken: JsonToken; var SharePointFolder: Record "SharePoint Folder" temporary)
-    begin
-    end;
+    var
+        SharepointEvents: Codeunit "Sharepoint Events";
 }

--- a/Modules/System/SharePoint/src/model/folder/SharePointFolder.Table.al
+++ b/Modules/System/SharePoint/src/model/folder/SharePointFolder.Table.al
@@ -14,7 +14,6 @@ table 9106 "SharePoint Folder"
     DataClassification = SystemMetadata; // Data classification is SystemMetadata as the table is temporary
     Caption = 'SharePoint Folder';
     TableType = Temporary;
-    Extensible = false;
 
     fields
     {

--- a/Modules/System/SharePoint/src/model/list/SharePointList.Codeunit.al
+++ b/Modules/System/SharePoint/src/model/list/SharePointList.Codeunit.al
@@ -96,12 +96,10 @@ codeunit 9104 "SharePoint List"
             if Payload.Get('type', JToken) then
                 SharePointList.OdataType := CopyStr(JToken.AsValue().AsText(), 1, MaxStrLen(SharePointList.OdataType));
 
-            OnAfterApplyMetadata(JToken, SharePointList);
+            SharepointEvents.OnAfterApplySharepointListMetadata(JToken, SharePointList);
         end;
     end;
 
-    [IntegrationEvent(false, false)]
-    local procedure OnAfterApplyMetadata(JToken: JsonToken; var SharePointList: Record "SharePoint List" temporary)
-    begin
-    end;
+    var
+        SharepointEvents: Codeunit "Sharepoint Events";
 }

--- a/Modules/System/SharePoint/src/model/list/SharePointList.Codeunit.al
+++ b/Modules/System/SharePoint/src/model/list/SharePointList.Codeunit.al
@@ -95,6 +95,13 @@ codeunit 9104 "SharePoint List"
 
             if Payload.Get('type', JToken) then
                 SharePointList.OdataType := CopyStr(JToken.AsValue().AsText(), 1, MaxStrLen(SharePointList.OdataType));
+
+            OnAfterApplyMetadata(JToken, SharePointList);
         end;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterApplyMetadata(JToken: JsonToken; var SharePointList: Record "SharePoint List" temporary)
+    begin
     end;
 }

--- a/Modules/System/SharePoint/src/model/list/SharePointList.Table.al
+++ b/Modules/System/SharePoint/src/model/list/SharePointList.Table.al
@@ -14,7 +14,6 @@ table 9105 "SharePoint List"
     DataClassification = SystemMetadata; // Data classification is SystemMetadata as the table is temporary
     Caption = 'SharePoint List';
     TableType = Temporary;
-    Extensible = false;
 
     fields
     {

--- a/Modules/System/SharePoint/src/model/listitem/SharePointListItem.Codeunit.al
+++ b/Modules/System/SharePoint/src/model/listitem/SharePointListItem.Codeunit.al
@@ -83,7 +83,7 @@ codeunit 9103 "SharePoint List Item"
             if Payload.Get('uri', JToken) then
                 SharePointListItem.OdataEditLink := CopyStr(JToken.AsValue().AsText(), JToken.AsValue().AsText().IndexOf('Web/Lists'), MaxStrLen(SharePointListItem.OdataEditLink));
 
-            OnAfterApplyMetadata(JToken, SharePointListItem);
+            SharepointEvents.OnAfterApplySharepointListItemMetadata(JToken, SharePointListItem);
         end;
 
         if SharePointListItem.OdataEditLink <> '' then begin
@@ -93,8 +93,6 @@ codeunit 9103 "SharePoint List Item"
         end;
     end;
 
-    [IntegrationEvent(false, false)]
-    local procedure OnAfterApplyMetadata(JToken: JsonToken; var SharePointListItem: Record "SharePoint List Item" temporary)
-    begin
-    end;
+    var
+        SharepointEvents: Codeunit "Sharepoint Events";
 }

--- a/Modules/System/SharePoint/src/model/listitem/SharePointListItem.Codeunit.al
+++ b/Modules/System/SharePoint/src/model/listitem/SharePointListItem.Codeunit.al
@@ -82,6 +82,8 @@ codeunit 9103 "SharePoint List Item"
 
             if Payload.Get('uri', JToken) then
                 SharePointListItem.OdataEditLink := CopyStr(JToken.AsValue().AsText(), JToken.AsValue().AsText().IndexOf('Web/Lists'), MaxStrLen(SharePointListItem.OdataEditLink));
+
+            OnAfterApplyMetadata(JToken, SharePointListItem);
         end;
 
         if SharePointListItem.OdataEditLink <> '' then begin
@@ -89,5 +91,10 @@ codeunit 9103 "SharePoint List Item"
             //guid'854d7f21-1c6a-43ab-a081-20404894b449' -> 854d7f21-1c6a-43ab-a081-20404894b449
             SharePointListItem."List Id" := SharePointUriBuilder.GetMethodParameter('Lists').Substring(6, 36);
         end;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterApplyMetadata(JToken: JsonToken; var SharePointListItem: Record "SharePoint List Item" temporary)
+    begin
     end;
 }

--- a/Modules/System/SharePoint/src/model/listitem/SharePointListItem.Table.al
+++ b/Modules/System/SharePoint/src/model/listitem/SharePointListItem.Table.al
@@ -14,7 +14,6 @@ table 9103 "SharePoint List Item"
     DataClassification = SystemMetadata; // Data classification is SystemMetadata as the table is temporary
     Caption = 'SharePoint List Item';
     TableType = Temporary;
-    Extensible = false;
 
     fields
     {

--- a/Modules/System/SharePoint/src/model/listitemattachment/SharePointListItemAtch.Codeunit.al
+++ b/Modules/System/SharePoint/src/model/listitemattachment/SharePointListItemAtch.Codeunit.al
@@ -88,7 +88,7 @@ codeunit 9102 "SharePoint List Item Atch."
             if Payload.Get('type', JToken) then
                 SharePointListItemAttachment.OdataType := CopyStr(JToken.AsValue().AsText(), 1, MaxStrLen(SharePointListItemAttachment.OdataType));
 
-            OnAfterApplyMetadata(JToken, SharePointListItemAttachment);
+            SharepointEvents.OnAfterApplySharePointListItemAttachmentMetadata(JToken, SharePointListItemAttachment);
         end;
 
         if SharePointListItemAttachment.OdataEditLink <> '' then begin
@@ -99,8 +99,6 @@ codeunit 9102 "SharePoint List Item Atch."
         end;
     end;
 
-    [IntegrationEvent(false, false)]
-    local procedure OnAfterApplyMetadata(JToken: JsonToken; var SharePointListItemAttachment: Record "SharePoint List Item Atch" temporary)
-    begin
-    end;
+    var
+        SharepointEvents: Codeunit "Sharepoint Events";
 }

--- a/Modules/System/SharePoint/src/model/listitemattachment/SharePointListItemAtch.Codeunit.al
+++ b/Modules/System/SharePoint/src/model/listitemattachment/SharePointListItemAtch.Codeunit.al
@@ -87,6 +87,8 @@ codeunit 9102 "SharePoint List Item Atch."
 
             if Payload.Get('type', JToken) then
                 SharePointListItemAttachment.OdataType := CopyStr(JToken.AsValue().AsText(), 1, MaxStrLen(SharePointListItemAttachment.OdataType));
+
+            OnAfterApplyMetadata(JToken, SharePointListItemAttachment);
         end;
 
         if SharePointListItemAttachment.OdataEditLink <> '' then begin
@@ -95,5 +97,10 @@ codeunit 9102 "SharePoint List Item Atch."
             SharePointListItemAttachment."List Id" := SharePointUriBuilder.GetMethodParameter('Lists').Substring(6, 36);
             Evaluate(SharePointListItemAttachment."List Item Id", SharePointUriBuilder.GetMethodParameter('Items'));
         end;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterApplyMetadata(JToken: JsonToken; var SharePointListItemAttachment: Record "SharePoint List Item Atch" temporary)
+    begin
     end;
 }

--- a/Modules/System/SharePoint/src/model/listitemattachment/SharePointListItemAtch.Table.al
+++ b/Modules/System/SharePoint/src/model/listitemattachment/SharePointListItemAtch.Table.al
@@ -14,7 +14,6 @@ table 9104 "SharePoint List Item Atch"
     DataClassification = SystemMetadata; // Data classification is SystemMetadata as the table is temporary
     Caption = 'SharePoint List Item Attachment';
     TableType = Temporary;
-    Extensible = false;
 
     fields
     {


### PR DESCRIPTION
I intend to enhance the existing SharePoint connector by incorporating metadata functionality. 

I have implemented this enhancement by introducing new events and enabling extensibility in the tables. As a result, when establishing a connection, I can now seamlessly integrate my metadata fields into the appropriate tables and populate them with data through events in the "SharePoint Client" codeunit.