### PR TITLE
Allowed to set more Environment Infos in tests

### DIFF
--- a/Modules/System Test Libraries/Environment Information/src/EnvironmentInfoTestLibrary.Codeunit.al
+++ b/Modules/System Test Libraries/Environment Information/src/EnvironmentInfoTestLibrary.Codeunit.al
@@ -19,11 +19,24 @@ codeunit 135094 "Environment Info Test Library"
     /// This functions should only be used for testing purposes.
     /// </remarks>
     /// <param name="EnableSandboxForTest">The value to be set to the testability sandbox flag.</param>
-    [Scope('OnPrem')]
     procedure SetTestabilitySandbox(EnableSandboxForTest: Boolean)
     begin
+        EnvironmentInformationImpl.SetTestMode(true);
         EnvironmentInformationImpl.SetTestabilitySandbox(EnableSandboxForTest);
     end;
+
+    /// <summary>
+    /// Sets the test mode flag.
+    /// </summary>
+    /// <remarks>
+    /// This functions should only be used for testing purposes.
+    /// </remarks>
+    /// <param name="EnableTests">The value to be set to the test flag.</param>
+    procedure SetTestability(EnableTests: Boolean)
+    begin
+        EnvironmentInformationImpl.SetTestMode(EnableTests);
+    end;
+
 
     /// <summary>
     /// Sets the testability SaaS flag.
@@ -32,17 +45,37 @@ codeunit 135094 "Environment Info Test Library"
     /// This functions should only be used for testing purposes.
     /// </remarks>
     /// <param name="EnableSoftwareAsAServiceForTest">The value to be set to the testability SaaS flag.</param>
-    [Scope('OnPrem')]
     procedure SetTestabilitySoftwareAsAService(EnableSoftwareAsAServiceForTest: Boolean)
     begin
+        EnvironmentInformationImpl.SetTestMode(true);
         EnvironmentInformationImpl.SetTestabilitySoftwareAsAService(EnableSoftwareAsAServiceForTest);
+    end;
+
+    /// <summary>
+    /// Sets the App ID that of the current application (for example, 'FIN' - Financials).
+    /// </summary>
+    /// <param name="NewAppId">The desired new App ID.</param>
+    procedure SetTestabilityAppId(NewAppId: Text)
+    begin
+        EnvironmentInformationImpl.SetTestMode(true);
+        EnvironmentInformationImpl.SetTestabilityAppId(NewAppId);
+    end;
+
+    /// <summary>
+    /// Sets the Environment Name that of the current Environment.
+    /// </summary>
+    /// <param name="NewEnvironmentName">The desired new Environment Name.</param>
+    procedure SetTestabilityEn(NewEnvironmentName: Text)
+    begin
+        EnvironmentInformationImpl.SetTestMode(true);
+        EnvironmentInformationImpl.SetTestabilityEnvironmentName(NewEnvironmentName);
     end;
 
     /// <summary>
     /// Sets the App ID that of the current application (for example, 'FIN' - Financials) when the sunscription is bound.
     /// Uses <see cref="OnBeforeGetApplicationIdentifier"/> event.
     /// </summary>
-    /// <param name="NewAppId">The desired ne App ID.</param>
+    /// <param name="NewAppId">The desired new App ID.</param>
     [Scope('OnPrem')]
     procedure SetAppId(NewAppId: Text)
     begin

--- a/Modules/System Test Libraries/Environment Information/src/EnvironmentInfoTestLibrary.Codeunit.al
+++ b/Modules/System Test Libraries/Environment Information/src/EnvironmentInfoTestLibrary.Codeunit.al
@@ -65,7 +65,7 @@ codeunit 135094 "Environment Info Test Library"
     /// Sets the Environment Name that of the current Environment.
     /// </summary>
     /// <param name="NewEnvironmentName">The desired new Environment Name.</param>
-    procedure SetTestabilityEn(NewEnvironmentName: Text)
+    procedure SetTestabilityEnvironmentName(NewEnvironmentName: Text)
     begin
         EnvironmentInformationImpl.SetTestMode(true);
         EnvironmentInformationImpl.SetTestabilityEnvironmentName(NewEnvironmentName);

--- a/Modules/System Tests/Environment Information/src/EnvironmentInformationTest.Codeunit.al
+++ b/Modules/System Tests/Environment Information/src/EnvironmentInformationTest.Codeunit.al
@@ -14,7 +14,6 @@ codeunit 135091 "Environment Information Test"
         EnvironmentInfoTestLibrary: Codeunit "Environment Info Test Library";
 
     [Test]
-    [Scope('OnPrem')]
     procedure TestCanStartSessionWithTestIsolationEnabled()
     begin
         // [Scenario] When running the tests with the test isolation enabled (the default), CanStartSession returns false.
@@ -24,7 +23,6 @@ codeunit 135091 "Environment Information Test"
     end;
 
     [Test]
-    [Scope('OnPrem')]
     procedure TestIsSandboxIsTrueWhenTestabilitySandboxIsSet()
     begin
         // [Scenario] Set the testability to true. IsSandBox returns correct values.
@@ -38,7 +36,6 @@ codeunit 135091 "Environment Information Test"
     end;
 
     [Test]
-    [Scope('OnPrem')]
     procedure TestIsSandboxIsFalseWhenTestabilitySandboxIsNotSet()
     begin
         // [Scenario] Set the testability to false. IsSandBox returns correct values.
@@ -52,8 +49,20 @@ codeunit 135091 "Environment Information Test"
     end;
 
     [Test]
-    [Scope('OnPrem')]
-    procedure TestIsSaaSIsTrueWhenTestabilitySaaSIsSet()
+    procedure TestIsSandboxIsFalseWhenTestabilitySandboxIsNotSet()
+    begin
+        // [Scenario] Set the testability to false. IsSandBox returns correct values.
+
+        // [Given] Set the testability sandbox to false
+        EnvironmentInfoTestLibrary.SetTestability(false);
+
+        // [When] Poll for IsSandbox
+        // [Then] Should return false
+        Assert.IsFalse(EnvironmentInformation.IsSandbox(), 'Testability should have dictacted a non-sandbox environment');
+    end;
+
+    [Test]
+    procedure TestIsSaaSIsTrueWhenTestabilitySaaSIsSetTrue()
     begin
         // [SCENARIO] Set the testability to true. IsSaaS returns correct values.
 
@@ -66,13 +75,25 @@ codeunit 135091 "Environment Information Test"
     end;
 
     [Test]
-    [Scope('OnPrem')]
-    procedure TestIsSaaSIsFalseWhenTestabilitySaaSIsNotSet()
+    procedure TestIsSaaSIsFalseWhenTestabilitySaaSIsSetFalse()
     begin
-        // [SCENARIO] Set the testability to false. IsSaaS returns correct values.
+        // [SCENARIO] Set the testability to false. IsSaaS returns false.
 
         // [Given] Set the testability SaaS to false
         EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(false);
+
+        // [When] Poll for IsSaaS
+        // [Then] Should return false
+        Assert.IsFalse(EnvironmentInformation.IsSaaS(), 'Testability should have dictacted a non- SaaS environment');
+    end;
+
+    [Test]
+    procedure TestIsSaaSIsFalseWhenTestabilitySaaSIsNotSet()
+    begin
+        // [SCENARIO] Set the testability to false. IsSaaS returns false.
+
+        // [Given] Set the testability SaaS to false
+        EnvironmentInfoTestLibrary.SetTestability(false);
 
         // [When] Poll for IsSaaS
         // [Then] Should return false

--- a/Modules/System Tests/Environment Information/src/EnvironmentInformationTest.Codeunit.al
+++ b/Modules/System Tests/Environment Information/src/EnvironmentInformationTest.Codeunit.al
@@ -23,7 +23,7 @@ codeunit 135091 "Environment Information Test"
     end;
 
     [Test]
-    procedure TestIsSandboxIsTrueWhenTestabilitySandboxIsSet()
+    procedure TestIsSandboxIsTrueWhenTestabilitySandboxIsSetTrue()
     begin
         // [Scenario] Set the testability to true. IsSandBox returns correct values.
 
@@ -36,7 +36,7 @@ codeunit 135091 "Environment Information Test"
     end;
 
     [Test]
-    procedure TestIsSandboxIsFalseWhenTestabilitySandboxIsNotSet()
+    procedure TestIsSandboxIsFalseWhenTestabilitySandboxIsSetFalse()
     begin
         // [Scenario] Set the testability to false. IsSandBox returns correct values.
 

--- a/Modules/System/Environment Information/src/EnvironmentInformationImpl.Codeunit.al
+++ b/Modules/System/Environment Information/src/EnvironmentInformationImpl.Codeunit.al
@@ -14,6 +14,9 @@ codeunit 3702 "Environment Information Impl."
         NavTenantSettingsHelper: DotNet NavTenantSettingsHelper;
         TestabilitySoftwareAsAService: Boolean;
         TestabilitySandbox: Boolean;
+        TestabilityAppId: Text;
+        TestabilityEnvironmentName: Text;
+        TestMode: Boolean;
         IsSaasInitialized: Boolean;
         IsSaaSConfig: Boolean;
         IsSandboxConfig: Boolean;
@@ -28,8 +31,8 @@ codeunit 3702 "Environment Information Impl."
 
     procedure IsSandbox(): Boolean
     begin
-        if TestabilitySandbox then
-            exit(true);
+        if TestMode then
+            exit(TestabilitySandbox);
 
         if not IsSandboxInitialized then begin
             IsSandboxConfig := NavTenantSettingsHelper.IsSandbox();
@@ -42,6 +45,9 @@ codeunit 3702 "Environment Information Impl."
     var
         EnvironmentName: Text;
     begin
+        If TestMode then
+            exit(TestabilityEnvironmentName);
+
         EnvironmentName := NavTenantSettingsHelper.GetEnvironmentName();
         if EnvironmentName <> '' then
             exit(EnvironmentName);
@@ -62,12 +68,27 @@ codeunit 3702 "Environment Information Impl."
         TestabilitySoftwareAsAService := EnableSoftwareAsAServiceForTest;
     end;
 
+    procedure SetTestabilityAppId(AppId: Text)
+    begin
+        TestabilityAppId := AppId;
+    end;
+
+    procedure SetTestabilityEnvironmentName(Name: Text)
+    begin
+        TestabilityEnvironmentName := Name;
+    end;
+
+    procedure SetTestMode(Mode: Boolean)
+    begin
+        TestMode := Mode;
+    end;
+
     procedure IsSaaS(): Boolean
     var
         ServerSettings: Codeunit "Server Setting";
     begin
-        if TestabilitySoftwareAsAService then
-            exit(true);
+        if TestMode then
+            exit(TestabilitySoftwareAsAService);
 
         if not IsSaasInitialized then begin
             IsSaaSConfig := IsSandbox() or ServerSettings.GetEnableMembershipEntitlement();
@@ -81,8 +102,8 @@ codeunit 3702 "Environment Information Impl."
     var
         UserAccountHelper: DotNet NavUserAccountHelper;
     begin
-        if TestabilitySoftwareAsAService then
-            exit(true);
+        if TestMode then
+            exit(TestabilitySoftwareAsAService);
 
         exit(IsSaaS() and UserAccountHelper.IsAzure());
     end;
@@ -133,6 +154,9 @@ codeunit 3702 "Environment Information Impl."
 
     local procedure GetAppId() AppId: Text
     begin
+        if TestMode then
+            exit(TestabilityAppId);
+
         OnBeforeGetApplicationIdentifier(AppId);
         if AppId = '' then
             AppId := ApplicationIdentifier();


### PR DESCRIPTION
This PR allows the developer to set AppId and EnvironmentName.

It also adds the ability to set IsSaaS and IsSandbox to false instead of setting it to true or not setting it. 