### PR TITLE
Shopify allow use of customer creation and update

### DIFF
--- a/Apps/W1/Shopify/app/src/Customer/Codeunits/ShpfyCreateCustomer.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Customer/Codeunits/ShpfyCreateCustomer.Codeunit.al
@@ -3,7 +3,6 @@
 /// </summary>
 codeunit 30110 "Shpfy Create Customer"
 {
-    Access = Internal;
     Permissions =
 #if not CLEAN22
         tabledata "Config. Template Header" = r,
@@ -171,7 +170,7 @@ codeunit 30110 "Shpfy Create Customer"
     /// Set Shop.
     /// </summary>
     /// <param name="Code">Parameter of type Code[20].</param>
-    internal procedure SetShop(Code: Code[20])
+    procedure SetShop(Code: Code[20])
     begin
         Clear(Shop);
         Shop.Get(Code);
@@ -181,7 +180,7 @@ codeunit 30110 "Shpfy Create Customer"
     /// Set Shop.
     /// </summary>
     /// <param name="ShopifyShop">Parameter of type Record "Shopify Shop".</param>
-    internal procedure SetShop(ShopifyShop: Record "Shpfy Shop")
+    procedure SetShop(ShopifyShop: Record "Shpfy Shop")
     begin
         Shop := ShopifyShop;
     end;
@@ -190,7 +189,7 @@ codeunit 30110 "Shpfy Create Customer"
     /// Set Template Code.
     /// </summary>
     /// <param name="Code">Parameter of type Code[20].</param>
-    internal procedure SetTemplateCode(Code: Code[20])
+    procedure SetTemplateCode(Code: Code[20])
     begin
         TemplateCode := Code;
     end;

--- a/Apps/W1/Shopify/app/src/Customer/Codeunits/ShpfyCustomerImport.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Customer/Codeunits/ShpfyCustomerImport.Codeunit.al
@@ -3,8 +3,6 @@
 /// </summary>
 codeunit 30117 "Shpfy Customer Import"
 {
-    Access = Internal;
-
     trigger OnRun()
     var
         CustomerAddress: Record "Shpfy Customer Address";
@@ -49,12 +47,12 @@ codeunit 30117 "Shpfy Customer Import"
     /// Get Customer.
     /// </summary>
     /// <param name="ShopifyCustomerResult">Parameter of type Record "Shopify Customer".</param>
-    internal procedure GetCustomer(var ShopifyCustomerResult: Record "Shpfy Customer")
+    procedure GetCustomer(var ShopifyCustomerResult: Record "Shpfy Customer")
     begin
         ShopifyCustomerResult := ShopifyCustomer;
     end;
 
-    internal procedure SetAllowCreate(Value: Boolean)
+    procedure SetAllowCreate(Value: Boolean)
     begin
         AllowCreate := Value;
     end;
@@ -63,7 +61,7 @@ codeunit 30117 "Shpfy Customer Import"
     /// Set Customer.
     /// </summary>
     /// <param name="Id">Parameter of type BigInteger.</param>
-    internal procedure SetCustomer(Id: BigInteger)
+    procedure SetCustomer(Id: BigInteger)
     begin
         if Id <> 0 then begin
             Clear(ShopifyCustomer);
@@ -82,7 +80,7 @@ codeunit 30117 "Shpfy Customer Import"
     /// Set Customer.
     /// </summary>
     /// <param name="ShopifyCustomer">Parameter of type Record "Shopify Customer".</param>
-    internal procedure SetCustomer(ShopifyCustomer: Record "Shpfy Customer")
+    procedure SetCustomer(ShopifyCustomer: Record "Shpfy Customer")
     begin
         SetCustomer(ShopifyCustomer.Id);
     end;
@@ -91,7 +89,7 @@ codeunit 30117 "Shpfy Customer Import"
     /// Set Shop.
     /// </summary>
     /// <param name="Code">Parameter of type Code[20].</param>
-    internal procedure SetShop(Code: Code[20])
+    procedure SetShop(Code: Code[20])
     begin
         Clear(Shop);
         Shop.Get(Code);
@@ -102,7 +100,7 @@ codeunit 30117 "Shpfy Customer Import"
     /// Set Shop.
     /// </summary>
     /// <param name="ShopifyShop">Parameter of type Record "Shopify Shop".</param>
-    internal procedure SetShop(ShopifyShop: Record "Shpfy Shop")
+    procedure SetShop(ShopifyShop: Record "Shpfy Shop")
     begin
         Shop := ShopifyShop;
         CustomerApi.SetShop(Shop);
@@ -112,7 +110,7 @@ codeunit 30117 "Shpfy Customer Import"
     /// Set Template Code.
     /// </summary>
     /// <param name="Code">Parameter of type Code[10].</param>
-    internal procedure SetTemplateCode(Code: Code[10])
+    procedure SetTemplateCode(Code: Code[10])
     begin
         TemplateCode := Code;
     end;

--- a/Apps/W1/Shopify/app/src/Customer/Codeunits/ShpfyUpdateCustomer.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Customer/Codeunits/ShpfyUpdateCustomer.Codeunit.al
@@ -3,7 +3,6 @@
 /// </summary>
 codeunit 30124 "Shpfy Update Customer"
 {
-    Access = Internal;
     Permissions =
 #if not CLEAN22
         tabledata "Config. Template Header" = r,


### PR DESCRIPTION
We would like to make a custom mapping with different fields to identify existing customers and decide based on them to create a new customer from a shopify customer.

Since the enum "Shpfy Customer Mapping" is extensible we thought this should be possible,
Unfortunately the codeunits for creating and updating customers are only accessible internally and there is no other interface to change a customer based on shopify data.

We would like to avoid writing our own Create Customer and Update Customer codeunits just because they are only internal allowed. From our point of view there is no particular reason to not allow these codeunits to be used by an extension.

If we understood the usage of a codeunit wrong I would accept any clarification.
Thank you in advance.