### PR TITLE
Add OnBeforeSearchTable publisher for "Search in company data" feature

### DIFF
--- a/Apps/W1/DataSearch/App/DataSearchEvents.codeunit.al
+++ b/Apps/W1/DataSearch/App/DataSearchEvents.codeunit.al
@@ -88,4 +88,13 @@ codeunit 2682 "Data Search Events"
     procedure OnGetExcludedRelatedTableField(RelatedTableNo: Integer; var IsExcluded: Boolean)
     begin
     end;
+
+    /// <summary>
+    /// Allows the addition of additional filters for the specified <paramref name="RecordRef"/> during the search.
+    /// </summary>
+    /// <param name="RecordRef">The record on which the search is being conducted.</param>
+    [IntegrationEvent(false, false)]
+    procedure OnBeforeSearchTable(var RecordRef: RecordRef)
+    begin
+    end;
 }

--- a/Apps/W1/DataSearch/App/DataSearchInTable.codeunit.al
+++ b/Apps/W1/DataSearch/App/DataSearchInTable.codeunit.al
@@ -128,7 +128,7 @@ codeunit 2680 "Data Search in Table"
     local procedure SetTypeFilterOnRecRef(var RecRef: RecordRef; TableType: Integer; FieldNo: Integer)
     var
         FldRef: FieldRef;
-    begin 
+    begin
         if not RecRef.FieldExist(FieldNo) then
             exit;
         FldRef := RecRef.Field(FieldNo);
@@ -148,7 +148,7 @@ codeunit 2680 "Data Search in Table"
         case RecRef.Number of
             Database::"Sales Header", Database::"Sales Line",
             Database::"Purchase Header", Database::"Purchase Line",
-            Database::"Service Header",  Database::"Service Line",
+            Database::"Service Header", Database::"Service Line",
             Database::"Service Contract Line":
                 FieldNo := 1;
             Database::"Service Item Line":
@@ -185,6 +185,7 @@ codeunit 2680 "Data Search in Table"
 
     local procedure SearchTable(TableNo: Integer; TableType: Integer; var FieldList: List of [Integer]; var SearchStrings: List of [Text]; var Results: Dictionary of [Text, Text])
     var
+        DataSearchEvents: Codeunit "Data Search Events";
         [SecurityFiltering(SecurityFilter::Filtered)]
         RecRef: RecordRef;
         FldRef: FieldRef;
@@ -204,6 +205,7 @@ codeunit 2680 "Data Search in Table"
         FldRef := RecRef.Field(RecRef.SystemModifiedAtNo);
         RecRef.SetView(StrSubstNo(SetViewLbl, FldRef.Name));
         SetListedFieldFiltersOnRecRef(RecRef, TableType, SearchString1, UseTextSearch, FieldList);
+        DataSearchEvents.OnBeforeSearchTable(RecRef);
         if RecRef.FindSet() then
             repeat
                 FldRef := RecRef.Field(RecRef.SystemIdNo);


### PR DESCRIPTION
**Issue Description**

The "Search in company data" feature lacks the possibility to filter the results shown to the user.

There are some scenarios where displaying every single record that contains a given **Search String** is not desirable.

While "security filters" are included in the "Data Search," they may be insufficient if you have requirements to manage access to specific tables on a record level for multiple users in various scenarios. In some cases, this would require a consultant to create a separate permission set for each user and thats obviously a lot of effort.

**Solution**

This PR introduces new ```OnBeforeSearchTable``` publisher, which allows to prefilter the ```RecRef``` that is used for searching for the ```SearchString```.