### PR TITLE
Removed access internal

### DIFF
--- a/Modules/System/Word Templates/src/WordTemplatesRelatedTable.Table.al
+++ b/Modules/System/Word Templates/src/WordTemplatesRelatedTable.Table.al
@@ -12,7 +12,6 @@ using System.Reflection;
 /// </summary>
 table 9990 "Word Templates Related Table"
 {
-    Access = Internal;
     Extensible = false;
     InherentEntitlements = X;
     InherentPermissions = X;


### PR DESCRIPTION
Hi,

This change allows developers to reference to the "Word Templates Related Table" table object within their own code. 

Without the internal access we are able to transfer word templates with all the related data we need between multiple environments and up to 300 companies per environment. 

Please also note the Yammer conversation between Lorenz Roth and @JesperSchulz : https://www.yammer.com/dynamicsnavdev/#/Threads/show?threadId=1520243730882560