### PR TITLE
Add modify permissions to "Recurrence Schedule"

### DIFF
--- a/Modules/System/Recurrence Schedule/src/RecurrenceScheduleImpl.Codeunit.al
+++ b/Modules/System/Recurrence Schedule/src/RecurrenceScheduleImpl.Codeunit.al
@@ -13,7 +13,7 @@ codeunit 4691 "Recurrence Schedule Impl."
     InherentEntitlements = X;
     InherentPermissions = X;
     Permissions = tabledata Date = r,
-                  tabledata "Recurrence Schedule" = ri;
+                  tabledata "Recurrence Schedule" = rim;
 
     var
         MinDateTime: DateTime;


### PR DESCRIPTION
When trying to show a recurrence schedule (and make some changes to it), follow error is raised when closing the `Recurrence Schedule Card`.

![image](https://github.com/microsoft/ALAppExtensions/assets/25268332/7baa228d-951c-4383-a7db-de40f1381cc7)

---

**CallStack**
"Recurrence Schedule Impl."(CodeUnit 4691).**OpenRecurrenceSchedule** line 20 - System Application by Microsoft
"Recurrence Schedule"(CodeUnit 4690).OpenRecurrenceSchedule line 2 - System Application by Microsoft
"ESCA Recurrence Schedule"(Table 71096653).ShowRecurrenceSchedule line 12 - Dynavision Core by Dynavision

---

**Source of the problem**

![image](https://github.com/microsoft/ALAppExtensions/assets/25268332/1d79ffd7-d4b6-4a34-a317-261dae2f9bdd)

---

**Solution**

- Added `modify` permissions on the implementation codeunit