### PR TITLE
[Extensibility enhancements]No max duration on test suite

### DIFF
--- a/Modules/DevTools/BusinessCentralPerformanceToolkit/src/BCPTHeader.Table.al
+++ b/Modules/DevTools/BusinessCentralPerformanceToolkit/src/BCPTHeader.Table.al
@@ -28,8 +28,7 @@ table 149000 "BCPT Header"
         {
             Caption = 'Duration (minutes)';
             InitValue = 1;
-            MinValue = 1;
-            MaxValue = 240; // 4 hrs
+            MinValue = 1;            
         }
         field(4; Status; Enum "BCPT Header Status")
         {


### PR DESCRIPTION
According to:
![image](https://github.com/microsoft/ALAppExtensions/assets/34970096/87fea3a4-94a3-409a-b0ea-6ec2f0497f38)
https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-performance-toolkit#using-bcpt-to-produce-a-large-test-database

We can use BCPT to create big databases with test data. This setting is preventing just that since it had max time of 4 hours to run the test suite.