### PR TITLE
use "if" "then" with get for posted document when calling e-document subscriptions

### DIFF
--- a/Apps/W1/EDocument/app/src/Processing/EDocumentSubscription.Codeunit.al
+++ b/Apps/W1/EDocument/app/src/Processing/EDocumentSubscription.Codeunit.al
@@ -88,11 +88,11 @@ codeunit 6103 "E-Document Subscription"
             exit;
 
         if SalesInvHdrNo <> '' then begin
-            SalesInvHeader.Get(SalesInvHdrNo);
-            RunEDocumentCreation(SalesHeader, SalesInvHeader, SalesInvHdrNo);
+            if SalesInvHeader.Get(SalesInvHdrNo) then
+                RunEDocumentCreation(SalesHeader, SalesInvHeader, SalesInvHdrNo);
         end else begin
-            SalesCrMemoHeader.Get(SalesCrMemoHdrNo);
-            RunEDocumentCreation(SalesHeader, SalesCrMemoHeader, SalesCrMemoHdrNo);
+            if SalesCrMemoHeader.Get(SalesCrMemoHdrNo) then
+                RunEDocumentCreation(SalesHeader, SalesCrMemoHeader, SalesCrMemoHdrNo);
         end;
     end;
 
@@ -106,11 +106,11 @@ codeunit 6103 "E-Document Subscription"
             exit;
 
         if PurchInvHdrNo <> '' then begin
-            PurchInvHeader.Get(PurchInvHdrNo);
-            RunEDocumentCreation(PurchaseHeader, PurchInvHeader, PurchInvHdrNo);
+            if PurchInvHeader.Get(PurchInvHdrNo) then
+                RunEDocumentCreation(PurchaseHeader, PurchInvHeader, PurchInvHdrNo);
         end else begin
-            PurchCrMemoHdr.Get(PurchCrMemoHdrNo);
-            RunEDocumentCreation(PurchaseHeader, PurchCrMemoHdr, PurchCrMemoHdrNo);
+            if PurchCrMemoHdr.Get(PurchCrMemoHdrNo) then
+                RunEDocumentCreation(PurchaseHeader, PurchCrMemoHdr, PurchCrMemoHdrNo);
         end;
     end;
 
@@ -124,11 +124,11 @@ codeunit 6103 "E-Document Subscription"
             exit;
 
         if ServInvoiceNo <> '' then begin
-            ServiceInvoiceHeader.Get(ServInvoiceNo);
-            RunEDocumentCreation(ServiceHeader, ServiceInvoiceHeader, ServInvoiceNo);
+            if ServiceInvoiceHeader.Get(ServInvoiceNo) then
+                RunEDocumentCreation(ServiceHeader, ServiceInvoiceHeader, ServInvoiceNo);
         end else begin
-            ServiceCrMemoHdr.Get(ServCrMemoNo);
-            RunEDocumentCreation(ServiceHeader, ServiceCrMemoHdr, ServCrMemoNo);
+            if ServiceCrMemoHdr.Get(ServCrMemoNo) then
+                RunEDocumentCreation(ServiceHeader, ServiceCrMemoHdr, ServCrMemoNo);
         end;
     end;
 
@@ -139,8 +139,8 @@ codeunit 6103 "E-Document Subscription"
     begin
         if IssuedFinChargeMemoNo = '' then
             exit;
-        IssuedFinChrgMemoHeader.Get(IssuedFinChargeMemoNo);
-        RunEDocumentCreation(FinChargeMemoHeader, IssuedFinChrgMemoHeader, IssuedFinChargeMemoNo);
+        if IssuedFinChrgMemoHeader.Get(IssuedFinChargeMemoNo) then
+            RunEDocumentCreation(FinChargeMemoHeader, IssuedFinChrgMemoHeader, IssuedFinChargeMemoNo);
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Reminder-Issue", 'OnAfterIssueReminder', '', false, false)]
@@ -150,8 +150,8 @@ codeunit 6103 "E-Document Subscription"
     begin
         if IssuedReminderNo = '' then
             exit;
-        IssuedReminderHeader.Get(IssuedReminderNo);
-        RunEDocumentCreation(ReminderHeader, IssuedReminderHeader, IssuedReminderNo);
+        if IssuedReminderHeader.Get(IssuedReminderNo) then
+            RunEDocumentCreation(ReminderHeader, IssuedReminderHeader, IssuedReminderNo);
     end;
 
     [EventSubscriber(ObjectType::Table, Database::"Document Sending Profile", 'OnCheckElectronicSendingEnabled', '', false, false)]


### PR DESCRIPTION
In our BG localization we have a functionality based on Bulgarian legislation that allows to void a posting document. Therefore, during voiding, the header of an posted document is deleted, which is taken with GET without checking in the e-document app. For now we remove e-document for our customers to work with our localization. Please change the code i think it will not cause errors.<br /><br />Internal work item: AB#492530