### PR TITLE
BCHybrid / Cloudmifration failure codeunit should not create an error

### DIFF
--- a/Apps/W1/HybridBaseDeployment/app/src/codeunits/cod4012.HandleCreateCompanyICFailure.al
+++ b/Apps/W1/HybridBaseDeployment/app/src/codeunits/cod4012.HandleCreateCompanyICFailure.al
@@ -7,7 +7,6 @@ codeunit 4012 "Handle Create Company Failure"
     begin
         ErrorMessage := GetLastErrorText();
         UpdateIntelligentCloudSetup(ErrorMessage);
-        Error(CompanyCreationFailedErr, ErrorMessage);
     end;
 
     procedure UpdateIntelligentCloudSetup(ErrorMessage: Text)
@@ -22,7 +21,4 @@ codeunit 4012 "Handle Create Company Failure"
                 Commit();
             end;
     end;
-
-    var
-        CompanyCreationFailedErr: Label 'Failed to create company for the Data Migration setup.\\\\%1', Comment = '%1 - Error message';
 }


### PR DESCRIPTION
The Create Company Failure Codeunit has an error at the end. This results in 100 retries of the failure codeunit which results in multiple hours not being able to restart migration.<br /><br />Internal work item: AB#492571