### PR TITLE
Correct filtering by using SetRange instead of SetFilter.

### DIFF
--- a/Apps/W1/DynamicsGPHistoricalData/app/src/Pages/HistPayablesDocuments.Page.al
+++ b/Apps/W1/DynamicsGPHistoricalData/app/src/Pages/HistPayablesDocuments.Page.al
@@ -187,10 +187,10 @@ page 41017 "Hist. Payables Documents"
     trigger OnOpenPage()
     begin
         if FilterAuditCode <> '' then
-            Rec.SetFilter("Audit Code", FilterAuditCode);
+            Rec.SetRange("Audit Code", FilterAuditCode);
 
         if FilterVendorNo <> '' then
-            Rec.SetFilter("Vendor No.", FilterVendorNo);
+            Rec.SetRange("Vendor No.", FilterVendorNo);
     end;
 
     procedure SetFilterAuditCode(AuditCode: Code[35])

--- a/Apps/W1/DynamicsGPHistoricalData/app/src/Pages/HistPurchaseRecvHeaders.Page.al
+++ b/Apps/W1/DynamicsGPHistoricalData/app/src/Pages/HistPurchaseRecvHeaders.Page.al
@@ -172,7 +172,7 @@ page 41014 "Hist. Purchase Recv. Headers"
     trigger OnOpenPage()
     begin
         if FilterVendorNo <> '' then
-            Rec.SetFilter("Vendor No.", FilterVendorNo);
+            Rec.SetRange("Vendor No.", FilterVendorNo);
     end;
 
     procedure SetFilterVendorNo(VendorNo: Code[35])

--- a/Apps/W1/DynamicsGPHistoricalData/app/src/Pages/HistReceivablesDocuments.Page.al
+++ b/Apps/W1/DynamicsGPHistoricalData/app/src/Pages/HistReceivablesDocuments.Page.al
@@ -177,7 +177,7 @@ page 41016 "Hist. Receivables Documents"
     trigger OnOpenPage()
     begin
         if FilterCustomerNo <> '' then
-            Rec.SetFilter("Customer No.", FilterCustomerNo);
+            Rec.SetRange("Customer No.", FilterCustomerNo);
     end;
 
     procedure SetFilterCustomerNo(CustomerNo: Code[35])

--- a/Apps/W1/DynamicsGPHistoricalData/app/src/Pages/HistSalesTrxHeaders.Page.al
+++ b/Apps/W1/DynamicsGPHistoricalData/app/src/Pages/HistSalesTrxHeaders.Page.al
@@ -187,7 +187,7 @@ page 41002 "Hist. Sales Trx. Headers"
     trigger OnOpenPage()
     begin
         if FilterCustomerNo <> '' then
-            Rec.SetFilter("Customer No.", FilterCustomerNo);
+            Rec.SetRange("Customer No.", FilterCustomerNo);
     end;
 
     procedure SetFilterCustomerNo(CustomerNo: Code[35])


### PR DESCRIPTION
This change corrects filtering for some of the history pages. Filters were broken for Customers/Vendors that had an & symbol in their No. field.
Fixes #26487
Fixes [AB#537204](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/537204)
