### PR TITLE
[Shopify] Integration to use Sales Unit of Measure for inventory synchronization

### DIFF
--- a/Apps/W1/Shopify/app/src/Inventory/Codeunits/ShpfyInventoryAPI.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Inventory/Codeunits/ShpfyInventoryAPI.Codeunit.al
@@ -33,6 +33,7 @@ codeunit 30195 "Shpfy Inventory API"
         ShopifyVariant: Record "Shpfy Variant";
         StockCalculation: Interface "Shpfy Stock Calculation";
         UOM: Code[10];
+        SalesUOM: Code[10];
     begin
         SetShop(ShopInventory."Shop Code");
         if ShopifyProduct.Get(ShopInventory."Product Id") and ShopifyVariant.Get(ShopInventory."Variant Id") then begin
@@ -48,6 +49,7 @@ codeunit 30195 "Shpfy Inventory API"
             end;
 
             StockCalculationFactory(StockCalculation, ShopLocation."Stock Calculation");
+            SalesUOM := Item."Sales Unit of Measure";
             Stock := StockCalculation.GetStock(Item);
 
             case ShopifyVariant."UoM Option Id" of
@@ -58,7 +60,7 @@ codeunit 30195 "Shpfy Inventory API"
                 3:
                     UOM := CopyStr(ShopifyVariant."Option 3 Value", 1, MaxStrLen(UOM));
                 else
-                    UOM := Item."Sales Unit of Measure";
+                    UOM := SalesUOM;
             end;
             if (UOM <> '') and (UOM <> Item."Base Unit of Measure") then
                 if ItemUnitofMeasure.Get(Item."No.", UOM) then


### PR DESCRIPTION
This pull request does not have a related issue as it's part of delivery for development agreed directly with @AndreiPanko 

Quick summary:

We saw that the Sales Unit of Measure should be used for inventory synchronization but there is a bug that prevents it from doing it. In line 61, Item.???Sales Unit Of Measure??? will always be empty, because in the function in line 51, it is cleared. It means that if the statement in line 63 never is true, the Base Unit of Measure will always be used for inventory synchronization.

Fixes #26719
Fixes [AB#539103](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/539103)
