### PR TITLE
[Shopify] Connector - Different shipping charges types

### DIFF
--- a/Apps/W1/Shopify/app/src/Order handling/Codeunits/ShpfyOrderEvents.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Order handling/Codeunits/ShpfyOrderEvents.Codeunit.al
@@ -80,6 +80,25 @@ codeunit 30162 "Shpfy Order Events"
 
     [IntegrationEvent(false, false)]
     /// <summary> 
+    /// Description for OnBeforeMapShipmentAgent.
+    /// </summary>
+    /// <param name="ShopifyOrderHeader">Parameter of type Record "Shopify Order Header".</param>
+    /// <param name="Handled">Parameter of type Boolean.</param>
+    internal procedure OnBeforeMapShipmentAgent(var ShopifyOrderHeader: Record "Shpfy Order Header"; var Handled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    /// <summary> 
+    /// Description for OnAfterMapShipmentAgent.
+    /// </summary>
+    /// <param name="ShopifyOrderHeader">Parameter of type Record "Shopify Order Header".</param>
+    internal procedure OnAfterMapShipmentAgent(var ShopifyOrderHeader: Record "Shpfy Order Header")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    /// <summary> 
     /// Description for OnBeforeMapPaymentMethod.
     /// </summary>
     /// <param name="ShopifyOrderHeader">Parameter of type Record "Shopify Order Header".</param>

--- a/Apps/W1/Shopify/app/src/Order handling/Codeunits/ShpfyOrderMapping.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Order handling/Codeunits/ShpfyOrderMapping.Codeunit.al
@@ -1,7 +1,6 @@
 namespace Microsoft.Integration.Shopify;
 
 using Microsoft.Inventory.Item;
-using Microsoft.Sales.Document;
 using Microsoft.CRM.Contact;
 using Microsoft.CRM.BusinessRelation;
 

--- a/Apps/W1/Shopify/app/src/Order handling/Codeunits/ShpfyOrderMapping.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Order handling/Codeunits/ShpfyOrderMapping.Codeunit.al
@@ -1,6 +1,7 @@
 namespace Microsoft.Integration.Shopify;
 
 using Microsoft.Inventory.Item;
+using Microsoft.Sales.Document;
 using Microsoft.CRM.Contact;
 using Microsoft.CRM.BusinessRelation;
 
@@ -127,6 +128,7 @@ codeunit 30163 "Shpfy Order Mapping"
         end;
 
         MapShippingMethodCode(OrderHeader);
+        MapShippingAgent(OrderHeader);
         MapPaymentMethodCode(OrderHeader);
         OrderHeader.Modify();
         exit((OrderHeader."Bill-to Customer No." <> '') and (OrderHeader."Sell-to Customer No." <> ''));
@@ -163,6 +165,7 @@ codeunit 30163 "Shpfy Order Mapping"
         end;
 
         MapShippingMethodCode(OrderHeader);
+        MapShippingAgent(OrderHeader);
         MapPaymentMethodCode(OrderHeader);
         OrderHeader.Modify();
         exit((OrderHeader."Bill-to Customer No." <> '') and (OrderHeader."Sell-to Customer No." <> ''));
@@ -243,6 +246,26 @@ codeunit 30163 "Shpfy Order Mapping"
                     if ShipmentMethodMapping.Get(OrderHeader."Shop Code", OrderShippingCharges.Title) then
                         OrderHeader."Shipping Method Code" := ShipmentMethodMapping."Shipment Method Code";
                 OrderEvents.OnAfterMapShipmentMethod(OrderHeader);
+            end;
+        end;
+    end;
+
+    local procedure MapShippingAgent(var OrderHeader: Record "Shpfy Order Header")
+    var
+        OrderShippingCharges: Record "Shpfy Order Shipping Charges";
+        ShipmentMethodMapping: Record "Shpfy Shipment Method Mapping";
+        IsHandled: Boolean;
+    begin
+        if OrderHeader."Shipping Agent Code" = '' then begin
+            OrderEvents.OnBeforeMapShipmentAgent(OrderHeader, IsHandled);
+            if not IsHandled then begin
+                OrderShippingCharges.SetRange("Shopify Order Id", OrderHeader."Shopify Order Id");
+                if OrderShippingCharges.FindFirst() then
+                    if ShipmentMethodMapping.Get(OrderHeader."Shop Code", OrderShippingCharges.Title) then begin
+                        OrderHeader."Shipping Agent Code" := ShipmentMethodMapping."Shipping Agent Code";
+                        OrderHeader."Shipping Agent Service Code" := ShipmentMethodMapping."Shipping Agent Service Code";
+                    end;
+                OrderEvents.OnAfterMapShipmentAgent(OrderHeader);
             end;
         end;
     end;

--- a/Apps/W1/Shopify/app/src/Order handling/Codeunits/ShpfyProcessOrder.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Order handling/Codeunits/ShpfyProcessOrder.Codeunit.al
@@ -332,7 +332,7 @@ codeunit 30166 "Shpfy Process Order"
     var
         Currency: Record Currency;
     begin
-        SalesLine.GetSalesHeader();
+        SalesHeader := SalesLine.GetSalesHeader();
         Currency.Initialize(SalesHeader."Currency Code");
         if (SalesLine."Inv. Discount Amount" = 0) and (SalesLine."Line Discount Amount" = 0) and
             (not SalesHeader."Prices Including VAT")

--- a/Apps/W1/Shopify/app/src/Order handling/Codeunits/ShpfyProcessOrder.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Order handling/Codeunits/ShpfyProcessOrder.Codeunit.al
@@ -6,7 +6,6 @@ using Microsoft.Sales.Document;
 using Microsoft.Foundation.Address;
 using Microsoft.Sales.History;
 using Microsoft.Sales.Posting;
-using Microsoft.Foundation.UOM;
 
 /// <summary>
 /// Codeunit Shpfy Process Order (ID 30166).

--- a/Apps/W1/Shopify/app/src/Order handling/Pages/ShpfyOrder.Page.al
+++ b/Apps/W1/Shopify/app/src/Order handling/Pages/ShpfyOrder.Page.al
@@ -62,6 +62,16 @@ page 30113 "Shpfy Order"
                     ApplicationArea = All;
                     ToolTip = 'Specifies how items on the Shopify Order are shipped to the customer.';
                 }
+                field(ShippingAgentCode; Rec."Shipping Agent Code")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies which shipping agent is used to transport the items on the Shopify Order to the customer.';
+                }
+                field(ShippingAgentServiceCode; Rec."Shipping Agent Service Code")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the code that represents the default shipping agent service you are using for this Shopify Order.';
+                }
                 field("Payment Method"; Rec."Payment Method Code")
                 {
                     ApplicationArea = All;

--- a/Apps/W1/Shopify/app/src/Order handling/Tables/ShpfyOrderHeader.Table.al
+++ b/Apps/W1/Shopify/app/src/Order handling/Tables/ShpfyOrderHeader.Table.al
@@ -727,6 +727,22 @@ table 30118 "Shpfy Order Header"
             Caption = 'Has Order State Error';
             DataClassification = SystemMetadata;
         }
+        field(1021; "Shipping Agent Code"; Code[10])
+        {
+            Caption = 'Shipping Agent Code';
+            TableRelation = "Shipping Agent";
+
+            trigger OnValidate()
+            begin
+                if "Shipping Agent Code" <> xRec."Shipping Agent Code" then
+                    Clear("Shipping Agent Service Code");
+            end;
+        }
+        field(1022; "Shipping Agent Service Code"; Code[10])
+        {
+            Caption = 'Shipping Agent Service Code';
+            TableRelation = "Shipping Agent Services".Code where("Shipping Agent Code" = field("Shipping Agent Code"));
+        }
     }
     keys
     {

--- a/Apps/W1/Shopify/app/src/Shipping/Pages/ShpfyShipmentMethodsMapping.Page.al
+++ b/Apps/W1/Shopify/app/src/Shipping/Pages/ShpfyShipmentMethodsMapping.Page.al
@@ -26,6 +26,26 @@ page 30129 "Shpfy Shipment Methods Mapping"
                     ApplicationArea = All;
                     ToolTip = 'Specifies the shipping method in D365BC.';
                 }
+                field("Shipping Charges Type"; Rec."Shipping Charges Type")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the value of the Shipping Charges Type field.';
+                }
+                field("Shipping Charges No."; Rec."Shipping Charges No.")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the value of the Shipping Charges No. field.';
+                }
+                field("Shipping Agent Code"; Rec."Shipping Agent Code")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the code for the shipping agent who is transporting the items.';
+                }
+                field("Shipping Agent Service Code"; Rec."Shipping Agent Service Code")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the code for the service, such as a one-day delivery, that is offered by the shipping agent.';
+                }
             }
         }
     }

--- a/Apps/W1/Shopify/app/src/Shipping/Pages/ShpfyShipmentMethodsMapping.Page.al
+++ b/Apps/W1/Shopify/app/src/Shipping/Pages/ShpfyShipmentMethodsMapping.Page.al
@@ -34,6 +34,7 @@ page 30129 "Shpfy Shipment Methods Mapping"
                 field("Shipping Charges No."; Rec."Shipping Charges No.")
                 {
                     ApplicationArea = All;
+                    ShowMandatory = Rec."Shipping Charges Type" <> Rec."Shipping Charges Type"::" ";
                     ToolTip = 'Specifies the value of the Shipping Charges No. field.';
                 }
                 field("Shipping Agent Code"; Rec."Shipping Agent Code")

--- a/Apps/W1/Shopify/app/src/Shipping/Tables/ShpfyShipmentMethodMapping.Table.al
+++ b/Apps/W1/Shopify/app/src/Shipping/Tables/ShpfyShipmentMethodMapping.Table.al
@@ -1,6 +1,9 @@
 namespace Microsoft.Integration.Shopify;
 
 using Microsoft.Foundation.Shipping;
+using Microsoft.Sales.Document;
+using Microsoft.Finance.GeneralLedger.Account;
+using Microsoft.Inventory.Item;
 
 /// <summary>
 /// Table Shpfy Shipment Method Mapping (ID 30131).
@@ -30,6 +33,55 @@ table 30131 "Shpfy Shipment Method Mapping"
             Caption = 'Shipment Method Code';
             DataClassification = CustomerContent;
             TableRelation = "Shipment Method";
+        }
+        field(4; "Shipping Charges Type"; Enum "Sales Line Type")
+        {
+            Caption = 'Shipping Charges Type';
+            DataClassification = CustomerContent;
+            ValuesAllowed = " ", "G/L Account", Item, "Charge (Item)";
+
+            trigger OnValidate()
+            begin
+                if "Shipping Charges Type" <> xRec."Shipping Charges Type" then
+                    Clear("Shipping Charges No.");
+            end;
+        }
+        field(5; "Shipping Charges No."; Code[20])
+        {
+            Caption = 'Shipping Charges No.';
+            TableRelation = if ("Shipping Charges Type" = const("G/L Account")) "G/L Account"
+            else
+            if ("Shipping Charges Type" = const(Item)) Item
+            else
+            if ("Shipping Charges Type" = const("Charge (Item)")) "Item Charge";
+
+            trigger OnValidate()
+            var
+                GLAccount: Record "G/L Account";
+                ShpfyShop: Record "Shpfy Shop";
+            begin
+                if "Shipping Charges Type" = "Shipping Charges Type"::"G/L Account" then
+                    if GLAccount.Get("Shipping Charges No.") then
+                        ShpfyShop.CheckGLAccount(GLAccount);
+            end;
+        }
+        field(6; "Shipping Agent Code"; Code[10])
+        {
+            AccessByPermission = TableData "Shipping Agent Services" = R;
+            Caption = 'Shipping Agent Code';
+            TableRelation = "Shipping Agent";
+
+            trigger OnValidate()
+            begin
+                if "Shipping Agent Code" <> xRec."Shipping Agent Code" then
+                    Clear("Shipping Agent Service Code");
+            end;
+        }
+        field(7; "Shipping Agent Service Code"; Code[10])
+        {
+            AccessByPermission = TableData "Shipping Agent Services" = R;
+            Caption = 'Shipping Agent Service Code';
+            TableRelation = "Shipping Agent Services".Code where("Shipping Agent Code" = field("Shipping Agent Code"));
         }
     }
 


### PR DESCRIPTION
This pull request does not have a related issue as it's part of delivery for development agreed directly with @AndreiPanko 

Quick summary:

The Shopify Shipping Method Mapping page/table was extended to include a new Shipping Charges Type field, allowing users to select from GL, Item, or Item Charge. Depending on this selection, the Shipping Charges No. field opens the related table (item, GL, or item charges), and when an order is created, the shipping charge line reflects the new type and number. For Item Charges, a default allocation process is run for all item lines. The settings in the Shopify Shipping Method Mapping now take priority over those in the Shopify Shop - GL Account settings. Additionally, if the Shipping Agent Code and Shipping Agent Service fields are populated, they are automatically populated in the sales order as well.

Fixes #26819
[AB#449477](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/449477)
