### PR TITLE
[Fix] URL maximum length in E-Document Integration

### DIFF
--- a/Apps/W1/EDocument/app/src/Log/EDocumentIntegrationLog.Table.al
+++ b/Apps/W1/EDocument/app/src/Log/EDocumentIntegrationLog.Table.al
@@ -41,10 +41,22 @@ table 6127 "E-Document Integration Log"
         field(7; URL; Text[250])
         {
             Caption = 'URL';
+            ObsoleteReason = 'Replaced with Request URL field';
+#if not CLEAN25
+            ObsoleteState = Pending;
+            ObsoleteTag = '25.0';
+#else
+            ObsoleteState = Removed;
+            ObsoleteTag = '28.0';
+#endif
         }
         field(8; Method; Text[10])
         {
             Caption = 'Method';
+        }
+        field(9; "Request URL"; Text[2048])
+        {
+            Caption = 'URL';
         }
     }
 

--- a/Apps/W1/EDocument/app/src/Log/EDocumentIntegrationLogs.Page.al
+++ b/Apps/W1/EDocument/app/src/Log/EDocumentIntegrationLogs.Page.al
@@ -31,7 +31,7 @@ page 6128 "E-Document Integration Logs"
                     {
                         ToolTip = 'Specifies the service code for the document.';
                     }
-                    field(URL; Rec.URL)
+                    field(URL; Rec."Request URL")
                     {
                         ToolTip = 'Specifies the integration url used to send the document.';
                     }

--- a/Apps/W1/EDocument/app/src/Log/EDocumentLog.Codeunit.al
+++ b/Apps/W1/EDocument/app/src/Log/EDocumentLog.Codeunit.al
@@ -108,7 +108,10 @@ codeunit 6132 "E-Document Log"
         EDocumentIntegrationLog.Validate("E-Doc. Entry No", EDocument."Entry No");
         EDocumentIntegrationLog.Validate("Service Code", EDocumentService.Code);
         EDocumentIntegrationLog.Validate("Response Status", HttpResponse.HttpStatusCode());
-        EDocumentIntegrationLog.Validate(URL, HttpRequest.GetRequestUri());
+#if not CLEAN25
+        EDocumentIntegrationLog.Validate("Url", CopyStr(HttpRequest.GetRequestUri(), 1, 250));
+#endif
+        EDocumentIntegrationLog.Validate("Request URL", HttpRequest.GetRequestUri());
         EDocumentIntegrationLog.Validate(Method, HttpRequest.Method());
         EDocumentIntegrationLog.Insert();
 

--- a/Apps/W1/EDocument/test/src/Log/EDocLogTest.Codeunit.al
+++ b/Apps/W1/EDocument/test/src/Log/EDocLogTest.Codeunit.al
@@ -734,7 +734,7 @@ codeunit 139616 "E-Doc Log Test"
         Assert.IsTrue(EDocumentIntegrationLog.FindFirst(), 'There should be an edocument integration log entry');
         Assert.AreEqual(EDocumentIntegrationLog."E-Doc. Entry No", EDocument."Entry No", 'EDocument integration log should be linked to edocument');
         Assert.AreEqual(HttpRequest.Method(), EDocumentIntegrationLog.Method, 'Integration log should contain method type from request message');
-        Assert.AreEqual(HttpRequest.GetRequestUri(), EDocumentIntegrationLog.URL, 'Integration log should contain url from request message');
+        Assert.AreEqual(HttpRequest.GetRequestUri(), EDocumentIntegrationLog."Request URL", 'Integration log should contain url from request message');
 
         EDocumentIntegrationLog.CalcFields("Request Blob");
         EDocumentIntegrationLog.CalcFields("Response Blob");


### PR DESCRIPTION
#### Summary <!-- Provide a general summary of your changes -->
Added a new field "Request URL" to table 6127 "E-Document Integration Log" with a maximum string length of 2048 to allow for longer URLs when using the "E-Document Integration" interface. The new filed replaces the existing field URL. I marked the existing field as obsolete and updated three (all) references from the old URL field to the new "Request URL" field.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #26672



Fixes [AB#540448](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/540448)

