### PR TITLE
[Shopify][BC Idea]: Enhancing Shopify Connector for Accurate Price Synchronization with Business Central based on Customer

### DIFF
--- a/Apps/W1/Shopify/app/src/Catalogs/Pages/ShpfyCatalogs.Page.al
+++ b/Apps/W1/Shopify/app/src/Catalogs/Pages/ShpfyCatalogs.Page.al
@@ -25,6 +25,11 @@ page 30159 "Shpfy Catalogs"
                     ToolTip = 'Specifies the unique identifier for the catalog in Shopify.';
                     Editable = false;
                 }
+                field("Customer No."; Rec."Customer No.")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the customer''s no.';
+                }
                 field(Name; Rec.Name)
                 {
                     ApplicationArea = All;

--- a/Apps/W1/Shopify/app/src/Catalogs/Pages/ShpfyCatalogs.Page.al
+++ b/Apps/W1/Shopify/app/src/Catalogs/Pages/ShpfyCatalogs.Page.al
@@ -28,7 +28,7 @@ page 30159 "Shpfy Catalogs"
                 field("Customer No."; Rec."Customer No.")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies the customer''s no.';
+                    ToolTip = 'Specifies the customer''s no.  When Customer No. is Selected: Parameters like ''Customer Discount Group'', ''Customer Price Group'', and ''Allow Line Discount'' on the customer card take precedence over catalog settings';
                 }
                 field(Name; Rec.Name)
                 {

--- a/Apps/W1/Shopify/app/src/Catalogs/Pages/ShpfyCatalogs.Page.al
+++ b/Apps/W1/Shopify/app/src/Catalogs/Pages/ShpfyCatalogs.Page.al
@@ -28,6 +28,7 @@ page 30159 "Shpfy Catalogs"
                 field("Customer No."; Rec."Customer No.")
                 {
                     ApplicationArea = All;
+                    Visible = false;
                     ToolTip = 'Specifies the customer''s no.  When Customer No. is Selected: Parameters like ''Customer Discount Group'', ''Customer Price Group'', and ''Allow Line Discount'' on the customer card take precedence over catalog settings';
                 }
                 field(Name; Rec.Name)

--- a/Apps/W1/Shopify/app/src/Catalogs/Tables/ShpfyCatalog.Table.al
+++ b/Apps/W1/Shopify/app/src/Catalogs/Tables/ShpfyCatalog.Table.al
@@ -111,6 +111,12 @@ table 30152 "Shpfy Catalog"
             Caption = 'Sync Prices';
             DataClassification = CustomerContent;
         }
+        field(17; "Customer No."; Code[20])
+        {
+            Caption = 'Customer No.';
+            DataClassification = CustomerContent;
+            TableRelation = "Customer";
+        }
     }
     keys
     {

--- a/Apps/W1/Shopify/app/src/Products/Codeunits/ShpfyProductPriceCalc.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Products/Codeunits/ShpfyProductPriceCalc.Codeunit.al
@@ -93,20 +93,18 @@ codeunit 30182 "Shpfy Product Price Calc."
     /// </summary>
     local procedure CreateTempSalesHeader()
     var
-        CustomerRec: Record Customer;
+        Customer: Record Customer;
     begin
         Clear(TempSalesHeader);
         TempSalesHeader."Document Type" := TempSalesHeader."Document Type"::Quote;
         TempSalesHeader."No." := Shop.Code;
         if CustomerNo <> '' then begin
-            if CustomerRec.GET(CustomerNo) then begin
-                TempSalesHeader."Sell-to Customer No." := CustomerNo;
-                TempSalesHeader."Bill-to Customer No." := CustomerNo;
-                TempSalesHeader."Customer Price Group" := CustomerRec."Customer Price Group";
-                TempSalesHeader."Customer Disc. Group" := CustomerRec."Customer Disc. Group";
-                TempSalesHeader."Allow Line Disc." := CustomerRec."Allow Line Disc.";
-                TempSalesHeader."Invoice Disc. Code" := CustomerRec."Invoice Disc. Code";
-            end
+            Customer.GET(CustomerNo);
+            TempSalesHeader."Sell-to Customer No." := CustomerNo;
+            TempSalesHeader."Bill-to Customer No." := CustomerNo;
+            TempSalesHeader."Customer Price Group" := Customer."Customer Price Group";
+            TempSalesHeader."Customer Disc. Group" := Customer."Customer Disc. Group";
+            TempSalesHeader."Allow Line Disc." := Customer."Allow Line Disc.";
         end
         else begin
             TempSalesHeader."Sell-to Customer No." := Shop.Code;

--- a/Apps/W1/Shopify/app/src/Products/Codeunits/ShpfyProductPriceCalc.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Products/Codeunits/ShpfyProductPriceCalc.Codeunit.al
@@ -54,7 +54,7 @@ codeunit 30182 "Shpfy Product Price Calc."
         ShpfyUpdatePriceSouce: codeunit "Shpfy Update Price Source";
         IsHandled: Boolean;
     begin
-        ProductEvents.OnBeforeCalculateUnitPrice(Item, ItemVariant, UnitOfMeasure, Shop, UnitCost, Catalog, Price, ComparePrice, IsHandled);
+        ProductEvents.OnBeforeCalculateUnitPrice(Item, ItemVariant, UnitOfMeasure, Shop, Catalog, UnitCost, Price, ComparePrice, IsHandled);
         if not IsHandled then begin
             BindSubscription(ShpfyUpdatePriceSouce);
             if TempSalesHeader.FindFirst() then begin

--- a/Apps/W1/Shopify/app/src/Products/Codeunits/ShpfyProductPriceCalc.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Products/Codeunits/ShpfyProductPriceCalc.Codeunit.al
@@ -54,7 +54,7 @@ codeunit 30182 "Shpfy Product Price Calc."
         ShpfyUpdatePriceSouce: codeunit "Shpfy Update Price Source";
         IsHandled: Boolean;
     begin
-        ProductEvents.OnBeforeCalculateUnitPrice(Item, ItemVariant, UnitOfMeasure, Shop, UnitCost, Price, ComparePrice, IsHandled);
+        ProductEvents.OnBeforeCalculateUnitPrice(Item, ItemVariant, UnitOfMeasure, Shop, UnitCost, Catalog, Price, ComparePrice, IsHandled);
         if not IsHandled then begin
             BindSubscription(ShpfyUpdatePriceSouce);
             if TempSalesHeader.FindFirst() then begin
@@ -85,7 +85,7 @@ codeunit 30182 "Shpfy Product Price Calc."
             if ComparePrice <= Price then
                 ComparePrice := 0;
         end;
-        ProductEvents.OnAfterCalculateUnitPrice(Item, ItemVariant, UnitOfMeasure, Shop, UnitCost, Price, ComparePrice);
+        ProductEvents.OnAfterCalculateUnitPrice(Item, ItemVariant, UnitOfMeasure, Shop, Catalog, UnitCost, Price, ComparePrice);
     end;
 
     /// <summary> 

--- a/Apps/W1/Shopify/test/Catalogs/ShpfyCatalogPricesTest.Codeunit.al
+++ b/Apps/W1/Shopify/test/Catalogs/ShpfyCatalogPricesTest.Codeunit.al
@@ -73,9 +73,6 @@ codeunit 139646 "Shpfy Catalog Prices Test"
         LibraryAssert.AreNearlyEqual(InitPrice * (1 - InitDiscountPerc / 100), Price, 0.01, 'Discount Price');
     end;
 
-
-
-
     [Test]
     procedure UnitTestCalcCatalogPriceAllCustomers()
     var
@@ -98,7 +95,7 @@ codeunit 139646 "Shpfy Catalog Prices Test"
         Price: Decimal;
         ComparePrice: Decimal;
     begin
-        // Setup initial test environment and create necessary records.
+        // [GIVEN] Initializing test environment and creating necessary test records.
         Shop := InitializeTest.CreateShop();
         CompanyInitialize.CreateShopifyCompany(ShopifyCompany);
         Catalog := CatalogInitialize.CreateCatalog(ShopifyCompany);
@@ -107,29 +104,35 @@ codeunit 139646 "Shpfy Catalog Prices Test"
         InitPrice := Any.DecimalInRange(2 * InitUnitCost, 4 * InitUnitCost, 1);
         InitDiscountPerc := Any.DecimalInRange(5, 20, 1);
         Item := ProductInitTest.CreateItem(Shop."Item Templ. Code", InitUnitCost, InitPrice);
-        LibrarySales.CreateCustomer(Customer);  // This may be unused if discount applies to all customers generically.
 
-        // Verify initial price calculations without any discounts applied.
+        // Creating a customer entry, though it is generic as discounts apply to all customers.
+        LibrarySales.CreateCustomer(Customer);
+
+        // [WHEN] Calculating initial prices without any discounts applied.
         ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
         ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
-        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Verify initial unit cost is as expected.');
-        LibraryAssert.AreEqual(InitPrice, Price, 'Verify initial price is as expected without any discounts.');
 
-        // Update the catalog to apply a universal discount to all customers and verify the changes.
+        // [THEN] Confirm initial price calculations match expectations.
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Initial unit cost should match expected.');
+        LibraryAssert.AreEqual(InitPrice, Price, 'Initial price should match expected before discount application.');
+
+        // [GIVEN] Updating the catalog to apply a universal discount to all customers.
         ProductInitTest.CreateAllCustomerPriceList(Shop.Code, Item."No.", InitPrice, InitDiscountPerc);
-        Catalog."Customer No." := Customer."No.";  // This step might need adjustment depending on business logic.
+        Catalog."Customer No." := Customer."No.";
         Catalog.Modify();
+
+        // [WHEN] Recalculating prices after applying the discount.
         ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
         ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
 
-        // Validate the results after applying the discount.
-        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Unit cost should remain consistent even after discount application.');
-        LibraryAssert.AreEqual(InitPrice, ComparePrice, 'Compare price should reflect the original price before any discounts were applied.');
+        // [THEN] Validate the results reflect the universal discount.
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Unit cost should remain consistent after discount application.');
+        LibraryAssert.AreEqual(InitPrice, ComparePrice, 'Compare price should reflect the original price prior to any discounts.');
         LibraryAssert.AreNearlyEqual(InitPrice * (1 - InitDiscountPerc / 100), Price, 0.01, 'The final price should accurately reflect the applied discount for all customers.');
     end;
 
     [Test]
-    procedure UnitTestCalcCatalogPriceCustomer()
+    procedure UnitTestCalcCustomerCatalogPrice()
     var
         Shop: Record "Shpfy Shop";
         Catalog: Record "Shpfy Catalog";
@@ -150,7 +153,7 @@ codeunit 139646 "Shpfy Catalog Prices Test"
         ComparePrice: Decimal;
         CustDiscPerc: Decimal;
     begin
-        // Set up the test environment: Shop, Catalog, Item, and Customer with specific pricing and discount.
+        // [GIVEN] Setting up the test environment: Shop, Catalog, Item, and Customer with specific pricing and discount.
         Shop := InitializeTest.CreateShop();
         CompanyInitialize.CreateShopifyCompany(ShopifyCompany);
         Catalog := CatalogInitialize.CreateCatalog(ShopifyCompany);
@@ -161,31 +164,30 @@ codeunit 139646 "Shpfy Catalog Prices Test"
         CustDiscPerc := Any.DecimalInRange(5, 20, 1);
         Item := ProductInitTest.CreateItem(Shop."Item Templ. Code", InitUnitCost, InitPrice);
         ProductInitTest.CreateSalesPrice(Shop.Code, Item."No.", InitPrice);
-
-        // Create a customer price list with a specific discount.
         Customer := ProductInitTest.CreateCustomerPriceList(Shop.Code, Item."No.", InitPrice, CustDiscPerc);
 
-        // Validate initial price calculations without customer-specific discount.
+        // [WHEN] Calculating prices without and then with customer-specific discounts.
         ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
         ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
-        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Initial unit cost should match setup.');
-        LibraryAssert.AreEqual(InitPrice, Price, 'Initial price should match setup before discount application.');
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Verify initial unit cost matches setup.');
+        LibraryAssert.AreEqual(InitPrice, Price, 'Verify initial price matches setup before discount.');
 
-        // Apply the customer-specific discount and re-calculate the prices.
+        // [GIVEN] Applying customer-specific discounts.
         Catalog."Customer No." := Customer."No.";
         Catalog.Modify();
         ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
+
+        // [WHEN] Recalculating prices with customer-specific discounts.
         ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
 
-        // Confirm that the pricing reflects the customer-specific discounts correctly.
-        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Unit cost should remain unchanged.');
-        LibraryAssert.AreEqual(InitPrice, ComparePrice, 'Compare price should reflect the price before discount.');
-        LibraryAssert.AreNearlyEqual(InitPrice * (1 - CustDiscPerc / 100), Price, 0.01, 'Discounted price should be correctly calculated.');
+        // [THEN] Confirming pricing accuracy with applied discounts.
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Unit cost should remain unchanged after applying discounts.');
+        LibraryAssert.AreEqual(InitPrice, ComparePrice, 'Compare price should reflect the original price pre-discount.');
+        LibraryAssert.AreNearlyEqual(InitPrice * (1 - CustDiscPerc / 100), Price, 0.01, 'Discounted price should be accurately calculated.');
     end;
 
-
     [Test]
-    procedure UnitTestCalcCatalogPriceCustomer2()
+    procedure UnitTestCalcCustomerCatalogPriceAllCustomers()
     var
         Shop: Record "Shpfy Shop";
         Catalog: Record "Shpfy Catalog";
@@ -206,46 +208,43 @@ codeunit 139646 "Shpfy Catalog Prices Test"
         Price: Decimal;
         ComparePrice: Decimal;
     begin
-        // Setup test environment: creating shop, catalog, and customer with specific discounts.
+        // [GIVEN] Setting up shop, catalog, item, and customer-specific pricing.
         Shop := InitializeTest.CreateShop();
         CompanyInitialize.CreateShopifyCompany(ShopifyCompany);
         Catalog := CatalogInitialize.CreateCatalog(ShopifyCompany);
         CatalogInitialize.CopyParametersFromShop(Catalog, Shop);
         InitUnitCost := Any.DecimalInRange(10, 100, 1);
         InitPrice := Any.DecimalInRange(2 * InitUnitCost, 4 * InitUnitCost, 1);
-        InitPerc := Any.DecimalInRange(5, 20, 1);
         CustDiscPerc := Any.DecimalInRange(5, 20, 1);
         Item := ProductInitTest.CreateItem(Shop."Item Templ. Code", InitUnitCost, InitPrice);
-
-        // Create standard sales price for item.
         ProductInitTest.CreateSalesPrice(Shop.Code, Item."No.", InitPrice);
-
-        // Create customer-specific price list which might include specific discounts.
         Customer := ProductInitTest.CreateCustomerPriceList(Shop.Code, Item."No.", InitPrice, CustDiscPerc);
 
-        // Begin test scenario for price calculation without initial discounts.
+        // [WHEN] Calculating prices without discounts applied.
         ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
         ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
 
-        // Validate initial prices without discounts.
-        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Validate initial unit cost matches expected.');
-        LibraryAssert.AreEqual(InitPrice, Price, 'Validate initial price matches expected before discount.');
+        // [THEN] Verifying initial prices match expectations.
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Initial unit cost should match.');
+        LibraryAssert.AreEqual(InitPrice, Price, 'Initial price should match before discount.');
 
-        // Update catalog with customer-specific discount and validate recalculated prices.
+        // [GIVEN] Applying a universal discount for all customers.
+        ProductInitTest.CreateAllCustomerPriceList(Shop.Code, Item."No.", InitPrice, InitPerc);
         Catalog."Customer No." := Customer."No.";
         Catalog.Modify();
-        ProductInitTest.CreateAllCustomerPriceList(Shop.Code, Item."No.", InitPrice, InitPerc);
+
+        // [WHEN] Recalculating prices with discounts.
         ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
         ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
 
-        // Verify the results post discount application.
-        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Unit cost should remain consistent post-discount.');
-        LibraryAssert.AreEqual(InitPrice, ComparePrice, 'Compare price should still reflect initial price pre-discount.');
-        LibraryAssert.AreNearlyEqual(InitPrice * (1 - CustDiscPerc / 100), Price, 0.01, 'Verify discounted price is calculated correctly.');
+        // [THEN] Confirming discounts are accurately reflected in the final prices.
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Unit cost should remain consistent.');
+        LibraryAssert.AreEqual(InitPrice, ComparePrice, 'Compare price should reflect initial pricing.');
+        LibraryAssert.AreNearlyEqual(InitPrice * (1 - CustDiscPerc / 100), Price, 0.01, 'Discounted price should be accurately calculated.');
     end;
 
     [Test]
-    procedure UnitTestCalcCatalogPriceCustomer3()
+    procedure UnitTestCalcCustomerDiscountCatalogPrice()
     var
         Shop: Record "Shpfy Shop";
         Catalog: Record "Shpfy Catalog";
@@ -266,7 +265,7 @@ codeunit 139646 "Shpfy Catalog Prices Test"
         ComparePrice: Decimal;
         Customer: Record Customer;
     begin
-        // Set up the initial environment and create necessary records.
+        // [GIVEN] Creating shop, catalog, item, and setting customer discount details.
         Shop := InitializeTest.CreateShop();
         CompanyInitialize.CreateShopifyCompany(ShopifyCompany);
         Catalog := CatalogInitialize.CreateCatalog(ShopifyCompany);
@@ -278,24 +277,27 @@ codeunit 139646 "Shpfy Catalog Prices Test"
         LibrarySales.CreateCustomer(Customer);
         CustomerDiscountGroup := ProductInitTest.CreateCustDiscPriceList(Any.AlphabeticText(10), Item."No.", InitPrice, InitDiscountPerc);
 
-        // Perform initial price calculation without any discounts applied.
+        // [WHEN] Calculating initial prices without any discounts applied.
         ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
         ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
-        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Unit Cost should match the initial setup.');
-        LibraryAssert.AreEqual(InitPrice, Price, 'Price should match the initial setup without discounts.');
 
-        // Update the catalog with customer discount information and re-calculate the prices.
+        // [THEN] Verifying initial price settings.
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Initial unit cost should match setup.');
+        LibraryAssert.AreEqual(InitPrice, Price, 'Initial price should match setup without discounts.');
+
+        // [GIVEN] Updating catalog with customer-specific discount group details.
         Catalog."Customer No." := Customer."No.";
         Customer."Customer Disc. Group" := CustomerDiscountGroup.Code;
         Customer.Modify();
         Catalog.Modify();
+
+        // [WHEN] Recalculating prices post-update.
         ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
         ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
 
-        // Confirm that the calculations reflect the updated discount information.
-        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Unit Cost should remain unchanged after applying discounts.');
-        LibraryAssert.AreEqual(InitPrice, ComparePrice, 'Compare Price should reflect the original price before discounts.');
-        LibraryAssert.AreNearlyEqual(InitPrice * (1 - InitDiscountPerc / 100), Price, 0.01, 'The discounted price should be accurately calculated.');
+        // [THEN] Confirming accurate reflection of discount updates in final prices.
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Unit cost should remain unchanged post-update.');
+        LibraryAssert.AreEqual(InitPrice, ComparePrice, 'Compare Price should match initial settings.');
+        LibraryAssert.AreNearlyEqual(InitPrice * (1 - InitDiscountPerc / 100), Price, 0.01, 'Accurate calculation of discounted price should be verified.');
     end;
-
 }

--- a/Apps/W1/Shopify/test/Catalogs/ShpfyCatalogPricesTest.Codeunit.al
+++ b/Apps/W1/Shopify/test/Catalogs/ShpfyCatalogPricesTest.Codeunit.al
@@ -72,4 +72,230 @@ codeunit 139646 "Shpfy Catalog Prices Test"
         // [THEN] InitPrice - InitDiscountPerc = Price
         LibraryAssert.AreNearlyEqual(InitPrice * (1 - InitDiscountPerc / 100), Price, 0.01, 'Discount Price');
     end;
+
+
+
+
+    [Test]
+    procedure UnitTestCalcCatalogPriceAllCustomers()
+    var
+        Shop: Record "Shpfy Shop";
+        LibrarySales: Codeunit "Library - Sales";
+        Catalog: Record "Shpfy Catalog";
+        ShopifyCompany: Record "Shpfy Company";
+        Item: Record Item;
+        CustomerDiscountGroup: Record "Customer Discount Group";
+        Customer: Record Customer;
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+        ProductInitTest: Codeunit "Shpfy Product Init Test";
+        CatalogInitialize: Codeunit "Shpfy Catalog Initialize";
+        CompanyInitialize: Codeunit "Shpfy Company Initialize";
+        ProductPriceCalculation: Codeunit "Shpfy Product Price Calc.";
+        InitUnitCost: Decimal;
+        InitPrice: Decimal;
+        InitDiscountPerc: Decimal;
+        UnitCost: Decimal;
+        Price: Decimal;
+        ComparePrice: Decimal;
+    begin
+        // Setup initial test environment and create necessary records.
+        Shop := InitializeTest.CreateShop();
+        CompanyInitialize.CreateShopifyCompany(ShopifyCompany);
+        Catalog := CatalogInitialize.CreateCatalog(ShopifyCompany);
+        CatalogInitialize.CopyParametersFromShop(Catalog, Shop);
+        InitUnitCost := Any.DecimalInRange(10, 100, 1);
+        InitPrice := Any.DecimalInRange(2 * InitUnitCost, 4 * InitUnitCost, 1);
+        InitDiscountPerc := Any.DecimalInRange(5, 20, 1);
+        Item := ProductInitTest.CreateItem(Shop."Item Templ. Code", InitUnitCost, InitPrice);
+        LibrarySales.CreateCustomer(Customer);  // This may be unused if discount applies to all customers generically.
+
+        // Verify initial price calculations without any discounts applied.
+        ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
+        ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Verify initial unit cost is as expected.');
+        LibraryAssert.AreEqual(InitPrice, Price, 'Verify initial price is as expected without any discounts.');
+
+        // Update the catalog to apply a universal discount to all customers and verify the changes.
+        ProductInitTest.CreateAllCustomerPriceList(Shop.Code, Item."No.", InitPrice, InitDiscountPerc);
+        Catalog."Customer No." := Customer."No.";  // This step might need adjustment depending on business logic.
+        Catalog.Modify();
+        ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
+        ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
+
+        // Validate the results after applying the discount.
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Unit cost should remain consistent even after discount application.');
+        LibraryAssert.AreEqual(InitPrice, ComparePrice, 'Compare price should reflect the original price before any discounts were applied.');
+        LibraryAssert.AreNearlyEqual(InitPrice * (1 - InitDiscountPerc / 100), Price, 0.01, 'The final price should accurately reflect the applied discount for all customers.');
+    end;
+
+    [Test]
+    procedure UnitTestCalcCatalogPriceCustomer()
+    var
+        Shop: Record "Shpfy Shop";
+        Catalog: Record "Shpfy Catalog";
+        ShopifyCompany: Record "Shpfy Company";
+        Item: Record Item;
+        CustomerDiscountGroup: Record "Customer Discount Group";
+        Customer: Record Customer;
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+        ProductInitTest: Codeunit "Shpfy Product Init Test";
+        CatalogInitialize: Codeunit "Shpfy Catalog Initialize";
+        CompanyInitialize: Codeunit "Shpfy Company Initialize";
+        ProductPriceCalculation: Codeunit "Shpfy Product Price Calc.";
+        InitUnitCost: Decimal;
+        InitPrice: Decimal;
+        InitDiscountPerc: Decimal;
+        UnitCost: Decimal;
+        Price: Decimal;
+        ComparePrice: Decimal;
+        CustDiscPerc: Decimal;
+    begin
+        // Set up the test environment: Shop, Catalog, Item, and Customer with specific pricing and discount.
+        Shop := InitializeTest.CreateShop();
+        CompanyInitialize.CreateShopifyCompany(ShopifyCompany);
+        Catalog := CatalogInitialize.CreateCatalog(ShopifyCompany);
+        CatalogInitialize.CopyParametersFromShop(Catalog, Shop);
+        InitUnitCost := Any.DecimalInRange(10, 100, 1);
+        InitPrice := Any.DecimalInRange(2 * InitUnitCost, 4 * InitUnitCost, 1);
+        InitDiscountPerc := Any.DecimalInRange(5, 20, 1);
+        CustDiscPerc := Any.DecimalInRange(5, 20, 1);
+        Item := ProductInitTest.CreateItem(Shop."Item Templ. Code", InitUnitCost, InitPrice);
+        ProductInitTest.CreateSalesPrice(Shop.Code, Item."No.", InitPrice);
+
+        // Create a customer price list with a specific discount.
+        Customer := ProductInitTest.CreateCustomerPriceList(Shop.Code, Item."No.", InitPrice, CustDiscPerc);
+
+        // Validate initial price calculations without customer-specific discount.
+        ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
+        ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Initial unit cost should match setup.');
+        LibraryAssert.AreEqual(InitPrice, Price, 'Initial price should match setup before discount application.');
+
+        // Apply the customer-specific discount and re-calculate the prices.
+        Catalog."Customer No." := Customer."No.";
+        Catalog.Modify();
+        ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
+        ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
+
+        // Confirm that the pricing reflects the customer-specific discounts correctly.
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Unit cost should remain unchanged.');
+        LibraryAssert.AreEqual(InitPrice, ComparePrice, 'Compare price should reflect the price before discount.');
+        LibraryAssert.AreNearlyEqual(InitPrice * (1 - CustDiscPerc / 100), Price, 0.01, 'Discounted price should be correctly calculated.');
+    end;
+
+
+    [Test]
+    procedure UnitTestCalcCatalogPriceCustomer2()
+    var
+        Shop: Record "Shpfy Shop";
+        Catalog: Record "Shpfy Catalog";
+        ShopifyCompany: Record "Shpfy Company";
+        Item: Record Item;
+        CustomerDiscountGroup: Record "Customer Discount Group";
+        Customer: Record Customer;
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+        ProductInitTest: Codeunit "Shpfy Product Init Test";
+        CatalogInitialize: Codeunit "Shpfy Catalog Initialize";
+        CompanyInitialize: Codeunit "Shpfy Company Initialize";
+        ProductPriceCalculation: Codeunit "Shpfy Product Price Calc.";
+        InitUnitCost: Decimal;
+        InitPrice: Decimal;
+        InitPerc: Decimal;
+        CustDiscPerc: Decimal;
+        UnitCost: Decimal;
+        Price: Decimal;
+        ComparePrice: Decimal;
+    begin
+        // Setup test environment: creating shop, catalog, and customer with specific discounts.
+        Shop := InitializeTest.CreateShop();
+        CompanyInitialize.CreateShopifyCompany(ShopifyCompany);
+        Catalog := CatalogInitialize.CreateCatalog(ShopifyCompany);
+        CatalogInitialize.CopyParametersFromShop(Catalog, Shop);
+        InitUnitCost := Any.DecimalInRange(10, 100, 1);
+        InitPrice := Any.DecimalInRange(2 * InitUnitCost, 4 * InitUnitCost, 1);
+        InitPerc := Any.DecimalInRange(5, 20, 1);
+        CustDiscPerc := Any.DecimalInRange(5, 20, 1);
+        Item := ProductInitTest.CreateItem(Shop."Item Templ. Code", InitUnitCost, InitPrice);
+
+        // Create standard sales price for item.
+        ProductInitTest.CreateSalesPrice(Shop.Code, Item."No.", InitPrice);
+
+        // Create customer-specific price list which might include specific discounts.
+        Customer := ProductInitTest.CreateCustomerPriceList(Shop.Code, Item."No.", InitPrice, CustDiscPerc);
+
+        // Begin test scenario for price calculation without initial discounts.
+        ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
+        ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
+
+        // Validate initial prices without discounts.
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Validate initial unit cost matches expected.');
+        LibraryAssert.AreEqual(InitPrice, Price, 'Validate initial price matches expected before discount.');
+
+        // Update catalog with customer-specific discount and validate recalculated prices.
+        Catalog."Customer No." := Customer."No.";
+        Catalog.Modify();
+        ProductInitTest.CreateAllCustomerPriceList(Shop.Code, Item."No.", InitPrice, InitPerc);
+        ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
+        ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
+
+        // Verify the results post discount application.
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Unit cost should remain consistent post-discount.');
+        LibraryAssert.AreEqual(InitPrice, ComparePrice, 'Compare price should still reflect initial price pre-discount.');
+        LibraryAssert.AreNearlyEqual(InitPrice * (1 - CustDiscPerc / 100), Price, 0.01, 'Verify discounted price is calculated correctly.');
+    end;
+
+    [Test]
+    procedure UnitTestCalcCatalogPriceCustomer3()
+    var
+        Shop: Record "Shpfy Shop";
+        Catalog: Record "Shpfy Catalog";
+        LibrarySales: Codeunit "Library - Sales";
+        ShopifyCompany: Record "Shpfy Company";
+        Item: Record Item;
+        CustomerDiscountGroup: Record "Customer Discount Group";
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+        ProductInitTest: Codeunit "Shpfy Product Init Test";
+        CatalogInitialize: Codeunit "Shpfy Catalog Initialize";
+        CompanyInitialize: Codeunit "Shpfy Company Initialize";
+        ProductPriceCalculation: Codeunit "Shpfy Product Price Calc.";
+        InitUnitCost: Decimal;
+        InitPrice: Decimal;
+        InitDiscountPerc: Decimal;
+        UnitCost: Decimal;
+        Price: Decimal;
+        ComparePrice: Decimal;
+        Customer: Record Customer;
+    begin
+        // Set up the initial environment and create necessary records.
+        Shop := InitializeTest.CreateShop();
+        CompanyInitialize.CreateShopifyCompany(ShopifyCompany);
+        Catalog := CatalogInitialize.CreateCatalog(ShopifyCompany);
+        CatalogInitialize.CopyParametersFromShop(Catalog, Shop);
+        InitUnitCost := Any.DecimalInRange(10, 100, 1);
+        InitPrice := Any.DecimalInRange(2 * InitUnitCost, 4 * InitUnitCost, 1);
+        InitDiscountPerc := Any.DecimalInRange(5, 20, 1);
+        Item := ProductInitTest.CreateItem(Shop."Item Templ. Code", InitUnitCost, InitPrice);
+        LibrarySales.CreateCustomer(Customer);
+        CustomerDiscountGroup := ProductInitTest.CreateCustDiscPriceList(Any.AlphabeticText(10), Item."No.", InitPrice, InitDiscountPerc);
+
+        // Perform initial price calculation without any discounts applied.
+        ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
+        ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Unit Cost should match the initial setup.');
+        LibraryAssert.AreEqual(InitPrice, Price, 'Price should match the initial setup without discounts.');
+
+        // Update the catalog with customer discount information and re-calculate the prices.
+        Catalog."Customer No." := Customer."No.";
+        Customer."Customer Disc. Group" := CustomerDiscountGroup.Code;
+        Customer.Modify();
+        Catalog.Modify();
+        ProductPriceCalculation.SetShopAndCatalog(Shop, Catalog);
+        ProductPriceCalculation.CalcPrice(Item, '', '', UnitCost, Price, ComparePrice);
+
+        // Confirm that the calculations reflect the updated discount information.
+        LibraryAssert.AreEqual(InitUnitCost, UnitCost, 'Unit Cost should remain unchanged after applying discounts.');
+        LibraryAssert.AreEqual(InitPrice, ComparePrice, 'Compare Price should reflect the original price before discounts.');
+        LibraryAssert.AreNearlyEqual(InitPrice * (1 - InitDiscountPerc / 100), Price, 0.01, 'The discounted price should be accurately calculated.');
+    end;
+
 }

--- a/Apps/W1/Shopify/test/Products/ShpfyProductInitTest.Codeunit.al
+++ b/Apps/W1/Shopify/test/Products/ShpfyProductInitTest.Codeunit.al
@@ -183,10 +183,12 @@ codeunit 139603 "Shpfy Product Init Test"
         CustomerPriceGroup: Record "Customer Price Group";
         SalesPrice: Record "Sales Price";
     begin
-        CustomerPriceGroup.Init();
-        CustomerPriceGroup.Code := Code;
-        CustomerPriceGroup."Allow Line Disc." := true;
-        CustomerPriceGroup.Insert();
+        if not CustomerPriceGroup.Get(Code) then begin
+            CustomerPriceGroup.Init();
+            CustomerPriceGroup.Code := Code;
+            CustomerPriceGroup."Allow Line Disc." := true;
+            CustomerPriceGroup.Insert();
+        end;
 
         SalesPrice.Init();
         SalesPrice."Sales Type" := Enum::"Sales Price Type"::"All Customers";
@@ -199,9 +201,11 @@ codeunit 139603 "Shpfy Product Init Test"
     var
         SalesLineDiscount: Record "Sales Line Discount";
     begin
-        CustDiscGrp.Init();
-        CustDiscGrp.Code := Code;
-        CustDiscGrp.Insert();
+        if not CustDiscGrp.get(Code) then begin
+            CustDiscGrp.Init();
+            CustDiscGrp.Code := Code;
+            CustDiscGrp.Insert();
+        end;
 
         SalesLineDiscount.Init();
         SalesLineDiscount.Type := Enum::"Sales Line Discount Type"::Item;

--- a/Apps/W1/Shopify/test/Products/ShpfyProductInitTest.Codeunit.al
+++ b/Apps/W1/Shopify/test/Products/ShpfyProductInitTest.Codeunit.al
@@ -340,4 +340,108 @@ codeunit 139603 "Shpfy Product Init Test"
         else
             exit(10000);
     end;
+
+    internal procedure CreateAllCustomerPriceList(Code: Code[10]; ItemNo: Code[20]; Price: Decimal; DiscountPerc: Decimal)
+    var
+        PriceListLine: Record "Price List Line";
+        PriceListHeader: Record "Price List Header";
+    begin
+        if not PriceListHeader.get(code) then begin
+            PriceListHeader.Init();
+            PriceListHeader.Code := code;
+            PriceListHeader."Source Group" := PriceListHeader."Source Group"::Customer;
+            PriceListHeader."Source Type" := PriceListHeader."Source Type"::"All Customers";
+            PriceListHeader."Price Type" := PriceListHeader."Price Type"::Sale;
+            PriceListHeader."Amount Type" := PriceListHeader."Amount Type"::Discount;
+            PriceListHeader.Status := PriceListHeader.Status::Active;
+            PriceListHeader.Insert();
+
+
+            PriceListLine.Init();
+            PriceListLine."Price List Code" := PriceListHeader.Code;
+            PriceListLine."Asset Type" := PriceListLine."Asset Type"::Item;
+            PriceListLine."Asset No." := ItemNo;
+            PriceListLine."Product No." := ItemNo;
+            PriceListLine."Price Type" := PriceListLine."Price Type"::Sale;
+            PriceListLine."Amount Type" := PriceListLine."Amount Type"::Discount;
+            PriceListLine."Source Type" := PriceListLine."Source Type"::"All Customers";
+            PriceListLine.Validate("Line Discount %", DiscountPerc);
+            PriceListLine.Status := PriceListLine.Status::Active;
+            PriceListLine.Insert();
+        end;
+    end;
+
+    internal procedure CreateCustDiscPriceList(Code: Code[10]; ItemNo: Code[20]; Price: Decimal; DiscountPerc: Decimal) CustDiscGrp: Record "Customer Discount Group"
+    var
+        PriceListHeader: Record "Price List Header";
+        PriceListLine: Record "Price List Line";
+    begin
+        if not CustDiscGrp.Get(Code) then begin
+            CustDiscGrp.Init();
+            CustDiscGrp.Code := Code;
+            CustDiscGrp.Insert();
+        end;
+
+        PriceListHeader.Init();
+        PriceListHeader.Code := Any.AlphabeticText(MaxStrLen(PriceListHeader.Code));
+        PriceListHeader."Source Group" := PriceListHeader."Source Group"::Customer;
+        PriceListHeader."Source Type" := PriceListHeader."Source Type"::"Customer Disc. Group";
+        PriceListHeader."Source No." := CustDiscGrp.Code;
+        PriceListHeader."Price Type" := PriceListHeader."Price Type"::Sale;
+        PriceListHeader."Amount Type" := PriceListHeader."Amount Type"::Discount;
+        PriceListHeader.Status := PriceListHeader.Status::Active;
+        PriceListHeader.Insert();
+
+        PriceListLine.Init();
+        PriceListLine."Price List Code" := PriceListHeader.Code;
+        PriceListLine."Asset Type" := PriceListLine."Asset Type"::Item;
+        PriceListLine."Asset No." := ItemNo;
+        PriceListLine."Product No." := ItemNo;
+        PriceListLine."Price Type" := PriceListLine."Price Type"::Sale;
+        PriceListLine."Amount Type" := PriceListLine."Amount Type"::Discount;
+        PriceListLine."Source Type" := PriceListLine."Source Type"::"Customer Disc. Group";
+        PriceListLine."Source No." := CustDiscGrp.Code;
+        PriceListLine.Validate("Line Discount %", DiscountPerc);
+        PriceListLine.Status := PriceListLine.Status::Active;
+        PriceListLine.Insert();
+    end;
+
+    internal procedure CreateCustomerPriceList(Code: Code[10]; ItemNo: Code[20]; Price: Decimal; DiscountPerc: Decimal) Cust: Record "Customer"
+    var
+        CustomerPriceGroup: Record "Customer Price Group";
+        PriceListLine: Record "Price List Line";
+        PriceListHeader: Record "Price List Header";
+    begin
+        if not Cust.get(code) then begin
+            Cust.Init();
+            Cust."No." := Code;
+            Cust.Insert();
+        end;
+
+        PriceListHeader.Init();
+        PriceListHeader.Code := Any.AlphabeticText(MaxStrLen(PriceListHeader.Code));
+        PriceListHeader."Source Group" := PriceListHeader."Source Group"::Customer;
+        PriceListHeader."Source Type" := PriceListHeader."Source Type"::Customer;
+        PriceListHeader."Source No." := Cust."No.";
+        PriceListHeader."Assign-to No." := Cust."No.";
+        PriceListHeader."Price Type" := PriceListHeader."Price Type"::Sale;
+        PriceListHeader."Amount Type" := PriceListHeader."Amount Type"::Discount;
+        PriceListHeader."Allow Line Disc." := true;
+        PriceListHeader.Status := PriceListHeader.Status::Active;
+        PriceListHeader."Filter Source No." := Cust."No.";
+        PriceListHeader.Insert();
+
+        PriceListLine.Init();
+        PriceListLine."Price List Code" := PriceListHeader.Code;
+        PriceListLine."Asset Type" := PriceListLine."Asset Type"::Item;
+        PriceListLine."Asset No." := ItemNo;
+        PriceListLine."Product No." := ItemNo;
+        PriceListLine."Price Type" := PriceListLine."Price Type"::Sale;
+        PriceListLine."Amount Type" := PriceListLine."Amount Type"::Discount;
+        PriceListLine."Source Type" := PriceListLine."Source Type"::Customer;
+        PriceListLine."Source No." := Cust."No.";
+        PriceListLine.Validate("Line Discount %", DiscountPerc);
+        PriceListLine.Status := PriceListLine.Status::Active;
+        PriceListLine.Insert();
+    end;
 }


### PR DESCRIPTION
#### Summary 
Added Customer No to the 
          table 30152 "Shpfy Catalog"
          page 30159 "Shpfy Catalogs"

Added logic to use customer specific pricing from catalog
           codeunit 30182 "Shpfy Product Price Calc."

Fixes #26980
Fixes [AB#544010](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/544010)



