### PR TITLE
Use procedure IsSaaSInfrastructure instead of IsSaaS

### DIFF
--- a/Apps/W1/EDocumentsConnector/app/src/E3Party/EDocExtConnectionSetupCard.Page.al
+++ b/Apps/W1/EDocumentsConnector/app/src/E3Party/EDocExtConnectionSetupCard.Page.al
@@ -27,7 +27,7 @@ page 6361 "EDoc Ext Connection Setup Card"
                     ToolTip = 'Specifies the client ID token.';
                     ApplicationArea = Basic, Suite;
                     ExtendedDatatype = Masked;
-                    Visible = not IsSaaS;
+                    Visible = not IsSaaSInfrastructure;
                     ShowMandatory = true;
 
                     trigger OnValidate()
@@ -41,7 +41,7 @@ page 6361 "EDoc Ext Connection Setup Card"
                     ToolTip = 'Specifies the client secret token.';
                     ApplicationArea = Basic, Suite;
                     ExtendedDatatype = Masked;
-                    Visible = not IsSaaS;
+                    Visible = not IsSaaSInfrastructure;
                     ShowMandatory = true;
 
                     trigger OnValidate()
@@ -53,13 +53,13 @@ page 6361 "EDoc Ext Connection Setup Card"
                 {
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the URL to connect to Pagero Online.';
-                    Visible = not IsSaaS;
+                    Visible = not IsSaaSInfrastructure;
                 }
                 field("Redirect URL"; Rec."Redirect URL")
                 {
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the redirect URL.';
-                    Visible = not IsSaaS;
+                    Visible = not IsSaaSInfrastructure;
                 }
                 field("FileAPI URL"; Rec."FileAPI URL")
                 {
@@ -122,7 +122,7 @@ page 6361 "EDoc Ext Connection Setup Card"
         EnvironmentInfo: Codeunit "Environment Information";
 
     begin
-        IsSaaS := EnvironmentInfo.IsSaaS();
+        IsSaaSInfrastructure := EnvironmentInfo.IsSaaSInfrastructure();
 
         PageroAuth.InitConnectionSetup();
         PageroAuth.IsClientCredsSet(ClientID, ClientSecret);
@@ -142,6 +142,6 @@ page 6361 "EDoc Ext Connection Setup Card"
         FeatureTelemetry: Codeunit "Feature Telemetry";
         [NonDebuggable]
         ClientID, ClientSecret : Text;
-        IsSaaS: Boolean;
+        IsSaaSInfrastructure: Boolean;
         ExternalServiceTok: Label 'ExternalServiceConnector', Locked = true;
 }

--- a/Apps/W1/EDocumentsConnector/app/src/Pagero/PageroAuth.Codeunit.al
+++ b/Apps/W1/EDocumentsConnector/app/src/Pagero/PageroAuth.Codeunit.al
@@ -50,7 +50,7 @@ codeunit 6364 "Pagero Auth."
     begin
         EDocExtConnectionSetup.Get();
 
-        if EnvironmentInfo.IsSaaS() then
+        if EnvironmentInfo.IsSaaSInfrastructure() then
             exit(true);
 
         if HasToken(EDocExtConnectionSetup."Client ID", DataScope::Company) then
@@ -192,7 +192,7 @@ codeunit 6364 "Pagero Auth."
         Secret: Text;
     begin
 
-        if EnvironmentInfo.IsSaaS() then begin
+        if EnvironmentInfo.IsSaaSInfrastructure() then begin
             AzureKeyVault.GetAzureKeyVaultSecret('pagero-client-id', Secret);
             exit(Secret);
         end;
@@ -207,7 +207,7 @@ codeunit 6364 "Pagero Auth."
         AzureKeyVault: Codeunit "Azure Key Vault";
         Secret: SecretText;
     begin
-        if EnvironmentInfo.IsSaaS() then begin
+        if EnvironmentInfo.IsSaaSInfrastructure() then begin
             AzureKeyVault.GetAzureKeyVaultSecret('pagero-client-secret', Secret);
             exit(Secret);
         end;


### PR DESCRIPTION
#### Summary
Use procedure IsSaaSInfrastructure since for azure key vault secrets it's only important if the environment is BC SaaS or anything else.
If the key vault feature should be checked during testing then this has to be done in a BC SaaS Sandbox.


#### Work Item(s)
Fixes #27260



Fixes [AB#549124](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/549124)

