### PR TITLE
Fix localdevenv in 1st Party Apps (W1) project

### DIFF
--- a/Build/projects/1st Party Apps (W1)/.AL-Go/NewBcContainer.ps1
+++ b/Build/projects/1st Party Apps (W1)/.AL-Go/NewBcContainer.ps1
@@ -1,0 +1,8 @@
+Param(
+    [Hashtable]$parameters
+)
+
+if ("$env:GITHUB_RUN_ID" -eq "") {
+    $script = Join-Path $PSScriptRoot "../../../scripts/NewBcContainer.ps1" -Resolve
+    . $script -parameters $parameters
+}

--- a/Build/projects/1st Party Apps (W1)/.AL-Go/localDevEnv.settings.json
+++ b/Build/projects/1st Party Apps (W1)/.AL-Go/localDevEnv.settings.json
@@ -1,0 +1,4 @@
+{
+    "doNotPublishApps": false,
+    "useCompilerFolder": false
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to AlAppExtensions please read our pull request guideline below
* https://github.com/microsoft/ALAppExtensions/blob/main/CONTRIBUTING.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Fix localdevenv in 1st Party Apps (W1) project. Running the NewBCContainer override will unpublish all the existing 1st party apps.  If we don't we'll run into issues like: 
`Publishing failed due to 'Cannot install the extension API Reports - Finance by Microsoft 26.0.0.0 because a newer version 26.0.24098.0 was already installed.'.`

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes [AB#550722](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/550722)



