### PR TITLE
Shopify Connector Tax ID, Multiple Company Locations, Tax ID export, Company Mapping by Tax ID,  Payment Terms Export/Import, Company External ID

### DIFF
--- a/Apps/W1/Shopify/app/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/Apps/W1/Shopify/app/src/Base/Pages/ShpfyShopCard.Page.al
@@ -425,11 +425,10 @@ page 30101 "Shpfy Shop Card"
                     ApplicationArea = All;
                     ToolTip = 'Specifies how to map companies.';
                 }
-                //JZA: Task 3 Tax ID
                 field("Shpfy Comp.Tax Id Mapping"; Rec."Shpfy Comp. Tax Id Mapping")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Specifies how to map Shopify Tax ID.';
+                    ToolTip = 'Specifies how to map Shopify Tax ID with Business Central.';
                 }
                 field("Auto Create Unknown Companies"; Rec."Auto Create Unknown Companies")
                 {

--- a/Apps/W1/Shopify/app/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/Apps/W1/Shopify/app/src/Base/Pages/ShpfyShopCard.Page.al
@@ -425,6 +425,12 @@ page 30101 "Shpfy Shop Card"
                     ApplicationArea = All;
                     ToolTip = 'Specifies how to map companies.';
                 }
+                //JZA: Task 3 Tax ID
+                field("Shpfy Comp.Tax Id Mapping"; Rec."Shpfy Comp. Tax Id Mapping")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies how to map Shopify Tax ID.';
+                }
                 field("Auto Create Unknown Companies"; Rec."Auto Create Unknown Companies")
                 {
                     ApplicationArea = All;

--- a/Apps/W1/Shopify/app/src/Base/Tables/ShpfyShop.Table.al
+++ b/Apps/W1/Shopify/app/src/Base/Tables/ShpfyShop.Table.al
@@ -788,7 +788,6 @@ table 30102 "Shpfy Shop"
             Caption = 'Weight Unit';
             DataClassification = CustomerContent;
         }
-        //JZA: Task 3 Tax ID
         field(130; "Shpfy Comp. Tax Id Mapping"; Enum "Shpfy Comp. Tax Id Mapping")
         {
             Caption = 'Company Tax Id Mapping';

--- a/Apps/W1/Shopify/app/src/Base/Tables/ShpfyShop.Table.al
+++ b/Apps/W1/Shopify/app/src/Base/Tables/ShpfyShop.Table.al
@@ -788,6 +788,12 @@ table 30102 "Shpfy Shop"
             Caption = 'Weight Unit';
             DataClassification = CustomerContent;
         }
+        //JZA: Task 3 Tax ID
+        field(130; "Shpfy Comp. Tax Id Mapping"; Enum "Shpfy Comp. Tax Id Mapping")
+        {
+            Caption = 'Company Tax Id Mapping';
+            DataClassification = CustomerContent;
+        }
         field(200; "Shop Id"; Integer)
         {
             DataClassification = SystemMetadata;

--- a/Apps/W1/Shopify/app/src/Catalogs/Codeunits/ShpfyCatalogAPI.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Catalogs/Codeunits/ShpfyCatalogAPI.Codeunit.al
@@ -1,6 +1,7 @@
 namespace Microsoft.Integration.Shopify;
 
 using Microsoft.Finance.GeneralLedger.Setup;
+using Microsoft.Sales.Customer;
 
 /// <summary>
 /// Codeunit Shpfy Catalog API (ID 30290).
@@ -15,7 +16,7 @@ codeunit 30290 "Shpfy Catalog API"
         JsonHelper: Codeunit "Shpfy Json Helper";
         ShopifyCatalogURLLbl: Label 'https://admin.shopify.com/store/%1/catalogs/%2/editor', Comment = '%1 - Shop Name, %2 - Catalog Id', Locked = true;
 
-    internal procedure CreateCatalog(ShopifyCompany: Record "Shpfy Company")
+    internal procedure CreateCatalog(ShopifyCompany: Record "Shpfy Company"; Customer: Record Customer)
     var
         Catalog: Record "Shpfy Catalog";
         GraphQLType: Enum "Shpfy GraphQL Type";
@@ -32,6 +33,7 @@ codeunit 30290 "Shpfy Catalog API"
             Catalog."Shop Code" := Shop.Code;
             Catalog.Name := ShopifyCompany.Name;
             Catalog."Company SystemId" := ShopifyCompany.SystemId;
+            Catalog."Customer No." := Customer."No.";
             Catalog.Insert();
             CreatePublication(Catalog);
             CreatePriceList(Catalog);

--- a/Apps/W1/Shopify/app/src/Catalogs/Pages/ShpfyCatalogs.Page.al
+++ b/Apps/W1/Shopify/app/src/Catalogs/Pages/ShpfyCatalogs.Page.al
@@ -28,7 +28,7 @@ page 30159 "Shpfy Catalogs"
                 field("Customer No."; Rec."Customer No.")
                 {
                     ApplicationArea = All;
-                    Visible = false;
+                    Editable = false;
                     ToolTip = 'Specifies the customer''s no.  When Customer No. is Selected: Parameters like ''Customer Discount Group'', ''Customer Price Group'', and ''Allow Line Discount'' on the customer card take precedence over catalog settings';
                 }
                 field(Name; Rec.Name)

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompByDefaultComp.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompByDefaultComp.Codeunit.al
@@ -1,5 +1,7 @@
 namespace Microsoft.Integration.Shopify;
 
+using Microsoft.Sales.Customer;
+
 /// <summary>
 /// Codeunit Shpfy Comp. By Default Comp. (ID 30305) implements Interface Shpfy ICompany Mapping.
 /// </summary>
@@ -14,5 +16,37 @@ codeunit 30305 "Shpfy Comp. By Default Comp." implements "Shpfy ICompany Mapping
     begin
         Shop.Get(ShopCode);
         exit(Shop."Default Company No.");
+    end;
+
+    internal procedure FindMapping(var ShopifyCompany: Record "Shpfy Company"; var TempShopifyCustomer: Record "Shpfy Customer" temporary): Boolean
+    var
+        Customer: Record Customer;
+        ShopifyCustomer: Record "Shpfy Customer";
+        Shop: Record "Shpfy Shop";
+    begin
+        if not IsNullGuid(ShopifyCompany."Customer SystemId") then
+            if Customer.GetBySystemId(ShopifyCompany."Customer SystemId") then
+                exit(true)
+            else begin
+                Clear(ShopifyCompany."Customer SystemId");
+                ShopifyCompany.Modify();
+            end;
+
+        if IsNullGuid(ShopifyCompany."Customer SystemId") then begin
+            Shop.Get(ShopifyCompany."Shop Code");
+            if Customer.Get(Shop."Default Company No.") then begin
+                ShopifyCompany."Customer SystemId" := Customer.SystemId;
+
+                if not ShopifyCustomer.Get(TempShopifyCustomer.Id) then begin
+                    ShopifyCustomer.Copy(TempShopifyCustomer);
+                    ShopifyCustomer."Customer SystemId" := Customer.SystemId;
+                    ShopifyCustomer.Insert();
+                end;
+
+                ShopifyCompany."Main Contact Customer Id" := ShopifyCustomer.Id;
+                ShopifyCompany.Modify();
+                exit(true);
+            end;
+        end;
     end;
 }

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompByEmailPhone.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompByEmailPhone.Codeunit.al
@@ -1,5 +1,7 @@
 namespace Microsoft.Integration.Shopify;
 
+using Microsoft.Sales.Customer;
+
 /// <summary>
 /// Codeunit ShoShpfypify Comp. By Email/Phone (ID 30304) implements Interface Shpfy ICompany Mapping.
 /// </summary>
@@ -25,6 +27,61 @@ codeunit 30304 "Shpfy Comp. By Email/Phone" implements "Shpfy ICompany Mapping"
         end else
             exit(CreateCompany(CompanyId, ShopCode, TemplateCode, AllowCreate));
         exit('');
+    end;
+
+    internal procedure FindMapping(var ShopifyCompany: Record "Shpfy Company"; var TempShopifyCustomer: Record "Shpfy Customer" temporary): Boolean
+    var
+        Customer: Record Customer;
+        ShopifyCustomer: Record "Shpfy Customer";
+        CustomerMapping: Codeunit "Shpfy Customer Mapping";
+        PhoneFilter: Text;
+    begin
+        if not IsNullGuid(ShopifyCompany."Customer SystemId") then
+            if Customer.GetBySystemId(ShopifyCompany."Customer SystemId") then
+                exit(true)
+            else begin
+                Clear(ShopifyCompany."Customer SystemId");
+                ShopifyCompany.Modify();
+            end;
+
+        if IsNullGuid(ShopifyCompany."Customer SystemId") then begin
+            if TempShopifyCustomer.Email <> '' then begin
+                Customer.SetFilter("E-Mail", '@' + TempShopifyCustomer.Email);
+                if Customer.FindFirst() then begin
+                    ShopifyCompany."Customer SystemId" := Customer.SystemId;
+
+                    if not ShopifyCustomer.Get(TempShopifyCustomer.Id) then begin
+                        ShopifyCustomer.Copy(TempShopifyCustomer);
+                        ShopifyCustomer."Customer SystemId" := Customer.SystemId;
+                        ShopifyCustomer.Insert();
+                    end;
+
+                    ShopifyCompany."Main Contact Customer Id" := ShopifyCustomer.Id;
+                    ShopifyCompany.Modify();
+                    exit(true);
+                end;
+            end;
+            if TempShopifyCustomer."Phone No." <> '' then begin
+                PhoneFilter := CustomerMapping.CreatePhoneFilter(TempShopifyCustomer."Phone No.");
+                if PhoneFilter <> '' then begin
+                    Clear(Customer);
+                    Customer.SetFilter("Phone No.", PhoneFilter);
+                    if Customer.FindFirst() then begin
+                        ShopifyCompany."Customer SystemId" := Customer.SystemId;
+
+                        if not ShopifyCustomer.Get(TempShopifyCustomer.Id) then begin
+                            ShopifyCustomer.Copy(TempShopifyCustomer);
+                            ShopifyCustomer."Customer SystemId" := Customer.SystemId;
+                            ShopifyCustomer.Insert();
+                        end;
+
+                        ShopifyCompany."Main Contact Customer Id" := ShopifyCustomer.Id;
+                        ShopifyCompany.Modify();
+                        exit(true);
+                    end;
+                end;
+            end;
+        end;
     end;
 
     local procedure CreateCompany(CompanyId: BigInteger; ShopCode: Code[20]; TemplateCode: Code[20]; AllowCreate: Boolean): Code[20]

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompByTaxId.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompByTaxId.Codeunit.al
@@ -1,0 +1,47 @@
+namespace Microsoft.Integration.Shopify;
+//JZA: Task 3 Tax ID
+/// <summary>
+/// Codeunit ShoShpfypify Comp. By Email/Phone (ID 30304) implements Interface Shpfy ICompany Mapping.
+/// </summary>
+codeunit 30366 "Shpfy Comp. By Tax Id" implements "Shpfy ICompany Mapping"
+{
+    Access = Internal;
+
+    internal procedure DoMapping(CompanyId: BigInteger; ShopCode: Code[20]; TemplateCode: Code[20]; AllowCreate: Boolean): Code[20]
+    var
+        ShopifyCompany: Record "Shpfy Company";
+    begin
+        ShopifyCompany.SetAutoCalcFields("Customer No.");
+        if ShopifyCompany.Get(CompanyId) then begin
+            if not IsNullGuid(ShopifyCompany."Customer SystemId") then begin
+                ShopifyCompany.CalcFields("Customer No.");
+                if ShopifyCompany."Customer No." = '' then begin
+                    Clear(ShopifyCompany."Customer SystemId");
+                    ShopifyCompany.Modify();
+                end else
+                    exit(ShopifyCompany."Customer No.");
+            end;
+            exit(CreateCompany(CompanyId, ShopCode, TemplateCode, AllowCreate));
+        end else
+            exit(CreateCompany(CompanyId, ShopCode, TemplateCode, AllowCreate));
+        exit('');
+    end;
+
+    local procedure CreateCompany(CompanyId: BigInteger; ShopCode: Code[20]; TemplateCode: Code[20]; AllowCreate: Boolean): Code[20]
+    var
+        ShopifyCompany: Record "Shpfy Company";
+        TempCompany: Record "Shpfy Company" temporary;
+        CompanyImport: Codeunit "Shpfy Company Import";
+    begin
+        CompanyImport.SetShop(ShopCode);
+        CompanyImport.SetAllowCreate(AllowCreate);
+        CompanyImport.SetTemplateCode(TemplateCode);
+        TempCompany.Id := CompanyId;
+        TempCompany.Insert();
+        CompanyImport.Run(TempCompany);
+        CompanyImport.GetCompany(ShopifyCompany);
+        if ShopifyCompany.Find() then
+            ShopifyCompany.CalcFields("Customer No.");
+        exit(ShopifyCompany."Customer No.");
+    end;
+}

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompByTaxId.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompByTaxId.Codeunit.al
@@ -3,7 +3,7 @@ namespace Microsoft.Integration.Shopify;
 using Microsoft.Sales.Customer;
 
 /// <summary>
-/// Codeunit ShoShpfypify Comp. By Email/Phone (ID 30304) implements Interface Shpfy ICompany Mapping.
+/// Codeunit Shpfy Comp. By Tax Id (ID 30366) implements Interface Shpfy ICompany Mapping.
 /// </summary>
 codeunit 30366 "Shpfy Comp. By Tax Id" implements "Shpfy ICompany Mapping"
 {

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompByTaxId.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompByTaxId.Codeunit.al
@@ -1,5 +1,7 @@
 namespace Microsoft.Integration.Shopify;
-//JZA: Task 3 Tax ID
+
+using Microsoft.Sales.Customer;
+
 /// <summary>
 /// Codeunit ShoShpfypify Comp. By Email/Phone (ID 30304) implements Interface Shpfy ICompany Mapping.
 /// </summary>
@@ -25,6 +27,48 @@ codeunit 30366 "Shpfy Comp. By Tax Id" implements "Shpfy ICompany Mapping"
         end else
             exit(CreateCompany(CompanyId, ShopCode, TemplateCode, AllowCreate));
         exit('');
+    end;
+
+    internal procedure FindMapping(var ShopifyCompany: Record "Shpfy Company"; var TempShopifyCustomer: Record "Shpfy Customer" temporary): Boolean
+    var
+        Customer: Record Customer;
+        ShopifyCustomer: Record "Shpfy Customer";
+        Shop: Record "Shpfy Shop";
+        CompanyLocation: Record "Shpfy Company Location";
+        ShpfyTaxRegistrationIdMapping: Interface "Shpfy Tax Registration Id Mapping";
+    begin
+        if not IsNullGuid(ShopifyCompany."Customer SystemId") then
+            if Customer.GetBySystemId(ShopifyCompany."Customer SystemId") then
+                exit(true)
+            else begin
+                Clear(ShopifyCompany."Customer SystemId");
+                ShopifyCompany.Modify();
+            end;
+
+        if IsNullGuid(ShopifyCompany."Customer SystemId") then begin
+            if ShopifyCompany."Location Id" <> 0 then begin
+                CompanyLocation.Get(ShopifyCompany."Location Id");
+                if CompanyLocation."Tax Registration Id" <> '' then begin
+                    Clear(Customer);
+                    Shop.Get(ShopifyCompany."Shop Code");
+                    ShpfyTaxRegistrationIdMapping := Shop."Shpfy Comp. Tax Id Mapping";
+                    ShpfyTaxRegistrationIdMapping.SetMappingFiltersForCustomers(Customer, CompanyLocation);
+                    if Customer.FindFirst() then begin
+                        ShopifyCompany."Customer SystemId" := Customer.SystemId;
+
+                        if not ShopifyCustomer.Get(TempShopifyCustomer.Id) then begin
+                            ShopifyCustomer.Copy(TempShopifyCustomer);
+                            ShopifyCustomer."Customer SystemId" := Customer.SystemId;
+                            ShopifyCustomer.Insert();
+                        end;
+
+                        ShopifyCompany."Main Contact Customer Id" := ShopifyCustomer.Id;
+                        ShopifyCompany.Modify();
+                        exit(true);
+                    end;
+                end;
+            end;
+        end;
     end;
 
     local procedure CreateCompany(CompanyId: BigInteger; ShopCode: Code[20]; TemplateCode: Code[20]; AllowCreate: Boolean): Code[20]

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyAPI.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyAPI.Codeunit.al
@@ -24,7 +24,8 @@ codeunit 30286 "Shpfy Company API"
         CompanyContactId: BigInteger;
         CompanyContactRoles: Dictionary of [Text, BigInteger];
     begin
-        GraphQuery := CreateCompanyGraphQLQuery(ShopifyCompany, CompanyLocation);
+        //JZA: Task 5 - External ID
+        GraphQuery := CreateCompanyGraphQLQuery(ShopifyCompany, CompanyLocation, ShopifyCustomer);
         JResponse := CommunicationMgt.ExecuteGraphQL(GraphQuery);
         if JResponse.SelectToken('$.data.companyCreate.company', JItem) then
             if JItem.IsObject then
@@ -102,13 +103,17 @@ codeunit 30286 "Shpfy Company API"
         exit(true);
     end;
 
-    internal procedure CreateCompanyGraphQLQuery(var ShopifyCompany: Record "Shpfy Company"; CompanyLocation: Record "Shpfy Company Location"): Text
+    internal procedure CreateCompanyGraphQLQuery(var ShopifyCompany: Record "Shpfy Company"; CompanyLocation: Record "Shpfy Company Location"; ShopifyCustomer: Record "Shpfy Customer"): Text
     var
         GraphQuery: TextBuilder;
     begin
         GraphQuery.Append('{"query":"mutation {companyCreate(input: {company: {');
         if ShopifyCompany.Name <> '' then
             AddFieldToGraphQuery(GraphQuery, 'name', ShopifyCompany.Name);
+        //JZA: Task 5 - External ID
+        ShopifyCustomer.CalcFields("Customer No.");
+        if ShopifyCustomer."Customer No." <> '' then
+            AddFieldToGraphQuery(GraphQuery, 'externalId', ShopifyCustomer."Customer No.");
         GraphQuery.Remove(GraphQuery.Length - 1, 2);
         GraphQuery.Append('}, companyLocation: {billingSameAsShipping: true,');
         AddFieldToGraphQuery(GraphQuery, 'name', CompanyLocation.Name);

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyAPI.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyAPI.Codeunit.al
@@ -300,6 +300,7 @@ codeunit 30286 "Shpfy Company API"
         OutStream: OutStream;
         PhoneNo: Text;
         IsDefaultCompanyLocation: Boolean;
+        CompanyLocationId: BigInteger;
     begin
         UpdatedAt := JsonHelper.GetValueAsDateTime(JCompany, 'updatedAt');
         if UpdatedAt <= ShopifyCompany."Updated At" then
@@ -322,11 +323,13 @@ codeunit 30286 "Shpfy Company API"
         IsDefaultCompanyLocation := true;
         if JsonHelper.GetJsonArray(JCompany, JLocations, 'locations.edges') then
             foreach JItem in JLocations do begin
-                ShopifyCompany."Location Id" := CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JItem, 'node.id'));
+                CompanyLocationId := CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JItem, 'node.id'));
+                if IsDefaultCompanyLocation then
+                    ShopifyCompany."Location Id" := CompanyLocationId;
 
-                CompanyLocation.SetRange(Id, ShopifyCompany."Location Id");
+                CompanyLocation.SetRange(Id, CompanyLocationId);
                 if not CompanyLocation.FindFirst() then begin
-                    CompanyLocation.Id := ShopifyCompany."Location Id";
+                    CompanyLocation.Id := CompanyLocationId;
                     CompanyLocation."Company SystemId" := ShopifyCompany.SystemId;
                     CompanyLocation.Name := CopyStr(JsonHelper.GetValueAsText(JItem, 'node.name'), 1, MaxStrLen(CompanyLocation.Name));
                     CompanyLocation.Insert();
@@ -343,7 +346,6 @@ codeunit 30286 "Shpfy Company API"
                 PhoneNo := CopyStr(DelChr(PhoneNo, '=', DelChr(PhoneNo, '=', '1234567890/+ .()')), 1, MaxStrLen(CompanyLocation."Phone No."));
                 CompanyLocation."Phone No." := CopyStr(PhoneNo, 1, MaxStrLen(CompanyLocation."Phone No."));
                 CompanyLocation."Tax Registration Id" := CopyStr(JsonHelper.GetValueAsText(JItem, 'node.taxRegistrationId', MaxStrLen(CompanyLocation."Tax Registration Id")), 1, MaxStrLen(CompanyLocation."Tax Registration Id"));
-                CompanyLocation.Default := false;
                 if IsDefaultCompanyLocation then begin
                     CompanyLocation.Default := IsDefaultCompanyLocation;
                     IsDefaultCompanyLocation := false;

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyAPI.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyAPI.Codeunit.al
@@ -24,13 +24,11 @@ codeunit 30286 "Shpfy Company API"
         CompanyContactId: BigInteger;
         CompanyContactRoles: Dictionary of [Text, BigInteger];
     begin
-        //JZA: Task 5 - External ID
         GraphQuery := CreateCompanyGraphQLQuery(ShopifyCompany, CompanyLocation, ShopifyCustomer);
         JResponse := CommunicationMgt.ExecuteGraphQL(GraphQuery);
         if JResponse.SelectToken('$.data.companyCreate.company', JItem) then
             if JItem.IsObject then
                 ShopifyCompany.Id := CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JItem, 'id'));
-        // JZA: Task2 - Task is only for Company location import. Exports won't work with for all locations
         if JsonHelper.GetJsonArray(JResponse, JLocations, 'data.companyCreate.company.locations.edges') then
             if JLocations.Count = 1 then
                 if JLocations.Get(0, JItem) then begin
@@ -110,7 +108,6 @@ codeunit 30286 "Shpfy Company API"
         GraphQuery.Append('{"query":"mutation {companyCreate(input: {company: {');
         if ShopifyCompany.Name <> '' then
             AddFieldToGraphQuery(GraphQuery, 'name', ShopifyCompany.Name);
-        //JZA: Task 5 - External ID
         ShopifyCustomer.CalcFields("Customer No.");
         if ShopifyCustomer."Customer No." <> '' then
             AddFieldToGraphQuery(GraphQuery, 'externalId', ShopifyCustomer."Customer No.");

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
@@ -59,7 +59,7 @@ codeunit 30284 "Shpfy Company Export"
                     ShopifyCompany.Insert();
 
                     if Shop."Auto Create Catalog" then
-                        CatalogAPI.CreateCatalog(ShopifyCompany);
+                        CatalogAPI.CreateCatalog(ShopifyCompany, Customer);
 
                     CompanyLocation."Company SystemId" := ShopifyCompany.SystemId;
                     CompanyLocation.Insert();

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
@@ -142,9 +142,26 @@ codeunit 30284 "Shpfy Company Export"
 
         CompanyLocation."Phone No." := Customer."Phone No.";
 
+        //JZA: Task 3 Tax ID
+        CompanyLocation."Tax Registration Id" := GetTaxRegistrationIdFromCustomer(Customer);
+
         if HasDiff(ShopifyCompany, TempShopifyCompany) or HasDiff(CompanyLocation, TempCompanyLocation) then begin
             ShopifyCompany."Last Updated by BC" := CurrentDateTime;
             exit(true);
+        end;
+    end;
+
+    //JZA: Task 3 Tax ID
+    local procedure GetTaxRegistrationIdFromCustomer(Customer: Record Customer): Text
+    begin
+        case Shop."Shpfy Comp. Tax Id Mapping" of
+            Shop."Shpfy Comp. Tax Id Mapping"::RegistrationNo:
+                exit(Customer."Registration Number");
+            Shop."Shpfy Comp. Tax Id Mapping"::VATRegistrationNo:
+                exit(Customer."VAT Registration No.");
+            else
+                exit('');
+        //JZA: "Shpfy Comp. Tax Id Mapping" enum is extended publisher is needed
         end;
     end;
 
@@ -186,6 +203,7 @@ codeunit 30284 "Shpfy Company Export"
             exit;
 
         CompanyLocation.SetRange("Company SystemId", ShopifyCompany.SystemId);
+        CompanyLocation.SetRange(Default, true);
         CompanyLocation.FindFirst();
 
         if FillInShopifyCompany(Customer, ShopifyCompany, CompanyLocation) then begin

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
@@ -61,6 +61,7 @@ codeunit 30284 "Shpfy Company Export"
                     if Shop."Auto Create Catalog" then
                         CatalogAPI.CreateCatalog(ShopifyCompany, Customer);
 
+                    CompanyLocation.Default := true;
                     CompanyLocation."Company SystemId" := ShopifyCompany.SystemId;
                     CompanyLocation.Insert();
                 end;

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
@@ -88,6 +88,7 @@ codeunit 30284 "Shpfy Company Export"
         TaxArea: Record "Shpfy Tax Area";
         TempShopifyCompany: Record "Shpfy Company" temporary;
         TempCompanyLocation: Record "Shpfy Company Location" temporary;
+        ShpfyTaxRegistrationIdMapping: Interface "Shpfy Tax Registration Id Mapping";
         CountyCodeTooLongErr: Text;
     begin
         TempShopifyCompany := ShopifyCompany;
@@ -144,25 +145,12 @@ codeunit 30284 "Shpfy Company Export"
         CompanyLocation."Phone No." := Customer."Phone No.";
 
         //JZA: Task 3 Tax ID
-        CompanyLocation."Tax Registration Id" := GetTaxRegistrationIdFromCustomer(Customer);
+        ShpfyTaxRegistrationIdMapping := Shop."Shpfy Comp. Tax Id Mapping";
+        CompanyLocation."Tax Registration Id" := ShpfyTaxRegistrationIdMapping.GetTaxRegistrationId(Customer);
 
         if HasDiff(ShopifyCompany, TempShopifyCompany) or HasDiff(CompanyLocation, TempCompanyLocation) then begin
             ShopifyCompany."Last Updated by BC" := CurrentDateTime;
             exit(true);
-        end;
-    end;
-
-    //JZA: Task 3 Tax ID
-    local procedure GetTaxRegistrationIdFromCustomer(Customer: Record Customer): Text
-    begin
-        case Shop."Shpfy Comp. Tax Id Mapping" of
-            Shop."Shpfy Comp. Tax Id Mapping"::RegistrationNo:
-                exit(Customer."Registration Number");
-            Shop."Shpfy Comp. Tax Id Mapping"::VATRegistrationNo:
-                exit(Customer."VAT Registration No.");
-            else
-                exit('');
-        //JZA: "Shpfy Comp. Tax Id Mapping" enum is extended publisher is needed
         end;
     end;
 

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
@@ -145,7 +145,6 @@ codeunit 30284 "Shpfy Company Export"
 
         CompanyLocation."Phone No." := Customer."Phone No.";
 
-        //JZA: Task 3 Tax ID
         ShpfyTaxRegistrationIdMapping := Shop."Shpfy Comp. Tax Id Mapping";
         CompanyLocation."Tax Registration Id" := ShpfyTaxRegistrationIdMapping.GetTaxRegistrationId(Customer);
 
@@ -196,7 +195,6 @@ codeunit 30284 "Shpfy Company Export"
             exit;
 
         CompanyLocation.SetRange("Company SystemId", ShopifyCompany.SystemId);
-        CompanyLocation.SetRange(Default, true);
         CompanyLocation.FindFirst();
 
         if FillInShopifyCompany(Customer, ShopifyCompany, CompanyLocation) then begin

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyExport.Codeunit.al
@@ -90,6 +90,7 @@ codeunit 30284 "Shpfy Company Export"
         TempCompanyLocation: Record "Shpfy Company Location" temporary;
         ShpfyTaxRegistrationIdMapping: Interface "Shpfy Tax Registration Id Mapping";
         CountyCodeTooLongErr: Text;
+        ShpfyPaymentTermsId: BigInteger;
     begin
         TempShopifyCompany := ShopifyCompany;
         TempCompanyLocation := CompanyLocation;
@@ -148,6 +149,9 @@ codeunit 30284 "Shpfy Company Export"
         ShpfyTaxRegistrationIdMapping := Shop."Shpfy Comp. Tax Id Mapping";
         CompanyLocation."Tax Registration Id" := ShpfyTaxRegistrationIdMapping.GetTaxRegistrationId(Customer);
 
+        if GetShpfyPaymentTermsIdFromCustomer(Customer, ShpfyPaymentTermsId) then
+            CompanyLocation."Shpfy Payment Terms Id" := ShpfyPaymentTermsId;
+
         if HasDiff(ShopifyCompany, TempShopifyCompany) or HasDiff(CompanyLocation, TempCompanyLocation) then begin
             ShopifyCompany."Last Updated by BC" := CurrentDateTime;
             exit(true);
@@ -205,5 +209,17 @@ codeunit 30284 "Shpfy Company Export"
     internal procedure SetCreateCompanies(NewCustomers: Boolean)
     begin
         CreateCustomers := NewCustomers;
+    end;
+
+    local procedure GetShpfyPaymentTermsIdFromCustomer(Customer: Record Customer; var ShpfyPaymentTermsId: BigInteger): Boolean
+    var
+        ShpfyPaymentTerms: Record "Shpfy Payment Terms";
+    begin
+        ShpfyPaymentTerms.SetRange("Shop Code", Shop.Code);
+        ShpfyPaymentTerms.SetRange("Payment Terms Code", Customer."Payment Terms Code");
+        if ShpfyPaymentTerms.FindFirst() then begin
+            ShpfyPaymentTermsId := ShpfyPaymentTerms.Id;
+            exit(true);
+        end;
     end;
 }

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyImport.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyCompanyImport.Codeunit.al
@@ -68,6 +68,7 @@ codeunit 30301 "Shpfy Company Import"
     begin
         Shop := ShopifyShop;
         CompanyApi.SetShop(Shop);
+        CompanyMapping.SetShop(Shop);
     end;
 
     internal procedure SetShop(ShopCode: Code[20])

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyTaxRegistrationNo.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyTaxRegistrationNo.Codeunit.al
@@ -8,5 +8,10 @@ codeunit 30367 "Shpfy Tax Registration No." implements "Shpfy Tax Registration I
     begin
         exit(Customer."Registration Number");
     end;
+
+    procedure SetMappingFiltersForCustomers(var Customer: Record Customer; CompanyLocation: Record "Shpfy Company Location")
+    begin
+        Customer.SetRange("Registration Number", CompanyLocation."Tax Registration Id");
+    end;
 }
 

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyTaxRegistrationNo.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyTaxRegistrationNo.Codeunit.al
@@ -2,6 +2,9 @@ namespace Microsoft.Integration.Shopify;
 
 using Microsoft.Sales.Customer;
 
+/// <summary>
+/// Codeunit Shpfy Tax Registration No. (ID 30367) implements Interface Shpfy Tax Registration Id Mapping.
+/// </summary>
 codeunit 30367 "Shpfy Tax Registration No." implements "Shpfy Tax Registration Id Mapping"
 {
     procedure GetTaxRegistrationId(var Customer: Record Customer): Text;
@@ -14,4 +17,3 @@ codeunit 30367 "Shpfy Tax Registration No." implements "Shpfy Tax Registration I
         Customer.SetRange("Registration Number", CompanyLocation."Tax Registration Id");
     end;
 }
-

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyTaxRegistrationNo.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyTaxRegistrationNo.Codeunit.al
@@ -1,0 +1,12 @@
+namespace Microsoft.Integration.Shopify;
+
+using Microsoft.Sales.Customer;
+
+codeunit 30367 "Shpfy Tax Registration No." implements "Shpfy Tax Registration Id Mapping"
+{
+    procedure GetTaxRegistrationId(var Customer: Record Customer): Text;
+    begin
+        exit(Customer."Registration Number");
+    end;
+}
+

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyVATTaxRegistrationNo.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyVATTaxRegistrationNo.Codeunit.al
@@ -1,0 +1,12 @@
+namespace Microsoft.Integration.Shopify;
+
+using Microsoft.Sales.Customer;
+
+codeunit 30368 "Shpfy VAT Tax Registration No." implements "Shpfy Tax Registration Id Mapping"
+{
+    procedure GetTaxRegistrationId(var Customer: Record Customer): Text;
+    begin
+        exit(Customer."VAT Registration No.");
+    end;
+}
+

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyVATTaxRegistrationNo.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyVATTaxRegistrationNo.Codeunit.al
@@ -2,6 +2,9 @@ namespace Microsoft.Integration.Shopify;
 
 using Microsoft.Sales.Customer;
 
+/// <summary>
+/// Codeunit Shpfy VAT Tax Registration No. (ID 30368) implements Interface Shpfy Tax Registration Id Mapping.
+/// </summary>
 codeunit 30368 "Shpfy VAT Tax Registration No." implements "Shpfy Tax Registration Id Mapping"
 {
     procedure GetTaxRegistrationId(var Customer: Record Customer): Text;
@@ -14,4 +17,3 @@ codeunit 30368 "Shpfy VAT Tax Registration No." implements "Shpfy Tax Registrati
         Customer.SetRange("VAT Registration No.", CompanyLocation."Tax Registration Id");
     end;
 }
-

--- a/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyVATTaxRegistrationNo.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Companies/Codeunits/ShpfyVATTaxRegistrationNo.Codeunit.al
@@ -8,5 +8,10 @@ codeunit 30368 "Shpfy VAT Tax Registration No." implements "Shpfy Tax Registrati
     begin
         exit(Customer."VAT Registration No.");
     end;
+
+    procedure SetMappingFiltersForCustomers(var Customer: Record Customer; CompanyLocation: Record "Shpfy Company Location")
+    begin
+        Customer.SetRange("VAT Registration No.", CompanyLocation."Tax Registration Id");
+    end;
 }
 

--- a/Apps/W1/Shopify/app/src/Companies/Enums/ShpfyCompTaxIdMapping.Enum.al
+++ b/Apps/W1/Shopify/app/src/Companies/Enums/ShpfyCompTaxIdMapping.Enum.al
@@ -1,0 +1,19 @@
+namespace Microsoft.Integration.Shopify;
+//JZA: Task 3 Tax ID
+/// <summary>
+/// Enum Shopify Company Tax Id Mapping (ID 30165).
+/// </summary>
+enum 30165 "Shpfy Comp. Tax Id Mapping"
+{
+    Caption = 'Shopify Company Tax Id Mapping';
+    Extensible = true;
+
+    value(0; RegistrationNo)
+    {
+        Caption = 'Registration No.';
+    }
+    value(1; VATRegistrationNo)
+    {
+        Caption = 'VAT Registration No.';
+    }
+}

--- a/Apps/W1/Shopify/app/src/Companies/Enums/ShpfyCompTaxIdMapping.Enum.al
+++ b/Apps/W1/Shopify/app/src/Companies/Enums/ShpfyCompTaxIdMapping.Enum.al
@@ -1,7 +1,7 @@
 namespace Microsoft.Integration.Shopify;
-//JZA: Task 3 Tax ID
+
 /// <summary>
-/// Enum Shopify Company Tax Id Mapping (ID 30165).
+/// Enum Shopify Company Tax Id Mapping (ID 30165) implements Interface Shpfy Tax Registration Id Mapping.
 /// </summary>
 enum 30165 "Shpfy Comp. Tax Id Mapping" implements "Shpfy Tax Registration Id Mapping"
 {

--- a/Apps/W1/Shopify/app/src/Companies/Enums/ShpfyCompTaxIdMapping.Enum.al
+++ b/Apps/W1/Shopify/app/src/Companies/Enums/ShpfyCompTaxIdMapping.Enum.al
@@ -3,17 +3,19 @@ namespace Microsoft.Integration.Shopify;
 /// <summary>
 /// Enum Shopify Company Tax Id Mapping (ID 30165).
 /// </summary>
-enum 30165 "Shpfy Comp. Tax Id Mapping"
+enum 30165 "Shpfy Comp. Tax Id Mapping" implements "Shpfy Tax Registration Id Mapping"
 {
     Caption = 'Shopify Company Tax Id Mapping';
     Extensible = true;
 
-    value(0; RegistrationNo)
+    value(0; "Registration No.")
     {
         Caption = 'Registration No.';
+        Implementation = "Shpfy Tax Registration Id Mapping" = "Shpfy Tax Registration No.";
     }
-    value(1; VATRegistrationNo)
+    value(1; "VAT Registration No.")
     {
         Caption = 'VAT Registration No.';
+        Implementation = "Shpfy Tax Registration Id Mapping" = "Shpfy VAT Tax Registration No.";
     }
 }

--- a/Apps/W1/Shopify/app/src/Companies/Enums/ShpfyCompanyMapping.Enum.al
+++ b/Apps/W1/Shopify/app/src/Companies/Enums/ShpfyCompanyMapping.Enum.al
@@ -13,6 +13,12 @@ enum 30151 "Shpfy Company Mapping" implements "Shpfy ICompany Mapping"
         Caption = 'By Email/Phone';
         Implementation = "Shpfy ICompany Mapping" = "Shpfy Comp. By Email/Phone";
     }
+    //JZA: Task 3 Tax ID
+    value(1; "By Tax Id")
+    {
+        Caption = 'By Tax Id';
+        Implementation = "Shpfy ICompany Mapping" = "Shpfy Comp. By Tax Id";
+    }
     value(2; DefaultCompany)
     {
         Caption = 'Always take the default Company';

--- a/Apps/W1/Shopify/app/src/Companies/Enums/ShpfyCompanyMapping.Enum.al
+++ b/Apps/W1/Shopify/app/src/Companies/Enums/ShpfyCompanyMapping.Enum.al
@@ -13,7 +13,6 @@ enum 30151 "Shpfy Company Mapping" implements "Shpfy ICompany Mapping"
         Caption = 'By Email/Phone';
         Implementation = "Shpfy ICompany Mapping" = "Shpfy Comp. By Email/Phone";
     }
-    //JZA: Task 3 Tax ID
     value(1; "By Tax Id")
     {
         Caption = 'By Tax Id';

--- a/Apps/W1/Shopify/app/src/Companies/Interfaces/ShpfyICompanyMapping.Interface.al
+++ b/Apps/W1/Shopify/app/src/Companies/Interfaces/ShpfyICompanyMapping.Interface.al
@@ -6,4 +6,6 @@ namespace Microsoft.Integration.Shopify;
 interface "Shpfy ICompany Mapping"
 {
     procedure DoMapping(CompanyId: BigInteger; ShopCode: Code[20]; TemplateCode: Code[20]; AllowCreate: Boolean): Code[20]
+
+    procedure FindMapping(var ShopifyCompany: Record "Shpfy Company"; var TempShopifyCustomer: Record "Shpfy Customer" temporary): Boolean;
 }

--- a/Apps/W1/Shopify/app/src/Companies/Interfaces/ShpfyITaxIdMapping.Interface.al
+++ b/Apps/W1/Shopify/app/src/Companies/Interfaces/ShpfyITaxIdMapping.Interface.al
@@ -1,0 +1,8 @@
+namespace Microsoft.Integration.Shopify;
+
+using Microsoft.Sales.Customer;
+
+interface "Shpfy Tax Registration Id Mapping"
+{
+    procedure GetTaxRegistrationId(var Customer: Record Customer): Text;
+}

--- a/Apps/W1/Shopify/app/src/Companies/Interfaces/ShpfyITaxRegistrationIdMapping.Interface.al
+++ b/Apps/W1/Shopify/app/src/Companies/Interfaces/ShpfyITaxRegistrationIdMapping.Interface.al
@@ -2,6 +2,9 @@ namespace Microsoft.Integration.Shopify;
 
 using Microsoft.Sales.Customer;
 
+/// <summary>
+/// Interface "Shpfy Tax Registration Id Mapping"
+/// </summary>
 interface "Shpfy Tax Registration Id Mapping"
 {
     procedure GetTaxRegistrationId(var Customer: Record Customer): Text;

--- a/Apps/W1/Shopify/app/src/Companies/Interfaces/ShpfyITaxRegistrationIdMapping.Interface.al
+++ b/Apps/W1/Shopify/app/src/Companies/Interfaces/ShpfyITaxRegistrationIdMapping.Interface.al
@@ -5,4 +5,6 @@ using Microsoft.Sales.Customer;
 interface "Shpfy Tax Registration Id Mapping"
 {
     procedure GetTaxRegistrationId(var Customer: Record Customer): Text;
+
+    procedure SetMappingFiltersForCustomers(var Customer: Record Customer; CompanyLocation: Record "Shpfy Company Location");
 }

--- a/Apps/W1/Shopify/app/src/Companies/Pages/ShpfyCompLocations.Page.al
+++ b/Apps/W1/Shopify/app/src/Companies/Pages/ShpfyCompLocations.Page.al
@@ -1,0 +1,82 @@
+namespace Microsoft.Integration.Shopify;
+
+using Microsoft.Sales.Customer;
+
+/// <summary>
+/// Page Shpfy Company Locations (ID 30165).
+/// </summary>
+page 30165 "Shpfy Comp. Locations"
+{
+    ApplicationArea = All;
+    Caption = 'Shopify Company Locations';
+    Editable = false;
+    InsertAllowed = false;
+    DeleteAllowed = false;
+    ModifyAllowed = false;
+    PageType = List;
+    SourceTable = "Shpfy Company Location";
+    UsageCategory = None;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(General)
+            {
+                field(Id; Rec.Id)
+                {
+                    ToolTip = 'Specifies the unique identifier for the company location in Shopify.';
+                }
+                field("Company SystemId"; Rec."Company SystemId")
+                {
+                    ToolTip = 'Specifies the unique identifier for the company in Shopify.';
+                }
+                field("Default"; Rec."Default")
+                {
+                    ToolTip = 'Specifies whether the location is the default location for the company.';
+                }
+                field(Address; Rec.Address)
+                {
+                    ToolTip = 'Specifies the address of the company location.';
+                }
+                field("Address 2"; Rec."Address 2")
+                {
+                    ToolTip = 'Specifies the second address line of the company location.';
+                }
+                field(Zip; Rec.Zip)
+                {
+                    ToolTip = 'Specifies the postal code of the company location.';
+                }
+                field(City; Rec.City)
+                {
+                    ToolTip = 'Specifies the city of the company location.';
+                }
+                field("Country/Region Code"; Rec."Country/Region Code")
+                {
+                    ToolTip = 'Specifies the country/region code of the company location.';
+                }
+                field("Phone No."; Rec."Phone No.")
+                {
+                    ToolTip = 'Specifies the phone number of the company location.';
+                }
+                field(Name; Rec.Name)
+                {
+                    ToolTip = 'Specifies the name of the company location.';
+                }
+                field("Province Code"; Rec."Province Code")
+                {
+                    ToolTip = 'Specifies the province code of the company location.';
+                }
+                field("Province Name"; Rec."Province Name")
+                {
+                    ToolTip = 'Specifies the province name of the company location.';
+                }
+                field("Tax Registration Id"; Rec."Tax Registration Id")
+                {
+                    ToolTip = 'Specifies the tax registration identifier of the company location.';
+                }
+            }
+        }
+    }
+
+}

--- a/Apps/W1/Shopify/app/src/Companies/Pages/ShpfyCompLocations.Page.al
+++ b/Apps/W1/Shopify/app/src/Companies/Pages/ShpfyCompLocations.Page.al
@@ -75,6 +75,10 @@ page 30165 "Shpfy Comp. Locations"
                 {
                     ToolTip = 'Specifies the tax registration identifier of the company location.';
                 }
+                field("Shpfy Payment Terms Id"; Rec."Shpfy Payment Terms Id")
+                {
+                    ToolTip = 'Specifies the Shopify Payment Terms Id which is mapped with Customer''s Payment Terms.';
+                }
             }
         }
     }

--- a/Apps/W1/Shopify/app/src/Companies/Pages/ShpfyCompanies.Page.al
+++ b/Apps/W1/Shopify/app/src/Companies/Pages/ShpfyCompanies.Page.al
@@ -118,6 +118,18 @@ page 30156 "Shpfy Companies"
                 RunPageLink = "Company SystemId" = field(SystemId);
                 ToolTip = 'View a list of Shopify catalogs for the company.';
             }
+            action(ShopifyLocations)
+            {
+                ApplicationArea = All;
+                Caption = 'Shopify Locations';
+                Image = Warehouse;
+                Promoted = true;
+                PromotedOnly = true;
+                PromotedCategory = Category4;
+                RunObject = Page "Shpfy Comp. Locations";
+                RunPageLink = "Company SystemId" = field(SystemId);
+                ToolTip = 'View a list of Shopify company locations.';
+            }
         }
 
         area(Processing)

--- a/Apps/W1/Shopify/app/src/Companies/Pages/ShpfyCompanyCard.Page.al
+++ b/Apps/W1/Shopify/app/src/Companies/Pages/ShpfyCompanyCard.Page.al
@@ -163,6 +163,18 @@ page 30157 "Shpfy Company Card"
                 RunPageLink = "Company SystemId" = field(SystemId);
                 ToolTip = 'View a list of Shopify catalogs for the company.';
             }
+            action(ShopifyLocations)
+            {
+                ApplicationArea = All;
+                Caption = 'Shopify Locations';
+                Image = Warehouse;
+                Promoted = true;
+                PromotedOnly = true;
+                PromotedCategory = Category4;
+                RunObject = Page "Shpfy Comp. Locations";
+                RunPageLink = "Company SystemId" = field(SystemId);
+                ToolTip = 'View a list of Shopify company locations.';
+            }
         }
 
     }

--- a/Apps/W1/Shopify/app/src/Companies/Tables/ShpfyCompanyLocation.Table.al
+++ b/Apps/W1/Shopify/app/src/Companies/Tables/ShpfyCompanyLocation.Table.al
@@ -73,6 +73,11 @@ table 30151 "Shpfy Company Location"
             Caption = 'Tax Registration Id';
             DataClassification = CustomerContent;
         }
+        field(13; "Default"; Boolean)
+        {
+            Caption = 'Default';
+            DataClassification = CustomerContent;
+        }
     }
     keys
     {

--- a/Apps/W1/Shopify/app/src/Companies/Tables/ShpfyCompanyLocation.Table.al
+++ b/Apps/W1/Shopify/app/src/Companies/Tables/ShpfyCompanyLocation.Table.al
@@ -78,6 +78,11 @@ table 30151 "Shpfy Company Location"
             Caption = 'Default';
             DataClassification = CustomerContent;
         }
+        field(14; "Shpfy Payment Terms Id"; BigInteger)
+        {
+            Caption = 'Shpfy Payment Terms Id';
+            DataClassification = CustomerContent;
+        }
     }
     keys
     {

--- a/Apps/W1/Shopify/app/src/Customers/Codeunits/ShpfyUpdateCustomer.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/Customers/Codeunits/ShpfyUpdateCustomer.Codeunit.al
@@ -165,6 +165,9 @@ codeunit 30124 "Shpfy Update Customer"
                 Customer.Validate("VAT Bus. Posting Group", ShopifyTaxArea."VAT Bus. Posting Group");
         end;
 
+        if CompanyLocation."Shpfy Payment Terms Id" <> 0 then
+            Customer.Validate("Payment Terms Code", GetPaymentTermsCodeFromShopifyPaymentTermsId(CompanyLocation."Shpfy Payment Terms Id"));
+
         Customer.Modify();
     end;
 
@@ -185,5 +188,15 @@ codeunit 30124 "Shpfy Update Customer"
     internal procedure SetShop(ShopifyShop: Record "Shpfy Shop")
     begin
         Shop := ShopifyShop;
+    end;
+
+    local procedure GetPaymentTermsCodeFromShopifyPaymentTermsId(ShpfyPaymentTermsId: BigInteger): Code[10]
+    var
+        ShpfyPaymentTerms: Record "Shpfy Payment Terms";
+    begin
+        ShpfyPaymentTerms.SetRange("Shop Code", Shop.Code);
+        ShpfyPaymentTerms.SetRange(Id, ShpfyPaymentTermsId);
+        if ShpfyPaymentTerms.FindFirst() then
+            exit(ShpfyPaymentTerms."Payment Terms Code");
     end;
 }

--- a/Apps/W1/Shopify/app/src/GraphQL/Codeunits/ShpfyGQLCompany.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/GraphQL/Codeunits/ShpfyGQLCompany.Codeunit.al
@@ -13,7 +13,7 @@ codeunit 30302 "Shpfy GQL Company" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Text.</returns>
     internal procedure GetGraphQL(): Text
     begin
-        exit('{"query":"{company(id: \"gid://shopify/Company/{{CompanyId}}\") {name id note createdAt updatedAt mainContact { id customer { id firstName lastName email phone}} locations(first:20, sortKey: CREATED_AT ) {edges { node { id name billingAddress {address1 address2 city countryCode phone province zip zoneCode} taxRegistrationId}}}}}"}');
+        exit('{"query":"{company(id: \"gid://shopify/Company/{{CompanyId}}\") {name id note createdAt updatedAt mainContact { id customer { id firstName lastName email phone}} locations(first:20, sortKey: CREATED_AT ) {edges { node { id name billingAddress {address1 address2 city countryCode phone province zip zoneCode} buyerExperienceConfiguration {paymentTermsTemplate {id}} taxRegistrationId}}}}}"}');
     end;
 
     /// <summary>

--- a/Apps/W1/Shopify/app/src/GraphQL/Codeunits/ShpfyGQLCompany.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/GraphQL/Codeunits/ShpfyGQLCompany.Codeunit.al
@@ -13,7 +13,7 @@ codeunit 30302 "Shpfy GQL Company" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Text.</returns>
     internal procedure GetGraphQL(): Text
     begin
-        exit('{"query":"{company(id: \"gid://shopify/Company/{{CompanyId}}\") {name id note createdAt updatedAt mainContact { id customer { id firstName lastName email phone}} locations(first:1, sortKey: CREATED_AT ) {edges { node { id name billingAddress {address1 address2 city countryCode phone province zip zoneCode} taxRegistrationId}}}}}"}');
+        exit('{"query":"{company(id: \"gid://shopify/Company/{{CompanyId}}\") {name id note createdAt updatedAt mainContact { id customer { id firstName lastName email phone}} locations(first:20, sortKey: CREATED_AT ) {edges { node { id name billingAddress {address1 address2 city countryCode phone province zip zoneCode} taxRegistrationId}}}}}"}');
     end;
 
     /// <summary>

--- a/Apps/W1/Shopify/app/src/GraphQL/Codeunits/ShpfyGQLCreateCompLocationTaxID.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/GraphQL/Codeunits/ShpfyGQLCreateCompLocationTaxID.Codeunit.al
@@ -1,0 +1,27 @@
+namespace Microsoft.Integration.Shopify;
+
+/// <summary>
+/// Codeunit Shpfy GQL CreateCompLocTaxId (ID 30369) implements Interface Shpfy IGraphQL.
+/// </summary>
+codeunit 30369 "Shpfy GQL CreateCompLocTaxId" implements "Shpfy IGraphQL"
+{
+    Access = Internal;
+
+    /// <summary>
+    /// GetGraphQL.
+    /// </summary>
+    /// <returns>Return value of type Text.</returns>
+    internal procedure GetGraphQL(): Text
+    begin
+        exit('{"query":"mutation {companyLocationCreateTaxRegistration(locationId: \"gid://shopify/CompanyLocation/{{LocationId}}\", taxId: \"{{TaxId}}\") {companyLocation {id, name, taxRegistrationId}, userErrors {field, message}}}"}');
+    end;
+
+    /// <summary>
+    /// GetExpectedCost.
+    /// </summary>
+    /// <returns>Return value of type Integer.</returns>
+    internal procedure GetExpectedCost(): Integer
+    begin
+        exit(4);
+    end;
+}

--- a/Apps/W1/Shopify/app/src/GraphQL/Codeunits/ShpfyGQLUpdateLocPmtTerms.Codeunit.al
+++ b/Apps/W1/Shopify/app/src/GraphQL/Codeunits/ShpfyGQLUpdateLocPmtTerms.Codeunit.al
@@ -1,0 +1,27 @@
+namespace Microsoft.Integration.Shopify;
+
+/// <summary>
+/// Codeunit Shpfy GQL UpdateLocPmtTerms (ID 30370) implements Interface Shpfy IGraphQL.
+/// </summary>
+codeunit 30370 "Shpfy GQL UpdateLocPmtTerms" implements "Shpfy IGraphQL"
+{
+    Access = Internal;
+
+    /// <summary>
+    /// GetGraphQL.
+    /// </summary>
+    /// <returns>Return value of type Text.</returns>
+    internal procedure GetGraphQL(): Text
+    begin
+        exit('{"query":"mutation {companyLocationUpdate(companyLocationId: \"gid://shopify/CompanyLocation/{{LocationId}}\", input: {buyerExperienceConfiguration: {paymentTermsTemplateId: \"gid://shopify/PaymentTermsTemplate/{{PaymentTermsId}}\"}}) {companyLocation {id, name}, userErrors {field, message}}}"}');
+    end;
+
+    /// <summary>
+    /// GetExpectedCost.
+    /// </summary>
+    /// <returns>Return value of type Integer.</returns>
+    internal procedure GetExpectedCost(): Integer
+    begin
+        exit(4);
+    end;
+}

--- a/Apps/W1/Shopify/app/src/GraphQL/Enums/ShpfyGraphQLType.Enum.al
+++ b/Apps/W1/Shopify/app/src/GraphQL/Enums/ShpfyGraphQLType.Enum.al
@@ -490,4 +490,14 @@ enum 30111 "Shpfy GraphQL Type" implements "Shpfy IGraphQL"
         Caption = 'Get Product Image';
         Implementation = "Shpfy IGraphQL" = "Shpfy GQL GetProductImage";
     }
+    value(98; CreateCompanyLocationTaxId)
+    {
+        Caption = 'Create Company Location Tax Id';
+        Implementation = "Shpfy IGraphQL" = "Shpfy GQL CreateCompLocTaxId";
+    }
+    value(99; UpdateCompanyLocationPaymentTerms)
+    {
+        Caption = 'Update Company Location Payment Terms';
+        Implementation = "Shpfy IGraphQL" = "Shpfy GQL UpdateLocPmtTerms";
+    }
 }


### PR DESCRIPTION
#### Implementation 1 (Customer No. in Shopify Catalogs)
- New functionality has been added to assign 'Customer No.' in Shopify Catalogs during Customer as Company export.

#### Implementation 2 (Import of Multiple Company Locations)
- New functionality has been added that stores all Company Locations during import from Shopify. The first Company Location in the response is marked as 'Default'. To receive all Company Locations instead of one, Query in ShpfyGQLCompany has been updated.
- During the Customer as Company export, new created Shopify Company Location is marked as 'Default'.
- Additionally Company Locations page was created to be able to see information from Business Central side. Company Locations page can be opened from Shopify Companies and Shopify Company Card pages.

#### Implementation 3 (Tax ID export and Company/Customer mapping by Tax Id)
- Tax ID export to Shopify - Added functionality to update Tax Id on Company Creation and Synchronization (new GraphQL 'companyLocationCreateTaxRegistration' created and extended GraphQL 'companyCreate' by including Tax ID). Which Customer field has to be used as Tax Id is determined by field 'Company Tax Id Mapping' value on 'Shopify Shop Card'. There are 2 possible options: 'Registration Number' and 'VAT Registration No.'. Enum is extensible, so that user could add any other option to which fields Tax ID has to be linked (implementation codeunit has to be created and linked to new Enum value).
- Company/Customer mapping by Tax Id - The logic how Company are linked to customer has to be mapped (by email/phone,  by tax id, default company) has to be defined on 'Company Mapping Type' field on 'Shopify Shop Card' page. The 'Company Mapping Type' enum value has to be linked with implementation codeunits that are doing actual Company/Customer mapping. The changes that has been made: 
     - Added new procedure 'FindMapping' to "Shpfy ICompany Mapping" interface
     - Moved Existing Mapping by email/phone logic to implementation codeunit
     - Added new functionality to implementation codeunit for 'Default Company' selection 
     - Created new implementation codeunit to do mapping by Tax ID

#### Implementation 4 (Company Location Payment Terms Export/Import)
- Company Location Payment Terms Export - new GraphQL implementation codeunit for 'Shpfy GraphQL Type' has been created which allows to send Payment Terms to Shopify. If mapped value for Customer Payment Terms Code exist in 'Payment Terms Mapping', Shopify Payment Terms ID is exported to Shopify for that Company/Customer.
- Company Location Payment Terms Import - GraphQL 'Shpfy GQL Company' that retrieves Company information from Shopify has been updated by adding new filed 'paymentTermsTemplate'. If During the import the mapping in 'Payment Terms Mapping' exist, the Customer in BC is updated by the Payment Terms from Shopify.

#### Implementation 5 (Populate External ID during the export customer as a company)
- Existing GraphQL that creates new Companies in Shopify has been updated by adding new field 'externalId'. The value which is 'Customer No.'