### PR TITLE
#943 Intrastat default transactions types

### DIFF
--- a/Apps/W1/Intrastat/app/src/IntrastatRepCustTemCard.PageExt.al
+++ b/Apps/W1/Intrastat/app/src/IntrastatRepCustTemCard.PageExt.al
@@ -1,0 +1,36 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Inventory.Intrastat;
+
+using Microsoft.Sales.Customer;
+
+pageextension 4817 "Intrastat Rep. Cust. Tem. Card" extends "Customer Templ. Card"
+{
+    layout
+    {
+        addafter(Shipping)
+        {
+            group(Intrastat)
+            {
+                Caption = 'Intrastat';
+                field("Default Trans. Type"; Rec."Default Trans. Type")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the default transaction type for regular sales shipments and service shipments.';
+                }
+                field("Default Trans. Type - Return"; Rec."Default Trans. Type - Return")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the default transaction type for sales returns and service returns.';
+                }
+                field("Def. Transport Method"; Rec."Def. Transport Method")
+                {
+                    ApplicationArea = All;
+                    ToolTip = 'Specifies the default transport method, for the purpose of reporting to INTRASTAT.';
+                }
+            }
+        }
+    }
+}

--- a/Apps/W1/Intrastat/app/src/IntrastatReportCustTempl.TableExt.al
+++ b/Apps/W1/Intrastat/app/src/IntrastatReportCustTempl.TableExt.al
@@ -1,0 +1,29 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Inventory.Intrastat;
+
+using Microsoft.Sales.Customer;
+
+tableextension 4822 "Intrastat Report Cust. Templ." extends "Customer Templ."
+{
+    fields
+    {
+        field(4810; "Default Trans. Type"; Code[10])
+        {
+            Caption = 'Default Trans. Type';
+            TableRelation = "Transaction Type";
+        }
+        field(4811; "Default Trans. Type - Return"; Code[10])
+        {
+            Caption = 'Default Trans. Type - Returns';
+            TableRelation = "Transaction Type";
+        }
+        field(4812; "Def. Transport Method"; Code[10])
+        {
+            Caption = 'Default Transport Method';
+            TableRelation = "Transport Method";
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to AlAppExtensions please read our pull request guideline below
* https://github.com/microsoft/ALAppExtensions/blob/main/CONTRIBUTING.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Based on approval:
https://github.com/microsoft/BusinessCentralApps/issues/943

This issue is generated from the following idea on [aka.ms/bcideas](https://github.com/microsoft/BusinessCentralApps/issues/aka.ms/bcideas): [Intrastat default transactions types](https://experience.dynamics.com/ideas/idea/?ideaid=ae80958c-159b-ed11-a76e-0003ff45e043)

To do the Intrastat reporting the "Default Trans. Types" must be filled on the customer card, but its not possible to add these fields to the customer template, its easy to forget to put in the data.

Please add the fields on the customer template.
#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->

Fixes #27520
Fixes [AB#461591](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/461591)


