### PR TITLE
GP - Remove the CLEAN25 preprocessor checks from the US app

### DIFF
--- a/Apps/US/HybridGP_US/app/src/Codeunits/GPCloudMigrationUS.Codeunit.al
+++ b/Apps/US/HybridGP_US/app/src/Codeunits/GPCloudMigrationUS.Codeunit.al
@@ -1,17 +1,13 @@
 namespace Microsoft.DataMigration.GP;
 
 using System.Integration;
-#if not CLEAN25
 using System.Environment.Configuration;
-#endif
 using Microsoft.Purchases.Vendor;
 
 codeunit 42004 "GP Cloud Migration US"
 {
     var
-#if not CLEAN25
         IRSFormFeatureKeyIdTok: Label 'IRSForm', Locked = true;
-#endif
 
     [EventSubscriber(ObjectType::Codeunit, CodeUnit::"Data Migration Mgt.", 'OnAfterMigrationFinished', '', false, false)]
     local procedure OnAfterMigrationFinishedSubscriber(var DataMigrationStatus: Record "Data Migration Status"; WasAborted: Boolean; StartTime: DateTime; Retry: Boolean)
@@ -73,16 +69,10 @@ codeunit 42004 "GP Cloud Migration US"
 
     internal procedure IsIRSFormsFeatureEnabled(): Boolean
     var
-#if not CLEAN25
         FeatureManagementFacade: Codeunit "Feature Management Facade";
-#endif
         IsEnabled: Boolean;
     begin
-        IsEnabled := true;
-
-#if not CLEAN25
         IsEnabled := FeatureManagementFacade.IsEnabled(IRSFormFeatureKeyIdTok);
-#endif
 
         exit(IsEnabled);
     end;

--- a/Apps/US/HybridGP_US/app/src/Codeunits/GPPopulateVendor1099Data.Codeunit.al
+++ b/Apps/US/HybridGP_US/app/src/Codeunits/GPPopulateVendor1099Data.Codeunit.al
@@ -132,16 +132,13 @@ codeunit 42003 "GP Populate Vendor 1099 Data"
     var
         GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
         IRS1099VendorFormBoxSetup: Record "IRS 1099 Vendor Form Box Setup";
-#if not CLEAN25
         GPCloudMigrationUS: Codeunit "GP Cloud Migration US";
-#endif
     begin
-#if not CLEAN25
 #pragma warning disable AL0432
         if not GPCloudMigrationUS.IsIRSFormsFeatureEnabled() then
             exit(Vendor."IRS 1099 Code" <> '');
 #pragma warning restore AL0432
-#endif
+
         GPCompanyAdditionalSettings.GetSingleInstance();
         if IRS1099VendorFormBoxSetup.Get(Format(GPCompanyAdditionalSettings.Get1099TaxYear()), Vendor."No.") then
             exit(true);
@@ -152,18 +149,15 @@ codeunit 42003 "GP Populate Vendor 1099 Data"
         GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
         IRS1099VendorFormBoxSetup: Record "IRS 1099 Vendor Form Box Setup";
         IRS1099FormBox: Record "IRS 1099 Form Box";
-#if not CLEAN25	
         GPCloudMigrationUS: Codeunit "GP Cloud Migration US";
-#endif
     begin
-#if not CLEAN25
 #pragma warning disable AL0432
         if not GPCloudMigrationUS.IsIRSFormsFeatureEnabled() then begin
             Vendor.Validate("IRS 1099 Code", IRS1099Code);
             exit(true);
         end;
 #pragma warning restore AL0432
-#endif
+
         IRS1099FormBox.SetRange("No.", IRS1099Code);
         if not IRS1099FormBox.FindFirst() then
             exit(false);
@@ -332,11 +326,9 @@ codeunit 42003 "GP Populate Vendor 1099 Data"
         GenJournalLine.Validate("Bal. Gen. Prod. Posting Group", '');
         GenJournalLine.Validate("Bal. VAT Prod. Posting Group", '');
         GenJournalLine.Validate("Bal. VAT Bus. Posting Group", '');
-#if not CLEAN25
 #pragma warning disable AL0432
         GenJournalLine.Validate("IRS 1099 Code", IRS1099Code);
 #pragma warning restore AL0432
-#endif
         GenJournalLine.Validate("Document Type", DocumentType);
         GenJournalLine.Validate("Source Code", SourceCodeTxt);
         GenJournalLine.Validate("External Document No.", ExternalDocumentNo);


### PR DESCRIPTION
This changes corrects an issue when migrating GP Vendor 1099 data on version v25, but the new IRS Forms feature is disabled.
Fixes [AB#559817](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/559817)