### PR TITLE
GP - Correct issue with IRS 1099 data migration

### DIFF
--- a/Apps/US/HybridGP_US/app/src/Codeunits/GPCloudMigrationUS.Codeunit.al
+++ b/Apps/US/HybridGP_US/app/src/Codeunits/GPCloudMigrationUS.Codeunit.al
@@ -11,9 +11,7 @@ using Microsoft.Purchases.Vendor;
 codeunit 42004 "GP Cloud Migration US"
 {
     var
-#if not CLEAN25
         IRSFormFeatureKeyIdTok: Label 'IRSForm', Locked = true;
-#endif
 
     [EventSubscriber(ObjectType::Codeunit, CodeUnit::"Data Migration Mgt.", 'OnAfterMigrationFinished', '', false, false)]
     local procedure OnAfterMigrationFinishedSubscriber(var DataMigrationStatus: Record "Data Migration Status"; WasAborted: Boolean; StartTime: DateTime; Retry: Boolean)

--- a/Apps/US/HybridGP_US/app/src/Codeunits/GPCloudMigrationUS.Codeunit.al
+++ b/Apps/US/HybridGP_US/app/src/Codeunits/GPCloudMigrationUS.Codeunit.al
@@ -1,8 +1,8 @@
 namespace Microsoft.DataMigration.GP;
 
 using System.Integration;
-#if not CLEAN25
 using System.Environment.Configuration;
+#if not CLEAN25
 using Microsoft.Finance.VAT.Reporting;
 #endif
 using Microsoft.Purchases.Vendor;


### PR DESCRIPTION
This change corrects an issue when migrating GP Vendor 1099 data on version v25.

Changes:

- Always check to see if the new IRS Forms feature is enabled.
- Initialize the original/old IRS 1099 Forms feature if required.

Fixes #26487
Fixes [AB#560225](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/560225)



