### PR TITLE
Add unpublish extension action in automation api

### DIFF
--- a/Apps/W1/APIV2/app/src/pages/APIV2AutExtensions.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2AutExtensions.Page.al
@@ -107,6 +107,7 @@ page 30002 "APIV2 - Aut. Extensions"
         IsExtensionInstalled: Boolean;
         IsNotInstalledErr: Label 'The extension %1 is not installed.', Comment = '%1=name of app';
         IsInstalledErr: Label 'The extension %1 is already installed.', Comment = '%1=name of app';
+        CannotUnpublishInstalledAppErr: Label 'The extension %1 cannot be unpublished because it is installed.', Comment = '%1=name of app';
 
     [ServiceEnabled]
     [Scope('Cloud')]
@@ -151,6 +152,18 @@ page 30002 "APIV2 - Aut. Extensions"
         ActionContext.SetObjectId(Page::"APIV2 - Aut. Extensions");
         ActionContext.AddEntityKey(Rec.FieldNo(ID), Rec.ID);
         ActionContext.SetResultCode(WebServiceActionResultCode::Updated);
+    end;
+
+    [ServiceEnabled]
+    [Scope('Cloud')]
+    procedure unpublish(var ActionContext: WebServiceActionContext)
+    begin
+        if ExtensionManagement.IsInstalledByPackageId(Rec."Package ID") then
+            Error(CannotUnpublishInstalledAppErr, Rec.Name);
+
+        ExtensionManagement.UnpublishExtension(Rec."Package ID");
+
+        ActionContext.SetResultCode(WebServiceActionResultCode::Deleted);
     end;
 
     var


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to AlAppExtensions please read our pull request guideline below
* https://github.com/microsoft/ALAppExtensions/blob/main/CONTRIBUTING.md
-->
#### Summary <!-- Provide a general summary of your changes -->
add a new action unpublish to page ```30002 "APIV2 - Aut. Extensions"``` [link](https://github.com/microsoft/ALAppExtensions/blob/a1f39200bc76cbc45e04461000fae0675d14610f/Apps/W1/APIV2/app/src/pages/APIV2AutExtensions.Page.al).

##### Flow:

1. User sends a request ```POST https://.../api/microsoft/automation/v2.0/companies(...)/extensions(<packageId>)/Microsoft.NAV.unpublish```
2. new unpublish action gets called
3. If package is installed, raise error
4. call ExtensionManagement.UnpublishExtension(Rec."Package ID"); to unpublish app
5. Return WebServiceActionResultCode::Deleted 

#### Work Item(s) 
<!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #27901

Fixes [AB#391847](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/391847)

