### PR TITLE
Mandatory Setup fields for Intrastat

### DIFF
--- a/Apps/W1/Intrastat/app/src/Processing/IntrastatReportDocCompl.Codeunit.al
+++ b/Apps/W1/Intrastat/app/src/Processing/IntrastatReportDocCompl.Codeunit.al
@@ -96,21 +96,10 @@ codeunit 4812 "Intrastat Report Doc. Compl."
             exit;
 
         if SalesHeader.Ship or SalesHeader.Receive then begin
-            if IntrastatReportSetup."Transaction Type Mandatory" then
-                if SalesHeader."Transaction Type" = '' then
-                    TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, SalesHeader.FieldCaption("Transaction Type")));
-
-            if IntrastatReportSetup."Transaction Spec. Mandatory" then
-                if SalesHeader."Transaction Specification" = '' then
-                    TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, SalesHeader.FieldCaption("Transaction Specification")));
-
-            if IntrastatReportSetup."Shipment Method Mandatory" then
-                if SalesHeader."Shipment Method Code" = '' then
-                    TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, SalesHeader.FieldCaption("Shipment Method Code")));
-
-            if IntrastatReportSetup."Transport Method Mandatory" then
-                if SalesHeader."Transport Method" = '' then
-                    TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, SalesHeader.FieldCaption("Transport Method")));
+            CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Transaction Type Mandatory", SalesHeader."Transaction Type", SalesHeader.FieldCaption("Transaction Type"));
+            CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Transaction Spec. Mandatory", SalesHeader."Transaction Specification", SalesHeader.FieldCaption("Transaction Specification"));
+            CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Shipment Method Mandatory", SalesHeader."Shipment Method Code", SalesHeader.FieldCaption("Shipment Method Code"));
+            CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Transport Method Mandatory", SalesHeader."Transport Method", SalesHeader.FieldCaption("Transport Method"));
 
             if TempErrorMessage.HasErrors(true) then
                 TempErrorMessage.ShowErrorMessages(true);
@@ -134,21 +123,10 @@ codeunit 4812 "Intrastat Report Doc. Compl."
             exit;
 
         if PurchHeader.Ship or PurchHeader.Receive then begin
-            if IntrastatReportSetup."Transaction Type Mandatory" then
-                if PurchHeader."Transaction Type" = '' then
-                    TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, PurchHeader.FieldCaption("Transaction Type")));
-
-            if IntrastatReportSetup."Transaction Spec. Mandatory" then
-                if PurchHeader."Transaction Specification" = '' then
-                    TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, PurchHeader.FieldCaption("Transaction Specification")));
-
-            if IntrastatReportSetup."Shipment Method Mandatory" then
-                if PurchHeader."Shipment Method Code" = '' then
-                    TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, PurchHeader.FieldCaption("Shipment Method Code")));
-
-            if IntrastatReportSetup."Transport Method Mandatory" then
-                if PurchHeader."Transport Method" = '' then
-                    TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, PurchHeader.FieldCaption("Transport Method")));
+            CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Transaction Type Mandatory", PurchHeader."Transaction Type", PurchHeader.FieldCaption("Transaction Type"));
+            CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Transaction Spec. Mandatory", PurchHeader."Transaction Specification", PurchHeader.FieldCaption("Transaction Specification"));
+            CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Shipment Method Mandatory", PurchHeader."Shipment Method Code", PurchHeader.FieldCaption("Shipment Method Code"));
+            CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Transport Method Mandatory", PurchHeader."Transport Method", PurchHeader.FieldCaption("Transport Method"));
 
             if TempErrorMessage.HasErrors(true) then
                 TempErrorMessage.ShowErrorMessages(true);
@@ -169,24 +147,13 @@ codeunit 4812 "Intrastat Report Doc. Compl."
         if TransferHeader."Trsf.-from Country/Region Code" = TransferHeader."Trsf.-to Country/Region Code" then
             exit;
 
-        if not IsIntrastatTransaction(TransferHeader."Trsf.-from Country/Region Code") then
+        if (not IsIntrastatTransaction(TransferHeader."Trsf.-to Country/Region Code")) and (not IsIntrastatTransaction(TransferHeader."Trsf.-from Country/Region Code")) then
             exit;
 
-        if IntrastatReportSetup."Transaction Type Mandatory" then
-            if TransferHeader."Transaction Type" = '' then
-                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, TransferHeader.FieldCaption("Transaction Type")));
-
-        if IntrastatReportSetup."Transaction Spec. Mandatory" then
-            if TransferHeader."Transaction Specification" = '' then
-                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, TransferHeader.FieldCaption("Transaction Specification")));
-
-        if IntrastatReportSetup."Shipment Method Mandatory" then
-            if TransferHeader."Shipment Method Code" = '' then
-                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, TransferHeader.FieldCaption("Shipment Method Code")));
-
-        if IntrastatReportSetup."Transport Method Mandatory" then
-            if TransferHeader."Transport Method" = '' then
-                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, TransferHeader.FieldCaption("Transport Method")));
+        CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Transaction Type Mandatory", TransferHeader."Transaction Type", TransferHeader.FieldCaption("Transaction Type"));
+        CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Transaction Spec. Mandatory", TransferHeader."Transaction Specification", TransferHeader.FieldCaption("Transaction Specification"));
+        CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Shipment Method Mandatory", TransferHeader."Shipment Method Code", TransferHeader.FieldCaption("Shipment Method Code"));
+        CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Transport Method Mandatory", TransferHeader."Transport Method", TransferHeader.FieldCaption("Transport Method"));
 
         if TempErrorMessage.HasErrors(true) then
             TempErrorMessage.ShowErrorMessages(true);
@@ -206,24 +173,13 @@ codeunit 4812 "Intrastat Report Doc. Compl."
         if TransferHeader."Trsf.-from Country/Region Code" = TransferHeader."Trsf.-to Country/Region Code" then
             exit;
 
-        if not IsIntrastatTransaction(TransferHeader."Trsf.-to Country/Region Code") and (not IsIntrastatTransaction(TransferHeader."Trsf.-from Country/Region Code")) then
+        if (not IsIntrastatTransaction(TransferHeader."Trsf.-to Country/Region Code")) and (not IsIntrastatTransaction(TransferHeader."Trsf.-from Country/Region Code")) then
             exit;
 
-        if IntrastatReportSetup."Transaction Type Mandatory" then
-            if TransferHeader."Transaction Type" = '' then
-                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, TransferHeader.FieldCaption("Transaction Type")));
-
-        if IntrastatReportSetup."Transaction Spec. Mandatory" then
-            if TransferHeader."Transaction Specification" = '' then
-                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, TransferHeader.FieldCaption("Transaction Specification")));
-
-        if IntrastatReportSetup."Shipment Method Mandatory" then
-            if TransferHeader."Shipment Method Code" = '' then
-                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, TransferHeader.FieldCaption("Shipment Method Code")));
-
-        if IntrastatReportSetup."Transport Method Mandatory" then
-            if TransferHeader."Transport Method" = '' then
-                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, TransferHeader.FieldCaption("Transport Method")));
+        CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Transaction Type Mandatory", TransferHeader."Transaction Type", TransferHeader.FieldCaption("Transaction Type"));
+        CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Transaction Spec. Mandatory", TransferHeader."Transaction Specification", TransferHeader.FieldCaption("Transaction Specification"));
+        CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Shipment Method Mandatory", TransferHeader."Shipment Method Code", TransferHeader.FieldCaption("Shipment Method Code"));
+        CheckIntrastatMandatoryFields(TempErrorMessage, IntrastatReportSetup."Transport Method Mandatory", TransferHeader."Transport Method", TransferHeader.FieldCaption("Transport Method"));
 
         if TempErrorMessage.HasErrors(true) then
             TempErrorMessage.ShowErrorMessages(true);
@@ -240,6 +196,12 @@ codeunit 4812 "Intrastat Report Doc. Compl."
             exit(false);
         CompanyInformation.Get();
         exit(CompanyInformation."Country/Region Code" <> CountryCode);
+    end;
+
+    local procedure CheckIntrastatMandatoryFields(var TempErrorMessage: Record "Error Message" temporary; ValueMandatory: Boolean; FieldValue: Code[20]; FieldCaption: Text)
+    begin
+        if ValueMandatory and (FieldValue = '') then
+            TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, FieldCaption));
     end;
 
     [IntegrationEvent(false, false)]

--- a/Apps/W1/Intrastat/app/src/Processing/IntrastatReportDocCompl.Codeunit.al
+++ b/Apps/W1/Intrastat/app/src/Processing/IntrastatReportDocCompl.Codeunit.al
@@ -135,31 +135,6 @@ codeunit 4812 "Intrastat Report Doc. Compl."
             if SalesHeader."Transport Method" = '' then
                 TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, SalesHeader.FieldCaption("Transport Method")));
 
-        if not (IntrastatReportSetup."Tariff No. Mandatory") and not (IntrastatReportSetup."Net Weight Mandatory") and not (IntrastatReportSetup."Country/Region of Origin Mand.") then begin
-            if TempErrorMessage.HasErrors(true) then
-                TempErrorMessage.ShowErrorMessages(true);
-            exit;
-        end;
-
-        SalesLine.SetRange("Document Type", SalesHeader."Document Type");
-        SalesLine.SetRange("Document No.", SalesHeader."No.");
-        SalesLine.SetRange(Type, SalesLine.Type::Item);
-        if SalesLine.FindSet() then
-            repeat
-                if IntrastatReportSetup."Net Weight Mandatory" then
-                    if SalesLine."Net Weight" = 0 then
-                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, SalesLine.FieldCaption("Net Weight"), SalesLine."Line No."));
-
-                if IntrastatReportSetup."Tariff No. Mandatory" then
-                    if Item.Get(SalesLine."No.") and (Item."Tariff No." = '') then
-                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, Item.FieldCaption("Tariff No."), SalesLine."Line No."));
-
-                if IntrastatReportSetup."Country/Region of Origin Mand." then
-                    if Item.Get(SalesLine."No.") and (Item."Country/Region of Origin Code" = '') then
-                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, Item.FieldCaption("Country/Region of Origin Code"), SalesLine."Line No."));
-
-            until SalesLine.Next() = 0;
-
         if TempErrorMessage.HasErrors(true) then
             TempErrorMessage.ShowErrorMessages(true);
     end;
@@ -217,31 +192,6 @@ codeunit 4812 "Intrastat Report Doc. Compl."
             if PurchHeader."Transport Method" = '' then
                 TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, PurchHeader.FieldCaption("Transport Method")));
 
-        if not (IntrastatReportSetup."Tariff No. Mandatory") and not (IntrastatReportSetup."Net Weight Mandatory") and not (IntrastatReportSetup."Country/Region of Origin Mand.") then begin
-            if TempErrorMessage.HasErrors(true) then
-                TempErrorMessage.ShowErrorMessages(true);
-            exit;
-        end;
-
-        PurchLine.SetRange("Document Type", PurchHeader."Document Type");
-        PurchLine.SetRange("Document No.", PurchHeader."No.");
-        PurchLine.SetRange(Type, PurchLine.Type::Item);
-        if PurchLine.FindSet() then
-            repeat
-                if IntrastatReportSetup."Net Weight Mandatory" then
-                    if PurchLine."Net Weight" = 0 then
-                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, PurchLine.FieldCaption("Net Weight"), PurchLine."Line No."));
-
-                if IntrastatReportSetup."Tariff No. Mandatory" then
-                    if Item.Get(PurchLine."No.") and (Item."Tariff No." = '') then
-                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, Item.FieldCaption("Tariff No."), PurchLine."Line No."));
-
-                if IntrastatReportSetup."Country/Region of Origin Mand." then
-                    if Item.Get(PurchLine."No.") and (Item."Country/Region of Origin Code" = '') then
-                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, Item.FieldCaption("Country/Region of Origin Code"), PurchLine."Line No."));
-
-            until PurchLine.Next() = 0;
-
         if TempErrorMessage.HasErrors(true) then
             TempErrorMessage.ShowErrorMessages(true);
     end;
@@ -282,29 +232,6 @@ codeunit 4812 "Intrastat Report Doc. Compl."
         if IntrastatReportSetup."Transport Method Mandatory" then
             if TransHeader."Transport Method" = '' then
                 TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, TransHeader.FieldCaption("Transport Method")));
-
-        if not (IntrastatReportSetup."Tariff No. Mandatory") and not (IntrastatReportSetup."Net Weight Mandatory") and not (IntrastatReportSetup."Country/Region of Origin Mand.") then begin
-            if TempErrorMessage.HasErrors(true) then
-                TempErrorMessage.ShowErrorMessages(true);
-            exit;
-        end;
-
-        TransferLine.SetRange("Document No.", TransHeader."No.");
-        if TransferLine.FindSet() then
-            repeat
-                if IntrastatReportSetup."Net Weight Mandatory" then
-                    if TransferLine."Net Weight" = 0 then
-                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, TransferLine.FieldCaption("Net Weight"), TransferLine."Line No."));
-
-                if IntrastatReportSetup."Tariff No. Mandatory" then
-                    if Item.Get(TransferLine."Item No.") and (Item."Tariff No." = '') then
-                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, Item.FieldCaption("Tariff No."), TransferLine."Line No."));
-
-                if IntrastatReportSetup."Country/Region of Origin Mand." then
-                    if Item.Get(TransferLine."Item No.") and (Item."Country/Region of Origin Code" = '') then
-                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, Item.FieldCaption("Country/Region of Origin Code"), TransferLine."Line No."));
-
-            until TransferLine.Next() = 0;
 
         if TempErrorMessage.HasErrors(true) then
             TempErrorMessage.ShowErrorMessages(true);

--- a/Apps/W1/Intrastat/app/src/Processing/IntrastatReportDocCompl.Codeunit.al
+++ b/Apps/W1/Intrastat/app/src/Processing/IntrastatReportDocCompl.Codeunit.al
@@ -8,7 +8,6 @@ using Microsoft.Foundation.Company;
 using Microsoft.Foundation.Address;
 using Microsoft.Inventory.Item;
 using System.Utilities;
-using Microsoft.Utilities;
 using Microsoft.Purchases.Document;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Purchases.Posting;
@@ -85,7 +84,7 @@ codeunit 4812 "Intrastat Report Doc. Compl."
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Post", OnAfterCheckSalesDoc, '', false, false)]
-    local procedure CheckIntrastatMandatoryFieldsInSales(var SalesHeader: Record "Sales Header")
+    local procedure CheckIntrastatMandatoryFieldsOnSalesDoc(var SalesHeader: Record "Sales Header")
     var
         TempErrorMessage: Record "Error Message" temporary;
         SalesLine: Record "Sales Line";
@@ -166,7 +165,7 @@ codeunit 4812 "Intrastat Report Doc. Compl."
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Purch.-Post", OnAfterCheckPurchDoc, '', false, false)]
-    local procedure CheckIntrastatMandatoryFieldsInPurchase(var PurchHeader: Record "Purchase Header")
+    local procedure CheckIntrastatMandatoryFieldsOnPurchaseDoc(var PurchHeader: Record "Purchase Header")
     var
         TempErrorMessage: Record "Error Message" temporary;
         PurchLine: Record "Purchase Line";
@@ -174,6 +173,9 @@ codeunit 4812 "Intrastat Report Doc. Compl."
         Item: Record Item;
     begin
         if PurchHeader.IsTemporary() or (not IntrastatReportSetup.ReadPermission) then
+            exit;
+
+        if not (PurchHeader."Document Type" in [PurchHeader."Document Type"::Order, PurchHeader."Document Type"::"Return Order"]) then
             exit;
 
         if not IntrastatReportSetup.Get() then
@@ -245,7 +247,7 @@ codeunit 4812 "Intrastat Report Doc. Compl."
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"TransferOrder-Post (Yes/No)", OnCodeOnBeforePostTransferOrder, '', false, false)]
-    local procedure CheckIntrastatMandatoryFieldsInTransfer(var TransHeader: Record "Transfer Header"; var Selection: Option)
+    local procedure CheckIntrastatMandatoryFieldsOnTransferDoc(var TransHeader: Record "Transfer Header"; var Selection: Option)
     var
         TempErrorMessage: Record "Error Message" temporary;
         TransferLine: Record "Transfer Line";

--- a/Apps/W1/Intrastat/app/src/Processing/IntrastatReportDocCompl.Codeunit.al
+++ b/Apps/W1/Intrastat/app/src/Processing/IntrastatReportDocCompl.Codeunit.al
@@ -4,7 +4,15 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Inventory.Intrastat;
 
+using Microsoft.Foundation.Company;
+using Microsoft.Foundation.Address;
+using Microsoft.Inventory.Item;
+using System.Utilities;
+using Microsoft.Utilities;
 using Microsoft.Purchases.Document;
+using Microsoft.Inventory.Transfer;
+using Microsoft.Purchases.Posting;
+using Microsoft.Sales.Posting;
 using Microsoft.Sales.Document;
 using Microsoft.Service.Document;
 
@@ -12,6 +20,9 @@ codeunit 4812 "Intrastat Report Doc. Compl."
 {
     var
         IntrastatReportSetup: Record "Intrastat Report Setup";
+        CompanyInformation: Record "Company Information";
+        MandatoryFieldErr: Label '%1 field cannot be empty.', Comment = '%1 - field name';
+        MandatoryFieldsLineErr: Label '%1 field cannot be empty for the line %2.', Comment = '%1 - field name, %2 - Line No.';
 
     [EventSubscriber(ObjectType::Table, Database::"Sales Header", 'OnBeforeInsertEvent', '', false, false)]
     local procedure DefaultSalesDocuments(var Rec: Record "Sales Header"; RunTrigger: Boolean)
@@ -71,6 +82,203 @@ codeunit 4812 "Intrastat Report Doc. Compl."
                 Rec."Transaction Type" := IntrastatReportSetup."Default Trans. - Purchase";
 
         OnAfterDefaultServiceDocuments(Rec, IntrastatReportSetup);
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Post", OnAfterCheckSalesDoc, '', false, false)]
+    local procedure CheckIntrastatMandatoryFieldsInSales(var SalesHeader: Record "Sales Header")
+    var
+        TempErrorMessage: Record "Error Message" temporary;
+        SalesLine: Record "Sales Line";
+        CountryRegion: Record "Country/Region";
+        Item: Record Item;
+    begin
+        if SalesHeader.IsTemporary() or (not IntrastatReportSetup.ReadPermission) then
+            exit;
+        if not (SalesHeader."Document Type" in [SalesHeader."Document Type"::Order, SalesHeader."Document Type"::"Return Order"]) then
+            exit;
+
+        if not IntrastatReportSetup.Get() then
+            exit;
+
+        case IntrastatReportSetup."Shipments Based On" of
+            IntrastatReportSetup."Shipments Based On"::"Bill-to Country":
+                if not CountryRegion.Get(SalesHeader."Bill-to Country/Region Code") then
+                    exit;
+            IntrastatReportSetup."Shipments Based On"::"Sell-to Country":
+                if not CountryRegion.Get(SalesHeader."Sell-to Country/Region Code") then
+                    exit;
+            IntrastatReportSetup."Shipments Based On"::"Ship-to Country":
+                if not CountryRegion.Get(SalesHeader."Ship-to Country/Region Code") then
+                    exit;
+
+        end;
+        if CountryRegion."Intrastat Code" = '' then
+            exit;
+
+        if not CompanyInformation.Get() then
+            exit;
+
+        if CountryRegion.Code = CompanyInformation."Country/Region Code" then
+            exit;
+
+        if IntrastatReportSetup."Transaction Type Mandatory" then
+            if SalesHeader."Transaction Type" = '' then
+                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, SalesHeader.FieldCaption("Transaction Type")));
+
+        if IntrastatReportSetup."Transaction Spec. Mandatory" then
+            if SalesHeader."Transaction Specification" = '' then
+                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, SalesHeader.FieldCaption("Transaction Specification")));
+
+        if IntrastatReportSetup."Shipment Method Mandatory" then
+            if SalesHeader."Shipment Method Code" = '' then
+                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, SalesHeader.FieldCaption("Shipment Method Code")));
+
+        if IntrastatReportSetup."Transport Method Mandatory" then
+            if SalesHeader."Transport Method" = '' then
+                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, SalesHeader.FieldCaption("Transport Method")));
+
+        if not (IntrastatReportSetup."Tariff No. Mandatory") and not (IntrastatReportSetup."Net Weight Mandatory") and not (IntrastatReportSetup."Country/Region of Origin Mand.") then begin
+            if TempErrorMessage.HasErrors(true) then
+                TempErrorMessage.ShowErrorMessages(true);
+            exit;
+        end;
+
+        SalesLine.SetRange("Document Type", SalesHeader."Document Type");
+        SalesLine.SetRange("Document No.", SalesHeader."No.");
+        SalesLine.SetRange(Type, SalesLine.Type::Item);
+        if SalesLine.FindSet() then
+            repeat
+                if IntrastatReportSetup."Net Weight Mandatory" then
+                    if SalesLine."Net Weight" = 0 then
+                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, SalesLine.FieldCaption("Net Weight"), SalesLine."Line No."));
+
+                if IntrastatReportSetup."Tariff No. Mandatory" then
+                    if Item.Get(SalesLine."No.") and (Item."Tariff No." = '') then
+                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, Item.FieldCaption("Tariff No."), SalesLine."Line No."));
+
+                if IntrastatReportSetup."Country/Region of Origin Mand." then
+                    if Item.Get(SalesLine."No.") and (Item."Country/Region of Origin Code" = '') then
+                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, Item.FieldCaption("Country/Region of Origin Code"), SalesLine."Line No."));
+
+            until SalesLine.Next() = 0;
+
+        if TempErrorMessage.HasErrors(true) then
+            TempErrorMessage.ShowErrorMessages(true);
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Purch.-Post", OnAfterCheckPurchDoc, '', false, false)]
+    local procedure CheckIntrastatMandatoryFieldsInPurchase(var PurchHeader: Record "Purchase Header")
+    var
+        TempErrorMessage: Record "Error Message" temporary;
+        PurchLine: Record "Purchase Line";
+        Item: Record Item;
+    begin
+        if PurchHeader.IsTemporary() or (not IntrastatReportSetup.ReadPermission) then
+            exit;
+
+
+        if not IntrastatReportSetup.Get() then
+            exit;
+
+        if IntrastatReportSetup."Transaction Type Mandatory" then
+            if PurchHeader."Transaction Type" = '' then
+                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, PurchHeader.FieldCaption("Transaction Type")));
+
+        if IntrastatReportSetup."Transaction Spec. Mandatory" then
+            if PurchHeader."Transaction Specification" = '' then
+                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, PurchHeader.FieldCaption("Transaction Specification")));
+
+        if IntrastatReportSetup."Shipment Method Mandatory" then
+            if PurchHeader."Shipment Method Code" = '' then
+                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, PurchHeader.FieldCaption("Shipment Method Code")));
+
+        if IntrastatReportSetup."Transport Method Mandatory" then
+            if PurchHeader."Transport Method" = '' then
+                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, PurchHeader.FieldCaption("Transport Method")));
+
+        if not (IntrastatReportSetup."Tariff No. Mandatory") and not (IntrastatReportSetup."Net Weight Mandatory") and not (IntrastatReportSetup."Country/Region of Origin Mand.") then begin
+            if TempErrorMessage.HasErrors(true) then
+                TempErrorMessage.ShowErrorMessages(true);
+            exit;
+        end;
+
+        PurchLine.SetRange("Document Type", PurchHeader."Document Type");
+        PurchLine.SetRange("Document No.", PurchHeader."No.");
+        PurchLine.SetRange(Type, PurchLine.Type::Item);
+        if PurchLine.FindSet() then
+            repeat
+                if IntrastatReportSetup."Net Weight Mandatory" then
+                    if PurchLine."Net Weight" = 0 then
+                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, PurchLine.FieldCaption("Net Weight"), PurchLine."Line No."));
+
+                if IntrastatReportSetup."Tariff No. Mandatory" then
+                    if Item.Get(PurchLine."No.") and (Item."Tariff No." = '') then
+                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, Item.FieldCaption("Tariff No."), PurchLine."Line No."));
+
+                if IntrastatReportSetup."Country/Region of Origin Mand." then
+                    if Item.Get(PurchLine."No.") and (Item."Country/Region of Origin Code" = '') then
+                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, Item.FieldCaption("Country/Region of Origin Code"), PurchLine."Line No."));
+
+            until PurchLine.Next() = 0;
+
+        if TempErrorMessage.HasErrors(true) then
+            TempErrorMessage.ShowErrorMessages(true);
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"TransferOrder-Post (Yes/No)", OnCodeOnBeforePostTransferOrder, '', false, false)]
+    local procedure CheckIntrastatMandatoryFieldsInTransfer(var TransHeader: Record "Transfer Header")
+    var
+        TempErrorMessage: Record "Error Message" temporary;
+        TransferLine: Record "Transfer Line";
+        Item: Record Item;
+    begin
+        if TransHeader.IsTemporary() or (not IntrastatReportSetup.ReadPermission) then
+            exit;
+
+        if not IntrastatReportSetup.Get() then
+            exit;
+
+        if IntrastatReportSetup."Transaction Type Mandatory" then
+            if TransHeader."Transaction Type" = '' then
+                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, TransHeader.FieldCaption("Transaction Type")));
+
+        if IntrastatReportSetup."Transaction Spec. Mandatory" then
+            if TransHeader."Transaction Specification" = '' then
+                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, TransHeader.FieldCaption("Transaction Specification")));
+
+        if IntrastatReportSetup."Shipment Method Mandatory" then
+            if TransHeader."Shipment Method Code" = '' then
+                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, TransHeader.FieldCaption("Shipment Method Code")));
+
+        if IntrastatReportSetup."Transport Method Mandatory" then
+            if TransHeader."Transport Method" = '' then
+                TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldErr, TransHeader.FieldCaption("Transport Method")));
+
+        if not (IntrastatReportSetup."Tariff No. Mandatory") and not (IntrastatReportSetup."Net Weight Mandatory") and not (IntrastatReportSetup."Country/Region of Origin Mand.") then begin
+            if TempErrorMessage.HasErrors(true) then
+                TempErrorMessage.ShowErrorMessages(true);
+            exit;
+        end;
+
+        TransferLine.SetRange("Document No.", TransHeader."No.");
+        if TransferLine.FindSet() then
+            repeat
+                if IntrastatReportSetup."Net Weight Mandatory" then
+                    if TransferLine."Net Weight" = 0 then
+                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, TransferLine.FieldCaption("Net Weight"), TransferLine."Line No."));
+
+                if IntrastatReportSetup."Tariff No. Mandatory" then
+                    if Item.Get(TransferLine."Item No.") and (Item."Tariff No." = '') then
+                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, Item.FieldCaption("Tariff No."), TransferLine."Line No."));
+
+                if IntrastatReportSetup."Country/Region of Origin Mand." then
+                    if Item.Get(TransferLine."Item No.") and (Item."Country/Region of Origin Code" = '') then
+                        TempErrorMessage.LogSimpleMessage(TempErrorMessage."Message Type"::Error, StrSubstNo(MandatoryFieldsLineErr, Item.FieldCaption("Country/Region of Origin Code"), TransferLine."Line No."));
+
+            until TransferLine.Next() = 0;
+
+        if TempErrorMessage.HasErrors(true) then
+            TempErrorMessage.ShowErrorMessages(true);
     end;
 
     [IntegrationEvent(false, false)]

--- a/Apps/W1/Intrastat/app/src/Processing/IntrastatReportDocCompl.Codeunit.al
+++ b/Apps/W1/Intrastat/app/src/Processing/IntrastatReportDocCompl.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Inventory.Intrastat;
 
 using Microsoft.Foundation.Company;
 using Microsoft.Foundation.Address;
-using Microsoft.Inventory.Item;
 using System.Utilities;
 using Microsoft.Purchases.Document;
 using Microsoft.Inventory.Transfer;

--- a/Apps/W1/Intrastat/app/src/Processing/IntrastatReportDocCompl.Codeunit.al
+++ b/Apps/W1/Intrastat/app/src/Processing/IntrastatReportDocCompl.Codeunit.al
@@ -19,7 +19,6 @@ codeunit 4812 "Intrastat Report Doc. Compl."
 {
     var
         IntrastatReportSetup: Record "Intrastat Report Setup";
-        CompanyInformation: Record "Company Information";
         MandatoryFieldErr: Label '%1 field cannot be empty.', Comment = '%1 - field name';
 
     [EventSubscriber(ObjectType::Table, Database::"Sales Header", 'OnBeforeInsertEvent', '', false, false)]
@@ -170,7 +169,7 @@ codeunit 4812 "Intrastat Report Doc. Compl."
         if TransferHeader."Trsf.-from Country/Region Code" = TransferHeader."Trsf.-to Country/Region Code" then
             exit;
 
-        if not IsIntrastatTransaction(TransferHeader."Trsf.-to Country/Region Code") and (not IsIntrastatTransaction(TransferHeader."Trsf.-from Country/Region Code")) then
+        if not IsIntrastatTransaction(TransferHeader."Trsf.-from Country/Region Code") then
             exit;
 
         if IntrastatReportSetup."Transaction Type Mandatory" then
@@ -233,6 +232,7 @@ codeunit 4812 "Intrastat Report Doc. Compl."
     local procedure IsIntrastatTransaction(CountryCode: Code[10]): Boolean
     var
         CountryRegion: Record "Country/Region";
+        CompanyInformation: Record "Company Information";
     begin
         if not CountryRegion.Get(CountryCode) then
             exit(false);

--- a/Apps/W1/Intrastat/app/src/Setup/IntrastatReportSetup.Page.al
+++ b/Apps/W1/Intrastat/app/src/Setup/IntrastatReportSetup.Page.al
@@ -59,9 +59,6 @@ page 4810 "Intrastat Report Setup"
                 field("Transaction Spec. Mandatory"; Rec."Transaction Spec. Mandatory") { }
                 field("Transport Method Mandatory"; Rec."Transport Method Mandatory") { }
                 field("Shipment Method Mandatory"; Rec."Shipment Method Mandatory") { }
-                field("Tariff No. Mandatory"; Rec."Tariff No. Mandatory") { }
-                field("Net Weight Mandatory"; Rec."Net Weight Mandatory") { }
-                field("Country/Region of Origin Mand."; Rec."Country/Region of Origin Mand.") { }
             }
             group(Reporting)
             {

--- a/Apps/W1/Intrastat/app/src/Setup/IntrastatReportSetup.Page.al
+++ b/Apps/W1/Intrastat/app/src/Setup/IntrastatReportSetup.Page.al
@@ -55,6 +55,13 @@ page 4810 "Intrastat Report Setup"
                 field("Def. 3-Party Trade VAT No."; Rec."Def. 3-Party Trade VAT No.") { }
                 field("Def. VAT for Unknown State"; Rec."Def. VAT for Unknown State") { }
                 field("Def. Country/Region Code"; Rec."Def. Country/Region Code") { }
+                field("Transaction Type Mandatory"; Rec."Transaction Type Mandatory") { }
+                field("Transaction Spec. Mandatory"; Rec."Transaction Spec. Mandatory") { }
+                field("Transport Method Mandatory"; Rec."Transport Method Mandatory") { }
+                field("Shipment Method Mandatory"; Rec."Shipment Method Mandatory") { }
+                field("Tariff No. Mandatory"; Rec."Tariff No. Mandatory") { }
+                field("Net Weight Mandatory"; Rec."Net Weight Mandatory") { }
+                field("Country/Region of Origin Mand."; Rec."Country/Region of Origin Mand.") { }
             }
             group(Reporting)
             {

--- a/Apps/W1/Intrastat/app/src/Setup/IntrastatReportSetup.Table.al
+++ b/Apps/W1/Intrastat/app/src/Setup/IntrastatReportSetup.Table.al
@@ -230,6 +230,41 @@ table 4810 "Intrastat Report Setup"
             Caption = 'Purchase Intrastat Info Based On';
             ToolTip = 'Specifies based on which vendor code Intrastat settings are added to the document.';
         }
+        field(38; "Transaction Type Mandatory"; Boolean)
+        {
+            Caption = 'Transaction Type Mandatory';
+            ToolTip = 'Specifies if the transaction type should be filled on documents before posting';
+        }
+        field(39; "Transaction Spec. Mandatory"; Boolean)
+        {
+            Caption = 'Transaction Spec. Mandatory';
+            ToolTip = 'Specifies if the transaction specification should be filled on documents before posting';
+        }
+        field(40; "Transport Method Mandatory"; Boolean)
+        {
+            Caption = 'Transport Method Mandatory';
+            ToolTip = 'Specifies if the transprot method should be filled on documents before posting';
+        }
+        field(41; "Shipment Method Mandatory"; Boolean)
+        {
+            Caption = 'Shipment Method Mandatory';
+            ToolTip = 'Specifies if the shipment method should be filled on documents before posting';
+        }
+        field(42; "Tariff No. Mandatory"; Boolean)
+        {
+            Caption = 'Tariff No. Mandatory';
+            ToolTip = 'Specfies if the tariff no. should be filled on documents before posting';
+        }
+        field(43; "Net Weight Mandatory"; Boolean)
+        {
+            Caption = 'Net Weight Mandatory';
+            ToolTip = 'Specifies if the net weight should be filled on documents before posting';
+        }
+        field(44; "Country/Region of Origin Mand."; Boolean)
+        {
+            Caption = 'Country/Region of Origin Mandatory';
+            ToolTip = 'Specifies if the country/region of origin should be filled on documents before posting';
+        }
     }
 
     keys

--- a/Apps/W1/Intrastat/app/src/Setup/IntrastatReportSetup.Table.al
+++ b/Apps/W1/Intrastat/app/src/Setup/IntrastatReportSetup.Table.al
@@ -250,21 +250,6 @@ table 4810 "Intrastat Report Setup"
             Caption = 'Shipment Method Mandatory';
             ToolTip = 'Specifies if the shipment method should be filled on documents before posting';
         }
-        field(42; "Tariff No. Mandatory"; Boolean)
-        {
-            Caption = 'Tariff No. Mandatory';
-            ToolTip = 'Specfies if the tariff no. should be filled on documents before posting';
-        }
-        field(43; "Net Weight Mandatory"; Boolean)
-        {
-            Caption = 'Net Weight Mandatory';
-            ToolTip = 'Specifies if the net weight should be filled on documents before posting';
-        }
-        field(44; "Country/Region of Origin Mand."; Boolean)
-        {
-            Caption = 'Country/Region of Origin Mandatory';
-            ToolTip = 'Specifies if the country/region of origin should be filled on documents before posting';
-        }
     }
 
     keys

--- a/Apps/W1/Intrastat/app/src/Setup/IntrastatReportSetup.Table.al
+++ b/Apps/W1/Intrastat/app/src/Setup/IntrastatReportSetup.Table.al
@@ -233,22 +233,22 @@ table 4810 "Intrastat Report Setup"
         field(38; "Transaction Type Mandatory"; Boolean)
         {
             Caption = 'Transaction Type Mandatory';
-            ToolTip = 'Specifies if the transaction type should be filled on documents before posting';
+            ToolTip = 'Specifies if the transaction type should be filled in on documents before posting';
         }
         field(39; "Transaction Spec. Mandatory"; Boolean)
         {
             Caption = 'Transaction Spec. Mandatory';
-            ToolTip = 'Specifies if the transaction specification should be filled on documents before posting';
+            ToolTip = 'Specifies if the transaction specification should be filled in on documents before posting';
         }
         field(40; "Transport Method Mandatory"; Boolean)
         {
             Caption = 'Transport Method Mandatory';
-            ToolTip = 'Specifies if the transprot method should be filled on documents before posting';
+            ToolTip = 'Specifies if the transprot method should be filled in on documents before posting';
         }
         field(41; "Shipment Method Mandatory"; Boolean)
         {
             Caption = 'Shipment Method Mandatory';
-            ToolTip = 'Specifies if the shipment method should be filled on documents before posting';
+            ToolTip = 'Specifies if the shipment method should be filled in on documents before posting';
         }
     }
 

--- a/Apps/W1/Intrastat/test/src/IntrastatReportTest.Codeunit.al
+++ b/Apps/W1/Intrastat/test/src/IntrastatReportTest.Codeunit.al
@@ -39,6 +39,8 @@ codeunit 139550 "Intrastat Report Test"
         ShptMethodCodeErr: Label 'Wrong Shipment Method Code';
         StatPeriodFormatErr: Label '%1 must be 4 characters, for example, 9410 for October, 1994.', Comment = '%1 - field caption';
         StatPeriodMonthErr: Label 'Please check the month number.';
+        MandatoryFieldErr: Label '%1 field cannot be empty.', comment = '%1 - field caption';
+        WrongErrorOccursErr: Label 'Wrong error occurs';
 
     [Test]
     [Scope('OnPrem')]
@@ -4024,13 +4026,13 @@ codeunit 139550 "Intrastat Report Test"
         CustomerNo := LibraryIntrastat.CreateCustomer();
         ItemNo := LibraryIntrastat.CreateItem();
         LibraryIntrastat.CreateSalesDocument(SalesHeader, SalesLine, CustomerNo, WorkDate(), SalesHeader."Document Type"::Order, SalesLine.Type::Item, ItemNo, 1);
+        InsertIntrastatInfoInSalesHeader(SalesHeader);
         SalesHeader."Transaction Type" := '';
         SalesHeader.Modify();
-        LibraryVariableStorage.Enqueue(SalesHeader.FieldCaption("Transaction Type"));
         //[WHEN] Try to post
         asserterror LibrarySales.PostSalesDocument(SalesHeader, true, true);
         //[THEN] An error occurs
-
+        Assert.AreEqual(StrSubstNo(MandatoryFieldErr, SalesHeader.FieldCaption("Transaction Type")), LibraryVariableStorage.DequeueText(), WrongErrorOccursErr);
     end;
 
     [Test]
@@ -4054,12 +4056,13 @@ codeunit 139550 "Intrastat Report Test"
         CustomerNo := LibraryIntrastat.CreateCustomer();
         ItemNo := LibraryIntrastat.CreateItem();
         LibraryIntrastat.CreateSalesDocument(SalesHeader, SalesLine, CustomerNo, WorkDate(), SalesHeader."Document Type"::Order, SalesLine.Type::Item, ItemNo, 1);
+        InsertIntrastatInfoInSalesHeader(SalesHeader);
         SalesHeader."Transaction Specification" := '';
         SalesHeader.Modify();
-        LibraryVariableStorage.Enqueue(SalesHeader.FieldCaption("Transaction Specification"));
         //[WHEN] Try to post
         asserterror LibrarySales.PostSalesDocument(SalesHeader, true, true);
         //[THEN] An error occurs
+        Assert.AreEqual(StrSubstNo(MandatoryFieldErr, SalesHeader.FieldCaption("Transaction Specification")), LibraryVariableStorage.DequeueText(), WrongErrorOccursErr);
     end;
 
     [Test]
@@ -4083,12 +4086,13 @@ codeunit 139550 "Intrastat Report Test"
         CustomerNo := LibraryIntrastat.CreateCustomer();
         ItemNo := LibraryIntrastat.CreateItem();
         LibraryIntrastat.CreateSalesDocument(SalesHeader, SalesLine, CustomerNo, WorkDate(), SalesHeader."Document Type"::Order, SalesLine.Type::Item, ItemNo, 1);
+        InsertIntrastatInfoInSalesHeader(SalesHeader);
         SalesHeader."Shipment Method Code" := '';
         SalesHeader.Modify();
-        LibraryVariableStorage.Enqueue(SalesHeader.FieldCaption("Shipment Method Code"));
         //[WHEN] Try to post
         asserterror LibrarySales.PostSalesDocument(SalesHeader, true, true);
         //[THEN] An error occurs
+        Assert.AreEqual(StrSubstNo(MandatoryFieldErr, SalesHeader.FieldCaption("Shipment Method Code")), LibraryVariableStorage.DequeueText(), WrongErrorOccursErr);
     end;
 
     [Test]
@@ -4112,12 +4116,13 @@ codeunit 139550 "Intrastat Report Test"
         CustomerNo := LibraryIntrastat.CreateCustomer();
         ItemNo := LibraryIntrastat.CreateItem();
         LibraryIntrastat.CreateSalesDocument(SalesHeader, SalesLine, CustomerNo, WorkDate(), SalesHeader."Document Type"::Order, SalesLine.Type::Item, ItemNo, 1);
+        InsertIntrastatInfoInSalesHeader(SalesHeader);
         SalesHeader."Transport Method" := '';
         SalesHeader.Modify();
-        LibraryVariableStorage.Enqueue(SalesHeader.FieldCaption("Transport Method"));
         //[WHEN] Try to post
         asserterror LibrarySales.PostSalesDocument(SalesHeader, true, true);
         //[THEN] An error occurs
+        Assert.AreEqual(StrSubstNo(MandatoryFieldErr, SalesHeader.FieldCaption("Transport Method")), LibraryVariableStorage.DequeueText(), WrongErrorOccursErr);
     end;
 
     [Test]
@@ -4142,13 +4147,13 @@ codeunit 139550 "Intrastat Report Test"
         ItemNo := LibraryIntrastat.CreateItem();
         LibraryIntrastat.CreatePurchaseHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, WorkDate(), VendorNo);
         LibraryIntrastat.CreatePurchaseLine(PurchaseHeader, PurchaseLine, PurchaseLine.Type::Item, ItemNo);
+        InsertIntrastatInfoInPurchaseHeader(PurchaseHeader);
         PurchaseHeader."Transaction Type" := '';
         PurchaseHeader.Modify();
-        LibraryVariableStorage.Enqueue(PurchaseHeader.FieldCaption("Transaction Type"));
         //[WHEN] Try to post
         asserterror LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
         //[THEN] An error occurs
-
+        Assert.AreEqual(StrSubstNo(MandatoryFieldErr, PurchaseHeader.FieldCaption("Transaction Type")), LibraryVariableStorage.DequeueText(), WrongErrorOccursErr);
     end;
 
     [Test]
@@ -4173,12 +4178,13 @@ codeunit 139550 "Intrastat Report Test"
         ItemNo := LibraryIntrastat.CreateItem();
         LibraryIntrastat.CreatePurchaseHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, WorkDate(), VendorNo);
         LibraryIntrastat.CreatePurchaseLine(PurchaseHeader, PurchaseLine, PurchaseLine.Type::Item, ItemNo);
+        InsertIntrastatInfoInPurchaseHeader(PurchaseHeader);
         PurchaseHeader."Transaction Specification" := '';
         PurchaseHeader.Modify();
-        LibraryVariableStorage.Enqueue(PurchaseHeader.FieldCaption("Transaction Specification"));
         //[WHEN] Try to post
         asserterror LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
         //[THEN] An error occurs
+        Assert.AreEqual(StrSubstNo(MandatoryFieldErr, PurchaseHeader.FieldCaption("Transaction Specification")), LibraryVariableStorage.DequeueText(), WrongErrorOccursErr);
     end;
 
     [Test]
@@ -4203,12 +4209,13 @@ codeunit 139550 "Intrastat Report Test"
         ItemNo := LibraryIntrastat.CreateItem();
         LibraryIntrastat.CreatePurchaseHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, WorkDate(), VendorNo);
         LibraryIntrastat.CreatePurchaseLine(PurchaseHeader, PurchaseLine, PurchaseLine.Type::Item, ItemNo);
+        InsertIntrastatInfoInPurchaseHeader(PurchaseHeader);
         PurchaseHeader."Shipment Method Code" := '';
         PurchaseHeader.Modify();
-        LibraryVariableStorage.Enqueue(PurchaseHeader.FieldCaption("Shipment Method Code"));
         //[WHEN] Try to post
         asserterror LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
         //[THEN] An error occurs
+        Assert.AreEqual(StrSubstNo(MandatoryFieldErr, PurchaseHeader.FieldCaption("Shipment Method Code")), LibraryVariableStorage.DequeueText(), WrongErrorOccursErr);
     end;
 
     [Test]
@@ -4233,12 +4240,13 @@ codeunit 139550 "Intrastat Report Test"
         ItemNo := LibraryIntrastat.CreateItem();
         LibraryIntrastat.CreatePurchaseHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, WorkDate(), VendorNo);
         LibraryIntrastat.CreatePurchaseLine(PurchaseHeader, PurchaseLine, PurchaseLine.Type::Item, ItemNo);
+        InsertIntrastatInfoInPurchaseHeader(PurchaseHeader);
         PurchaseHeader."Transport Method" := '';
         PurchaseHeader.Modify();
-        LibraryVariableStorage.Enqueue(PurchaseHeader.FieldCaption("Transport Method"));
         //[WHEN] Try to post
         asserterror LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
         //[THEN] An error occurs
+        Assert.AreEqual(StrSubstNo(MandatoryFieldErr, PurchaseHeader.FieldCaption("Transport Method")), LibraryVariableStorage.DequeueText(), WrongErrorOccursErr);
     end;
 
     local procedure Initialize()
@@ -4279,7 +4287,8 @@ codeunit 139550 "Intrastat Report Test"
         VerifyIntrastatReportLine(DocumentNo, IntrastatReportNo, IntrastatReportLineType, LibraryIntrastat.GetCountryRegionCode(), ItemNo, Quantity);
     end;
 
-    procedure CreateAndVerifyIntrastatLine(DocumentNo: Code[20]; ItemNo: Code[20]; Quantity: Decimal; IntrastatReportLineType: Enum "Intrastat Report Line Type"; CountryRegionCode: Code[10]; LocationCode: Code[10])
+    procedure CreateAndVerifyIntrastatLine(DocumentNo: Code[20]; ItemNo: Code[20]; Quantity: Decimal; IntrastatReportLineType: Enum "Intrastat Report Line Type"; CountryRegionCode: Code[10];
+                                                                                                                                   LocationCode: Code[10])
     var
         IntrastatReportNo: Code[20];
     begin
@@ -4378,7 +4387,10 @@ codeunit 139550 "Intrastat Report Test"
             IntrastatReportLine.FieldCaption("Item No."), ItemNo, IntrastatReportLine.TableCaption()));
     end;
 
-    local procedure VerifyIntrastatReportLine(DocumentNo: Code[20]; IntrastatReportNo: Code[20]; Type: Enum "Intrastat Report Line Type"; CountryRegionCode: Code[10]; ItemNo: Code[20]; Quantity: Decimal; LocationCode: Code[10])
+    local procedure VerifyIntrastatReportLine(DocumentNo: Code[20]; IntrastatReportNo: Code[20]; Type: Enum "Intrastat Report Line Type"; CountryRegionCode: Code[10];
+                                                                                                           ItemNo: Code[20];
+                                                                                                           Quantity: Decimal;
+                                                                                                           LocationCode: Code[10])
     var
         IntrastatReportLine: Record "Intrastat Report Line";
     begin
@@ -4485,6 +4497,98 @@ codeunit 139550 "Intrastat Report Test"
         IntrastatReportLine.TestField("Country/Region of Origin Code", CountryOfOrigin);
     end;
 
+    local procedure InsertIntrastatInfoInSalesHeader(var SalesHeader: Record "Sales Header")
+    var
+        TransactionType: Record "Transaction Type";
+        TransactionSpecification: Record "Transaction Specification";
+        ShipmentMethod: Record "Shipment Method";
+        TransportMethod: Record "Transport Method";
+    begin
+        if SalesHeader."Transaction Type" = '' then begin
+            if not TransactionType.FindFirst() then begin
+                TransactionType.Init();
+                TransactionType.Code := LibraryRandom.RandText(MaxStrLen(TransactionType.Code));
+                TransactionType.Insert();
+            end;
+            SalesHeader."Transaction Type" := TransactionType.Code;
+            SalesHeader.Modify();
+        end;
+        if SalesHeader."Transaction Specification" = '' then begin
+            if not TransactionSpecification.FindFirst() then begin
+                TransactionSpecification.Init();
+                TransactionSpecification.Code := LibraryRandom.RandText(MaxStrLen(TransactionSpecification.Code));
+                TransactionSpecification.Insert();
+            end;
+            SalesHeader."Transaction Specification" := TransactionSpecification.Code;
+            SalesHeader.Modify();
+        end;
+        if SalesHeader."Shipment Method Code" = '' then begin
+            if not ShipmentMethod.FindFirst() then begin
+                ShipmentMethod.Init();
+                ShipmentMethod.Code := LibraryRandom.RandText(MaxStrLen(ShipmentMethod.Code));
+                ShipmentMethod.Insert();
+            end;
+            SalesHeader."Shipment Method Code" := ShipmentMethod.Code;
+            SalesHeader.Modify();
+        end;
+
+        if SalesHeader."Transport Method" = '' then begin
+            if not TransportMethod.FindFirst() then begin
+                TransportMethod.Init();
+                TransportMethod.Code := LibraryRandom.RandText(MaxStrLen(TransportMethod.Code));
+                TransportMethod.Insert();
+            end;
+            SalesHeader."Transport Method" := TransportMethod.Code;
+            SalesHeader.Modify();
+        end;
+    end;
+
+    local procedure InsertIntrastatInfoInPurchaseHeader(var PurchaseHeader: Record "Purchase Header")
+    var
+        TransactionType: Record "Transaction Type";
+        TransactionSpecification: Record "Transaction Specification";
+        ShipmentMethod: Record "Shipment Method";
+        TransportMethod: Record "Transport Method";
+    begin
+        if PurchaseHeader."Transaction Type" = '' then begin
+            if not TransactionType.FindFirst() then begin
+                TransactionType.Init();
+                TransactionType.Code := LibraryRandom.RandText(MaxStrLen(TransactionType.Code));
+                TransactionType.Insert();
+            end;
+            PurchaseHeader."Transaction Type" := TransactionType.Code;
+            PurchaseHeader.Modify();
+        end;
+        if PurchaseHeader."Transaction Specification" = '' then begin
+            if not TransactionSpecification.FindFirst() then begin
+                TransactionSpecification.Init();
+                TransactionSpecification.Code := LibraryRandom.RandText(MaxStrLen(TransactionSpecification.Code));
+                TransactionSpecification.Insert();
+            end;
+            PurchaseHeader."Transaction Specification" := TransactionSpecification.Code;
+            PurchaseHeader.Modify();
+        end;
+        if PurchaseHeader."Shipment Method Code" = '' then begin
+            if not ShipmentMethod.FindFirst() then begin
+                ShipmentMethod.Init();
+                ShipmentMethod.Code := LibraryRandom.RandText(MaxStrLen(ShipmentMethod.Code));
+                ShipmentMethod.Insert();
+            end;
+            PurchaseHeader."Shipment Method Code" := ShipmentMethod.Code;
+            PurchaseHeader.Modify();
+        end;
+
+        if PurchaseHeader."Transport Method" = '' then begin
+            if not TransportMethod.FindFirst() then begin
+                TransportMethod.Init();
+                TransportMethod.Code := LibraryRandom.RandText(MaxStrLen(TransportMethod.Code));
+                TransportMethod.Insert();
+            end;
+            PurchaseHeader."Transport Method" := TransportMethod.Code;
+            PurchaseHeader.Modify();
+        end;
+    end;
+
     [ModalPageHandler]
     [Scope('OnPrem')]
     procedure IntrastatReportListPageHandler(var IntrastatReportList: TestPage "Intrastat Report List")
@@ -4540,7 +4644,7 @@ codeunit 139550 "Intrastat Report Test"
         ErrorMessage: Record "Error Message";
     begin
         ErrorMessages.GetRecord(ErrorMessage);
-        Assert.AreEqual(ErrorMessage.Message, StrSubstNo('%1 field cannot be empty.', LibraryVariableStorage.DequeueText()), 'Error');
+        LibraryVariableStorage.Enqueue(ErrorMessage.Message);
     end;
 
     local procedure CreateIntrastatReportChecklist()

--- a/Apps/W1/Intrastat/test/src/IntrastatReportTest.Codeunit.al
+++ b/Apps/W1/Intrastat/test/src/IntrastatReportTest.Codeunit.al
@@ -4003,6 +4003,244 @@ codeunit 139550 "Intrastat Report Test"
         IntrastatReportSetup.Modify(true);
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('MessageHandlerEmpty,ErrorMessagePageHandler')]
+    procedure CheckMandatoryTransactionTypeOnSalesDocument()
+    var
+        IntrastatReportSetup: Record "Intrastat Report Setup";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        ItemNo: Code[20];
+        CustomerNo: Code[20];
+    begin
+        // [FFEATURE] [Mandatory fields in Intrastat Setup]
+        // [SCENARIO 332149] Check if error occurs for empty transaction type on Sales Doc if Transaction Type mandatory is set to true on Intrastat Setup
+        Initialize();
+        IntrastatReportSetup.Get();
+        IntrastatReportSetup.Validate("Transaction Type Mandatory", true);
+        IntrastatReportSetup.Modify();
+        //[GIVEN] Transaction Type Mandatory = true in Intrastat Setup, Sales Document for intrastat transaction created
+        CustomerNo := LibraryIntrastat.CreateCustomer();
+        ItemNo := LibraryIntrastat.CreateItem();
+        LibraryIntrastat.CreateSalesDocument(SalesHeader, SalesLine, CustomerNo, WorkDate(), SalesHeader."Document Type"::Order, SalesLine.Type::Item, ItemNo, 1);
+        SalesHeader."Transaction Type" := '';
+        SalesHeader.Modify();
+        LibraryVariableStorage.Enqueue(SalesHeader.FieldCaption("Transaction Type"));
+        //[WHEN] Try to post
+        asserterror LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        //[THEN] An error occurs
+
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('MessageHandlerEmpty,ErrorMessagePageHandler')]
+    procedure CheckMandatoryTransactionSpecOnSalesDocument()
+    var
+        IntrastatReportSetup: Record "Intrastat Report Setup";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        ItemNo: Code[20];
+        CustomerNo: Code[20];
+    begin
+        // [FFEATURE] [Mandatory fields in Intrastat Setup]
+        // [SCENARIO 332149] Check if error occurs for empty transaction specification on Sales Doc if Transaction Spec. mandatory is set to true on Intrastat Setup
+        Initialize();
+        IntrastatReportSetup.Get();
+        IntrastatReportSetup.Validate("Transaction Spec. Mandatory", true);
+        IntrastatReportSetup.Modify();
+        //[GIVEN] Transaction Spec. Mandatory = true in Intrastat Setup, Sales Document for intrastat transaction created
+        CustomerNo := LibraryIntrastat.CreateCustomer();
+        ItemNo := LibraryIntrastat.CreateItem();
+        LibraryIntrastat.CreateSalesDocument(SalesHeader, SalesLine, CustomerNo, WorkDate(), SalesHeader."Document Type"::Order, SalesLine.Type::Item, ItemNo, 1);
+        SalesHeader."Transaction Specification" := '';
+        SalesHeader.Modify();
+        LibraryVariableStorage.Enqueue(SalesHeader.FieldCaption("Transaction Specification"));
+        //[WHEN] Try to post
+        asserterror LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        //[THEN] An error occurs
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('MessageHandlerEmpty,ErrorMessagePageHandler')]
+    procedure CheckMandatoryShipmentMethodOnSalesDocument()
+    var
+        IntrastatReportSetup: Record "Intrastat Report Setup";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        ItemNo: Code[20];
+        CustomerNo: Code[20];
+    begin
+        // [FFEATURE] [Mandatory fields in Intrastat Setup]
+        // [SCENARIO 332149] Check if error occurs for empty shipment method on Sales Doc if Shipment Method mandatory is set to true on Intrastat Setup
+        Initialize();
+        IntrastatReportSetup.Get();
+        IntrastatReportSetup.Validate("Shipment Method Mandatory", true);
+        IntrastatReportSetup.Modify();
+        //[GIVEN] Shipment Method Mandatory = true in Intrastat Setup, Sales Document for intrastat transaction created
+        CustomerNo := LibraryIntrastat.CreateCustomer();
+        ItemNo := LibraryIntrastat.CreateItem();
+        LibraryIntrastat.CreateSalesDocument(SalesHeader, SalesLine, CustomerNo, WorkDate(), SalesHeader."Document Type"::Order, SalesLine.Type::Item, ItemNo, 1);
+        SalesHeader."Shipment Method Code" := '';
+        SalesHeader.Modify();
+        LibraryVariableStorage.Enqueue(SalesHeader.FieldCaption("Shipment Method Code"));
+        //[WHEN] Try to post
+        asserterror LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        //[THEN] An error occurs
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('MessageHandlerEmpty,ErrorMessagePageHandler')]
+    procedure CheckMandatoryTransportMethodOnSalesDocument()
+    var
+        IntrastatReportSetup: Record "Intrastat Report Setup";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        ItemNo: Code[20];
+        CustomerNo: Code[20];
+    begin
+        // [FFEATURE] [Mandatory fields in Intrastat Setup]
+        // [SCENARIO 332149] Check if error occurs for empty transport method on Sales Doc if Transport Method Mandatory is set to true on Intrastat Setup
+        Initialize();
+        IntrastatReportSetup.Get();
+        IntrastatReportSetup.Validate("Transport Method Mandatory", true);
+        IntrastatReportSetup.Modify();
+        //[GIVEN] Transport Method Mandatory = true in Intrastat Setup, Sales Document for intrastat transaction created
+        CustomerNo := LibraryIntrastat.CreateCustomer();
+        ItemNo := LibraryIntrastat.CreateItem();
+        LibraryIntrastat.CreateSalesDocument(SalesHeader, SalesLine, CustomerNo, WorkDate(), SalesHeader."Document Type"::Order, SalesLine.Type::Item, ItemNo, 1);
+        SalesHeader."Transport Method" := '';
+        SalesHeader.Modify();
+        LibraryVariableStorage.Enqueue(SalesHeader.FieldCaption("Transport Method"));
+        //[WHEN] Try to post
+        asserterror LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        //[THEN] An error occurs
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('MessageHandlerEmpty,ErrorMessagePageHandler')]
+    procedure CheckMandatoryTransactionTypeOnPurchDocument()
+    var
+        IntrastatReportSetup: Record "Intrastat Report Setup";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ItemNo: Code[20];
+        VendorNo: Code[20];
+    begin
+        // [FFEATURE] [Mandatory fields in Intrastat Setup]
+        // [SCENARIO 332149] Check if error occurs for empty transaction type on Purchase Doc if Transaction Type mandatory is set to true on Intrastat Setup
+        Initialize();
+        IntrastatReportSetup.Get();
+        IntrastatReportSetup.Validate("Transaction Type Mandatory", true);
+        IntrastatReportSetup.Modify();
+        //[GIVEN] Transaction Type Mandatory = true in Intrastat Setup, Purchase Document for intrastat transaction created
+        VendorNo := LibraryIntrastat.CreateVendorWithVATRegNo(true);
+        ItemNo := LibraryIntrastat.CreateItem();
+        LibraryIntrastat.CreatePurchaseHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, WorkDate(), VendorNo);
+        LibraryIntrastat.CreatePurchaseLine(PurchaseHeader, PurchaseLine, PurchaseLine.Type::Item, ItemNo);
+        PurchaseHeader."Transaction Type" := '';
+        PurchaseHeader.Modify();
+        LibraryVariableStorage.Enqueue(PurchaseHeader.FieldCaption("Transaction Type"));
+        //[WHEN] Try to post
+        asserterror LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+        //[THEN] An error occurs
+
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('MessageHandlerEmpty,ErrorMessagePageHandler')]
+    procedure CheckMandatoryTransactionSpecOnPurchDocument()
+    var
+        IntrastatReportSetup: Record "Intrastat Report Setup";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ItemNo: Code[20];
+        VendorNo: Code[20];
+    begin
+        // [FFEATURE] [Mandatory fields in Intrastat Setup]
+        // [SCENARIO 332149] Check if error occurs for empty transaction specification on Purchase Doc if Transaction Spec. mandatory is set to true on Intrastat Setup
+        Initialize();
+        IntrastatReportSetup.Get();
+        IntrastatReportSetup.Validate("Transaction Spec. Mandatory", true);
+        IntrastatReportSetup.Modify();
+        //[GIVEN] Transaction Spec. Mandatory = true in Intrastat Setup, Purchase Document for intrastat transaction created
+        VendorNo := LibraryIntrastat.CreateVendorWithVATRegNo(true);
+        ItemNo := LibraryIntrastat.CreateItem();
+        LibraryIntrastat.CreatePurchaseHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, WorkDate(), VendorNo);
+        LibraryIntrastat.CreatePurchaseLine(PurchaseHeader, PurchaseLine, PurchaseLine.Type::Item, ItemNo);
+        PurchaseHeader."Transaction Specification" := '';
+        PurchaseHeader.Modify();
+        LibraryVariableStorage.Enqueue(PurchaseHeader.FieldCaption("Transaction Specification"));
+        //[WHEN] Try to post
+        asserterror LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+        //[THEN] An error occurs
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('MessageHandlerEmpty,ErrorMessagePageHandler')]
+    procedure CheckMandatoryShipmentMethodOnPurchDocument()
+    var
+        IntrastatReportSetup: Record "Intrastat Report Setup";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ItemNo: Code[20];
+        VendorNo: Code[20];
+    begin
+        // [FFEATURE] [Mandatory fields in Intrastat Setup]
+        // [SCENARIO 332149] Check if error occurs for empty shipment method on Purchase Doc if Shipment Method mandatory is set to true on Intrastat Setup
+        Initialize();
+        IntrastatReportSetup.Get();
+        IntrastatReportSetup.Validate("Shipment Method Mandatory", true);
+        IntrastatReportSetup.Modify();
+        //[GIVEN] Shipment Method Mandatory = true in Intrastat Setup, Purchase Document for intrastat transaction created
+        VendorNo := LibraryIntrastat.CreateVendorWithVATRegNo(true);
+        ItemNo := LibraryIntrastat.CreateItem();
+        LibraryIntrastat.CreatePurchaseHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, WorkDate(), VendorNo);
+        LibraryIntrastat.CreatePurchaseLine(PurchaseHeader, PurchaseLine, PurchaseLine.Type::Item, ItemNo);
+        PurchaseHeader."Shipment Method Code" := '';
+        PurchaseHeader.Modify();
+        LibraryVariableStorage.Enqueue(PurchaseHeader.FieldCaption("Shipment Method Code"));
+        //[WHEN] Try to post
+        asserterror LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+        //[THEN] An error occurs
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('MessageHandlerEmpty,ErrorMessagePageHandler')]
+    procedure CheckMandatoryTransportMethodOnPurchDocument()
+    var
+        IntrastatReportSetup: Record "Intrastat Report Setup";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ItemNo: Code[20];
+        VendorNo: Code[20];
+    begin
+        // [FFEATURE] [Mandatory fields in Intrastat Setup]
+        // [SCENARIO 332149] Check if error occurs for empty transport method on Purchase Doc if Transport Method Mandatory is set to true on Intrastat Setup
+        Initialize();
+        IntrastatReportSetup.Get();
+        IntrastatReportSetup.Validate("Transport Method Mandatory", true);
+        IntrastatReportSetup.Modify();
+        //[GIVEN] Transport Method Mandatory = true in Intrastat Setup, Purchase Document for intrastat transaction created
+        VendorNo := LibraryIntrastat.CreateVendorWithVATRegNo(true);
+        ItemNo := LibraryIntrastat.CreateItem();
+        LibraryIntrastat.CreatePurchaseHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, WorkDate(), VendorNo);
+        LibraryIntrastat.CreatePurchaseLine(PurchaseHeader, PurchaseLine, PurchaseLine.Type::Item, ItemNo);
+        PurchaseHeader."Transport Method" := '';
+        PurchaseHeader.Modify();
+        LibraryVariableStorage.Enqueue(PurchaseHeader.FieldCaption("Transport Method"));
+        //[WHEN] Try to post
+        asserterror LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+        //[THEN] An error occurs
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -4293,6 +4531,16 @@ codeunit 139550 "Intrastat Report Test"
     begin
         VendorLookup.FILTER.SetFilter("No.", LibraryVariableStorage.DequeueText());
         VendorLookup.OK().Invoke();
+    end;
+
+    [PageHandler]
+    [Scope('OnPrem')]
+    procedure ErrorMessagePageHandler(var ErrorMessages: Page "Error Messages")
+    var
+        ErrorMessage: Record "Error Message";
+    begin
+        ErrorMessages.GetRecord(ErrorMessage);
+        Assert.AreEqual(ErrorMessage.Message, StrSubstNo('%1 field cannot be empty.', LibraryVariableStorage.DequeueText()), 'Error');
     end;
 
     local procedure CreateIntrastatReportChecklist()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to AlAppExtensions please read our pull request guideline below
* https://github.com/microsoft/ALAppExtensions/blob/main/CONTRIBUTING.md
-->
#### Summary <!-- Provide a general summary of your changes -->
This PR contains new setup for mandatory fields used in Intrastat.
Setup fields are added to Intrastat Report Setup and are used in Sales, Purchase and Transfer documents, before posting. 

3 additional fields described in the Idea have not been added, because without changing how Intrastat works and from this data are gained this setup won't work correctly.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. --> #27681
Fixes #27681

Fixes [AB#332149](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/332149)





