### PR TITLE
E-Document: Change accessibility level for EDoc WorkFlow

### DIFF
--- a/Apps/W1/EDocument/app/src/Workflow/EDocumentWorkFlowSetup.Codeunit.al
+++ b/Apps/W1/EDocument/app/src/Workflow/EDocumentWorkFlowSetup.Codeunit.al
@@ -8,9 +8,9 @@ using System.Automation;
 
 codeunit 6139 "E-Document Workflow Setup"
 {
-    Access = Internal;
+    Access = Public;
 
-    procedure InsertSendToSingleServiceTemplate()
+    internal procedure InsertSendToSingleServiceTemplate()
     var
         Workflow: Record Workflow;
         WorkflowSetup: Codeunit "Workflow Setup";
@@ -23,7 +23,7 @@ codeunit 6139 "E-Document Workflow Setup"
         Workflow.Modify();
     end;
 
-    procedure InsertSendToMultiServiceTemplate()
+    internal procedure InsertSendToMultiServiceTemplate()
     var
         Workflow: Record Workflow;
         WorkflowSetup: Codeunit "Workflow Setup";

--- a/Apps/W1/EDocument/app/src/Workflow/EDocumentWorkFlowSetup.Codeunit.al
+++ b/Apps/W1/EDocument/app/src/Workflow/EDocumentWorkFlowSetup.Codeunit.al
@@ -36,12 +36,12 @@ codeunit 6139 "E-Document Workflow Setup"
         Workflow.Modify();
     end;
 
-    procedure EDocReceived(): Code[128]
+    internal procedure EDocReceived(): Code[128]
     begin
         exit('EDOCRECEIVED');
     end;
 
-    procedure EDocImport(): Code[128]
+    internal procedure EDocImport(): Code[128]
     begin
         exit('EDOCIMPORT');
     end;
@@ -56,7 +56,7 @@ codeunit 6139 "E-Document Workflow Setup"
         exit('EDOCCREATEDEVENT')
     end;
 
-    procedure EDocStatusChanged(): code[128];
+    internal procedure EDocStatusChanged(): code[128];
     begin
         exit('EDOCSENT')
     end;


### PR DESCRIPTION
#### Summary 
Enables access to hardcoded WorkFlow-names.
The changed code does not change the actual functions I want exposed, since the whole object is now Public. The functions I want are `EDocReceived`, `EDocImport`, `EDocSendEDocResponseCode`, `EDocCreated` & `EDocStatusChanged`

#### Work Item(s) 
Fixes #28326
