### PR TITLE
Fix for GP 1099 issue

### DIFF
--- a/Apps/US/HybridGP_US/app/src/Codeunits/GPCloudMigrationUS.Codeunit.al
+++ b/Apps/US/HybridGP_US/app/src/Codeunits/GPCloudMigrationUS.Codeunit.al
@@ -107,6 +107,10 @@ codeunit 42004 "GP Cloud Migration US"
         if IsIRSFormsFeatureEnabled() then
             exit;
 
+        // Clear the table to ensure all available IRS 1099 Form-Box records are created
+        if not IRS1099FormBox.IsEmpty() then
+            IRS1099FormBox.DeleteAll();
+
         IRS1099FormBox.InitIRS1099FormBoxes();
     end;
 #endif

--- a/Apps/US/HybridGP_US/app/src/Codeunits/GPPopulateVendor1099Data.Codeunit.al
+++ b/Apps/US/HybridGP_US/app/src/Codeunits/GPPopulateVendor1099Data.Codeunit.al
@@ -332,9 +332,11 @@ codeunit 42003 "GP Populate Vendor 1099 Data"
         GenJournalLine.Validate("Bal. Gen. Prod. Posting Group", '');
         GenJournalLine.Validate("Bal. VAT Prod. Posting Group", '');
         GenJournalLine.Validate("Bal. VAT Bus. Posting Group", '');
+
 #if not CLEAN25
+        if not GPCloudMigrationUS.IsIRSFormsFeatureEnabled() then
 #pragma warning disable AL0432
-        GenJournalLine.Validate("IRS 1099 Code", IRS1099Code);
+            GenJournalLine.Validate("IRS 1099 Code", IRS1099Code);
 #pragma warning restore AL0432
 #endif
         GenJournalLine.Validate("Document Type", DocumentType);


### PR DESCRIPTION
This PR fixes issues with the GP 1099 migration.
- If the new IRS Forms Feature is disabled, the original IRS form boxes are cleared and recreated, ensuring that they all get created.
- If the new IRS Forms Feature is enabled, don't set the IRS 1099 Code on the GenJournalLine since that is a deprecated field.
