### PR TITLE
Avoid inconsistensies when posting auto acc in alternative currency

### DIFF
--- a/Apps/W1/AutomaticAccountCodes/app/src/Codeunits/AACodesPostingHelper.Codeunit.al
+++ b/Apps/W1/AutomaticAccountCodes/app/src/Codeunits/AACodesPostingHelper.Codeunit.al
@@ -71,6 +71,7 @@ codeunit 4850 "AA Codes Posting Helper"
         GenJnlCheckLine: Codeunit "Gen. Jnl.-Check Line";
         NoOfAutoAccounts: Decimal;
         TotalAmount: Decimal;
+        TotalAltAmount: Decimal;
         SourceCurrBaseAmount: Decimal;
         AccLine: Integer;
     begin
@@ -115,9 +116,11 @@ codeunit 4850 "AA Codes Posting Helper"
                 CopyDimensionFromAutoAccLine(GenJnlLine2, AutomaticAccountLine);
                 AccLine := AccLine + 1;
                 TotalAmount := TotalAmount + GenJnlLine2.Amount;
+                TotalAltAmount := TotalAltAmount + GenJnlLine2."Source Currency Amount";
                 if (AccLine = NoOfAutoAccounts) and (TotalAmount <> 0) then
                     GenJnlLine2.Validate(Amount, GenJnlLine2.Amount - TotalAmount);
-
+                if (AccLine = NoOfAutoAccounts) and (TotalAltAmount <> 0) then
+                    GenJnlLine2.Validate("Source Currency Amount", GenJnlLine2."Source Currency Amount" - TotalAltAmount);
                 GenJnlCheckLine.RunCheck(GenJnlLine2);
 
                 sender.InitGLEntry(GenJnlLine2, GLEntry,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to AlAppExtensions please read our pull request guideline below
* https://github.com/microsoft/ALAppExtensions/blob/main/CONTRIBUTING.md
-->
The Auto Acc funtionality sometimes create inconsistencies in the database when an alternative currency is used. To avoid this the code is updated with a validate to also set the GenJnlLine.Source Currency Amount.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->

Inconsistencies when posting Auto Acc and Alternative Currency

Fixes [AB#573902](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/573902)