### PR TITLE
GP - Delete pre-installed Dimensions at the start of the migration

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
@@ -1695,10 +1695,6 @@ codeunit 4037 "Helper Functions"
         DataMigrationErrorLogging: Codeunit "Data Migration Error Logging";
         DimCode: Code[20];
     begin
-        // First delete any dimensions created during company initialization
-        if not Dimension.IsEmpty() then
-            Dimension.DeleteAll();
-
         if GPSegments.FindSet() then begin
             repeat
                 DataMigrationErrorLogging.SetLastRecordUnderProcessing(Format(GPSegments.RecordId()));
@@ -2269,6 +2265,14 @@ codeunit 4037 "Helper Functions"
         end;
 
         exit(true);
+    end;
+
+    internal procedure RunPreMigrationCleanup()
+    var
+        Dimension: Record Dimension;
+    begin
+        if not Dimension.IsEmpty() then
+            Dimension.DeleteAll(true);
     end;
 
     [IntegrationEvent(false, false)]

--- a/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
@@ -1695,6 +1695,10 @@ codeunit 4037 "Helper Functions"
         DataMigrationErrorLogging: Codeunit "Data Migration Error Logging";
         DimCode: Code[20];
     begin
+        // First delete any dimensions created during company initialization
+        if not Dimension.IsEmpty() then
+            Dimension.DeleteAll();
+
         if GPSegments.FindSet() then begin
             repeat
                 DataMigrationErrorLogging.SetLastRecordUnderProcessing(Format(GPSegments.RecordId()));

--- a/Apps/W1/HybridGP/app/src/codeunits/GPCloudMigration.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/codeunits/GPCloudMigration.codeunit.al
@@ -126,6 +126,7 @@ codeunit 4025 "GP Cloud Migration"
         SelectLatestVersion();
         HelperFunctions.SetProcessesRunning(true);
 
+        HelperFunctions.RunPreMigrationCleanup();
         GPPopulateCombinedTables.PopulateAllMappedTables();
         Commit();
 


### PR DESCRIPTION
This change enhances the GP to BC migration by deleting Dimensions that are pre-installed upon company initialization, at the start of the migration.

Fixes [AB#575370](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/575370)