### PR TITLE
[Ext. File Storage]: Certificate Auth Supportin Sharepoint Connector

### DIFF
--- a/Apps/W1/External File Storage - SharePoint Connector/app/src/ExtSharePointAccount.Page.al
+++ b/Apps/W1/External File Storage - SharePoint Connector/app/src/ExtSharePointAccount.Page.al
@@ -29,40 +29,115 @@ page 4580 "Ext. SharePoint Account"
                 NotBlank = true;
                 ShowMandatory = true;
             }
+            field("SharePoint Url"; Rec."SharePoint Url") { }
+            field("Base Relative Folder Path"; Rec."Base Relative Folder Path") { }
             field("Tenant Id"; Rec."Tenant Id") { }
             field("Client Id"; Rec."Client Id") { }
+            field("Authentication Type"; Rec."Authentication Type")
+            {
+                ToolTip = 'Specifies the authentication method used for this SharePoint account.';
+
+                trigger OnValidate()
+                begin
+                    UpdateAuthTypeVisibility();
+                end;
+            }
             field(SecretField; ClientSecret)
             {
-                Caption = 'Password';
+                Caption = 'Client Secret';
                 Editable = ClientSecretEditable;
                 ExtendedDatatype = Masked;
-                ToolTip = 'Specifies the the Client Secret of the App Registration.';
+                ToolTip = 'Specifies the Client Secret of the App Registration.';
+                Visible = ClientSecretVisible;
 
                 trigger OnValidate()
                 begin
                     Rec.SetClientSecret(ClientSecret);
                 end;
             }
-            field("SharePoint Url"; Rec."SharePoint Url") { }
-            field("Base Relative Folder Path"; Rec."Base Relative Folder Path") { }
+            field(CertificateField; Certificate)
+            {
+                Caption = 'Certificate (Base64-encoded)';
+                Editable = CertificateEditable;
+                ExtendedDatatype = Masked;
+                ToolTip = 'Specifies the Base64-encoded certificate for the Application (client) configured in the Azure Portal.';
+                Visible = CertificateVisible;
+
+                trigger OnValidate()
+                begin
+                    Rec.SetCertificate(Certificate);
+                end;
+            }
+            field(CertificatePasswordField; CertificatePassword)
+            {
+                Caption = 'Certificate Password';
+                Editable = CertificatePasswordEditable;
+                ExtendedDatatype = Masked;
+                ToolTip = 'Specifies the password for the certificate.';
+                Visible = CertificatePasswordVisible;
+
+                trigger OnValidate()
+                begin
+                    Rec.SetCertificatePassword(CertificatePassword);
+                end;
+            }
             field(Disabled; Rec.Disabled) { }
         }
     }
 
     var
         ClientSecretEditable: Boolean;
+        ClientSecretVisible: Boolean;
+        CertificateEditable: Boolean;
+        CertificateVisible: Boolean;
+        CertificatePasswordEditable: Boolean;
+        CertificatePasswordVisible: Boolean;
         [NonDebuggable]
         ClientSecret: Text;
+        [NonDebuggable]
+        Certificate: Text;
+        [NonDebuggable]
+        CertificatePassword: Text;
 
     trigger OnOpenPage()
     begin
         Rec.SetCurrentKey(Name);
+        UpdateAuthTypeVisibility();
     end;
 
     trigger OnAfterGetCurrRecord()
     begin
         ClientSecretEditable := CurrPage.Editable();
+        CertificateEditable := CurrPage.Editable();
+        CertificatePasswordEditable := CurrPage.Editable();
+
         if not IsNullGuid(Rec."Client Secret Key") then
             ClientSecret := '***';
+
+        if not IsNullGuid(Rec."Certificate Key") then
+            Certificate := '***';
+
+        if not IsNullGuid(Rec."Certificate Password Key") then
+            CertificatePassword := '***';
+
+        UpdateAuthTypeVisibility();
+    end;
+
+    local procedure UpdateAuthTypeVisibility()
+    begin
+        case Rec."Authentication Type" of
+            Enum::"Ext. SharePoint Auth Type"::"Client Secret":
+                begin
+                    ClientSecretVisible := true;
+                    CertificateVisible := false;
+                    CertificatePasswordVisible := false;
+                end;
+            Enum::"Ext. SharePoint Auth Type"::Certificate:
+                begin
+                    ClientSecretVisible := false;
+                    CertificateVisible := true;
+                    CertificatePasswordVisible := true;
+                end;
+        end;
     end;
 }

--- a/Apps/W1/External File Storage - SharePoint Connector/app/src/ExtSharePointAccount.Page.al
+++ b/Apps/W1/External File Storage - SharePoint Connector/app/src/ExtSharePointAccount.Page.al
@@ -45,7 +45,7 @@ page 4580 "Ext. SharePoint Account"
             group(Credentials)
             {
                 Caption = 'Credentials';
-                Editable = IsPageEditable;
+                Editable = PageEditable;
 
                 group(SharePointClientSecretGroup)
                 {
@@ -99,7 +99,7 @@ page 4580 "Ext. SharePoint Account"
     }
 
     var
-        IsPageEditable: Boolean;
+        PageEditable: Boolean;
         ClientSecretVisible: Boolean;
         CertificateVisible: Boolean;
         [NonDebuggable]
@@ -117,7 +117,7 @@ page 4580 "Ext. SharePoint Account"
 
     trigger OnAfterGetCurrRecord()
     begin
-        IsPageEditable := CurrPage.Editable();
+        PageEditable := CurrPage.Editable();
 
         MaskSensitiveFields();
         UpdateAuthTypeVisibility();

--- a/Apps/W1/External File Storage - SharePoint Connector/app/src/ExtSharePointAccount.Table.al
+++ b/Apps/W1/External File Storage - SharePoint Connector/app/src/ExtSharePointAccount.Table.al
@@ -24,12 +24,12 @@ table 4580 "Ext. SharePoint Account"
         field(2; Name; Text[250])
         {
             Caption = 'Account Name';
-            ToolTip = 'Specifies the name of the storage account connection.';
+            ToolTip = 'Specifies a descriptive name for this SharePoint storage account connection.';
         }
         field(4; "SharePoint Url"; Text[2048])
         {
             Caption = 'SharePoint Url';
-            ToolTip = 'Specifies the the url to your SharePoint site.';
+            ToolTip = 'Specifies the complete URL to your SharePoint site (e.g., https://mysharepoint.sharepoint.com/sites/ProjectX). This is the site URL where your documents will be stored.';
         }
         field(5; "Base Relative Folder Path"; Text[2048])
         {
@@ -40,13 +40,13 @@ table 4580 "Ext. SharePoint Account"
         {
             Access = Internal;
             Caption = 'Tenant Id';
-            ToolTip = 'Specifies the Tenant Id of the App Registration.';
+            ToolTip = 'Specifies the Microsoft Entra ID Tenant ID (Directory ID) where your SharePoint site and app registration are located.';
         }
         field(7; "Client Id"; Guid)
         {
             Access = Internal;
             Caption = 'Client Id';
-            ToolTip = 'Specifies the the Client Id of the App Registration.';
+            ToolTip = 'Specifies the Client ID (Application ID) of the App Registration in Microsoft Entra ID.';
         }
         field(8; "Client Secret Key"; Guid)
         {
@@ -56,12 +56,12 @@ table 4580 "Ext. SharePoint Account"
         field(9; Disabled; Boolean)
         {
             Caption = 'Disabled';
-            ToolTip = 'Specifies if the account is disabled. This happens automatically when a sandbox is created.';
+            ToolTip = 'Specifies if the account is disabled. Accounts are automatically disabled when a sandbox environment is created from production.';
         }
         field(10; "Authentication Type"; Enum "Ext. SharePoint Auth Type")
         {
             Caption = 'Authentication Type';
-            ToolTip = 'Specifies the authentication method used for this SharePoint account.';
+            ToolTip = 'Specifies the authentication flow used for this SharePoint account. Client Secret uses User grant flow, which means that the user must sign in when using this account. Certificate uses Client credentials flow, which means that the user does not need to sign in when using this account.';
             InitValue = "Client Secret";
         }
         field(11; "Certificate Key"; Guid)
@@ -94,14 +94,9 @@ table 4580 "Ext. SharePoint Account"
 
     trigger OnDelete()
     begin
-        if not IsNullGuid(Rec."Client Secret Key") then
-            if IsolatedStorage.Delete(Rec."Client Secret Key") then;
-
-        if not IsNullGuid(Rec."Certificate Key") then
-            if IsolatedStorage.Delete(Rec."Certificate Key") then;
-
-        if not IsNullGuid(Rec."Certificate Password Key") then
-            if IsolatedStorage.Delete(Rec."Certificate Password Key") then;
+        TryDeleteIsolatedStorageValue(Rec."Client Secret Key");
+        TryDeleteIsolatedStorageValue(Rec."Certificate Key");
+        TryDeleteIsolatedStorageValue(Rec."Certificate Password Key");
     end;
 
     procedure SetClientSecret(ClientSecret: SecretText)
@@ -109,14 +104,26 @@ table 4580 "Ext. SharePoint Account"
         if IsNullGuid(Rec."Client Secret Key") then
             Rec."Client Secret Key" := CreateGuid();
 
-        if not IsolatedStorage.Set(Format(Rec."Client Secret Key"), ClientSecret, DataScope::Company) then
-            Error(UnableToSetClientSecretMsg);
+        SetIsolatedStorageValue(Rec."Client Secret Key", ClientSecret, UnableToSetClientSecretMsg);
+
+        // When setting client secret, clear certificate authentication 
+        // as only one authentication method can be active
+        ClearCertificateAuthentication();
     end;
 
-    procedure GetClientSecret(ClientSecretKey: Guid) ClientSecret: SecretText
+    local procedure ClearCertificateAuthentication()
     begin
-        if not IsolatedStorage.Get(Format(ClientSecretKey), DataScope::Company, ClientSecret) then
-            Error(UnableToGetClientMsg);
+        if not IsNullGuid(Rec."Certificate Key") then begin
+            TryDeleteIsolatedStorageValue(Rec."Certificate Key");
+            TryDeleteIsolatedStorageValue(Rec."Certificate Password Key");
+            Clear(Rec."Certificate Key");
+            Clear(Rec."Certificate Password Key");
+        end;
+    end;
+
+    procedure GetClientSecret(ClientSecretKey: Guid): SecretText
+    begin
+        exit(GetIsolatedStorageValue(ClientSecretKey, UnableToGetClientMsg));
     end;
 
     internal procedure SetCertificate(Certificate: SecretText)
@@ -124,14 +131,24 @@ table 4580 "Ext. SharePoint Account"
         if IsNullGuid(Rec."Certificate Key") then
             Rec."Certificate Key" := CreateGuid();
 
-        if not IsolatedStorage.Set(Format(Rec."Certificate Key"), Certificate, DataScope::Company) then
-            Error(UnableToSetCertificateMsg);
+        SetIsolatedStorageValue(Rec."Certificate Key", Certificate, UnableToSetCertificateMsg);
+
+        // When setting certificate, clear client secret authentication
+        // as only one authentication method can be active
+        ClearClientSecretAuthentication();
     end;
 
-    internal procedure GetCertificate(CertificateKey: Guid) Certificate: SecretText
+    local procedure ClearClientSecretAuthentication()
     begin
-        if not IsolatedStorage.Get(Format(CertificateKey), DataScope::Company, Certificate) then
-            Error(UnableToGetCertificateMsg);
+        if not IsNullGuid(Rec."Client Secret Key") then begin
+            TryDeleteIsolatedStorageValue(Rec."Client Secret Key");
+            Clear(Rec."Client Secret Key");
+        end;
+    end;
+
+    internal procedure GetCertificate(CertificateKey: Guid): SecretText
+    begin
+        exit(GetIsolatedStorageValue(CertificateKey, UnableToGetCertificateMsg));
     end;
 
     internal procedure SetCertificatePassword(CertificatePassword: SecretText)
@@ -139,13 +156,29 @@ table 4580 "Ext. SharePoint Account"
         if IsNullGuid(Rec."Certificate Password Key") then
             Rec."Certificate Password Key" := CreateGuid();
 
-        if not IsolatedStorage.Set(Format(Rec."Certificate Password Key"), CertificatePassword, DataScope::Company) then
-            Error(UnableToSetCertificatePasswordMsg);
+        SetIsolatedStorageValue(Rec."Certificate Password Key", CertificatePassword, UnableToSetCertificatePasswordMsg);
     end;
 
-    internal procedure GetCertificatePassword(CertificatePasswordKey: Guid) CertificatePassword: SecretText
+    internal procedure GetCertificatePassword(CertificatePasswordKey: Guid): SecretText
     begin
-        if not IsolatedStorage.Get(Format(CertificatePasswordKey), DataScope::Company, CertificatePassword) then
-            Error(UnableToGetCertificatePasswordMsg);
+        exit(GetIsolatedStorageValue(CertificatePasswordKey, UnableToGetCertificatePasswordMsg));
+    end;
+
+    local procedure TryDeleteIsolatedStorageValue(StorageKey: Guid)
+    begin
+        if not IsNullGuid(StorageKey) then
+            if IsolatedStorage.Delete(StorageKey) then;
+    end;
+
+    local procedure SetIsolatedStorageValue(StorageKey: Guid; Value: SecretText; ErrorMessage: Text)
+    begin
+        if not IsolatedStorage.Set(Format(StorageKey), Value, DataScope::Company) then
+            Error(ErrorMessage);
+    end;
+
+    local procedure GetIsolatedStorageValue(StorageKey: Guid; ErrorMessage: Text) Value: SecretText
+    begin
+        if not IsolatedStorage.Get(Format(StorageKey), DataScope::Company, Value) then
+            Error(ErrorMessage);
     end;
 }

--- a/Apps/W1/External File Storage - SharePoint Connector/app/src/ExtSharePointAccount.Table.al
+++ b/Apps/W1/External File Storage - SharePoint Connector/app/src/ExtSharePointAccount.Table.al
@@ -58,6 +58,22 @@ table 4580 "Ext. SharePoint Account"
             Caption = 'Disabled';
             ToolTip = 'Specifies if the account is disabled. This happens automatically when a sandbox is created.';
         }
+        field(10; "Authentication Type"; Enum "Ext. SharePoint Auth Type")
+        {
+            Caption = 'Authentication Type';
+            ToolTip = 'Specifies the authentication method used for this SharePoint account.';
+            InitValue = "Client Secret";
+        }
+        field(11; "Certificate Key"; Guid)
+        {
+            Access = Internal;
+            DataClassification = SystemMetadata;
+        }
+        field(12; "Certificate Password Key"; Guid)
+        {
+            Access = Internal;
+            DataClassification = SystemMetadata;
+        }
     }
 
     keys
@@ -71,11 +87,21 @@ table 4580 "Ext. SharePoint Account"
     var
         UnableToGetClientMsg: Label 'Unable to get SharePoint Account Client Secret.';
         UnableToSetClientSecretMsg: Label 'Unable to set SharePoint Client Secret.';
+        UnableToGetCertificateMsg: Label 'Unable to get SharePoint Account Certificate.';
+        UnableToSetCertificateMsg: Label 'Unable to set SharePoint Certificate.';
+        UnableToGetCertificatePasswordMsg: Label 'Unable to get SharePoint Account Certificate Password.';
+        UnableToSetCertificatePasswordMsg: Label 'Unable to set SharePoint Certificate Password.';
 
     trigger OnDelete()
     begin
         if not IsNullGuid(Rec."Client Secret Key") then
             if IsolatedStorage.Delete(Rec."Client Secret Key") then;
+
+        if not IsNullGuid(Rec."Certificate Key") then
+            if IsolatedStorage.Delete(Rec."Certificate Key") then;
+
+        if not IsNullGuid(Rec."Certificate Password Key") then
+            if IsolatedStorage.Delete(Rec."Certificate Password Key") then;
     end;
 
     procedure SetClientSecret(ClientSecret: SecretText)
@@ -91,5 +117,35 @@ table 4580 "Ext. SharePoint Account"
     begin
         if not IsolatedStorage.Get(Format(ClientSecretKey), DataScope::Company, ClientSecret) then
             Error(UnableToGetClientMsg);
+    end;
+
+    internal procedure SetCertificate(Certificate: SecretText)
+    begin
+        if IsNullGuid(Rec."Certificate Key") then
+            Rec."Certificate Key" := CreateGuid();
+
+        if not IsolatedStorage.Set(Format(Rec."Certificate Key"), Certificate, DataScope::Company) then
+            Error(UnableToSetCertificateMsg);
+    end;
+
+    internal procedure GetCertificate(CertificateKey: Guid) Certificate: SecretText
+    begin
+        if not IsolatedStorage.Get(Format(CertificateKey), DataScope::Company, Certificate) then
+            Error(UnableToGetCertificateMsg);
+    end;
+
+    internal procedure SetCertificatePassword(CertificatePassword: SecretText)
+    begin
+        if IsNullGuid(Rec."Certificate Password Key") then
+            Rec."Certificate Password Key" := CreateGuid();
+
+        if not IsolatedStorage.Set(Format(Rec."Certificate Password Key"), CertificatePassword, DataScope::Company) then
+            Error(UnableToSetCertificatePasswordMsg);
+    end;
+
+    internal procedure GetCertificatePassword(CertificatePasswordKey: Guid) CertificatePassword: SecretText
+    begin
+        if not IsolatedStorage.Get(Format(CertificatePasswordKey), DataScope::Company, CertificatePassword) then
+            Error(UnableToGetCertificatePasswordMsg);
     end;
 }

--- a/Apps/W1/External File Storage - SharePoint Connector/app/src/ExtSharePointAuthType.Enum.al
+++ b/Apps/W1/External File Storage - SharePoint Connector/app/src/ExtSharePointAuthType.Enum.al
@@ -1,0 +1,30 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace System.ExternalFileStorage;
+
+/// <summary>
+/// Specifies the authentication types for SharePoint accounts.
+/// </summary>
+enum 4585 "Ext. SharePoint Auth Type"
+{
+    Extensible = false;
+
+    /// <summary>
+    /// Authenticate using Client ID and Client Secret.
+    /// </summary>
+    value(0; "Client Secret")
+    {
+        Caption = 'Client Secret';
+    }
+
+    /// <summary>
+    /// Authenticate using Client ID and Certificate.
+    /// </summary>
+    value(1; Certificate)
+    {
+        Caption = 'Certificate';
+    }
+}

--- a/Apps/W1/External File Storage - SharePoint Connector/app/src/ExtSharePointConnectorImpl.Codeunit.al
+++ b/Apps/W1/External File Storage - SharePoint Connector/app/src/ExtSharePointConnectorImpl.Codeunit.al
@@ -359,14 +359,22 @@ codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage
         exit(true);
     end;
 
-    internal procedure CreateAccount(var AccountToCopy: Record "Ext. SharePoint Account"; Password: SecretText; var TempFileAccount: Record "File Account" temporary)
+    internal procedure CreateAccount(var AccountToCopy: Record "Ext. SharePoint Account"; ClientSecretOrCertificate: SecretText; CertificatePassword: SecretText; var TempFileAccount: Record "File Account" temporary)
     var
         NewExtSharePointAccount: Record "Ext. SharePoint Account";
     begin
         NewExtSharePointAccount.TransferFields(AccountToCopy);
-
         NewExtSharePointAccount.Id := CreateGuid();
-        NewExtSharePointAccount.SetClientSecret(Password);
+
+        case NewExtSharePointAccount."Authentication Type" of
+            Enum::"Ext. SharePoint Auth Type"::"Client Secret":
+                NewExtSharePointAccount.SetClientSecret(ClientSecretOrCertificate);
+            Enum::"Ext. SharePoint Auth Type"::Certificate:
+                begin
+                    NewExtSharePointAccount.SetCertificate(ClientSecretOrCertificate);
+                    NewExtSharePointAccount.SetCertificatePassword(CertificatePassword);
+                end;
+        end;
 
         NewExtSharePointAccount.Insert();
 
@@ -388,7 +396,23 @@ codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage
             Error(AccountDisabledErr, SharePointAccount.Name);
 
         Scopes.Add('00000003-0000-0ff1-ce00-000000000000/.default');
-        SharePointAuthorization := SharePointAuth.CreateAuthorizationCode(Format(SharePointAccount."Tenant Id", 0, 4), Format(SharePointAccount."Client Id", 0, 4), SharePointAccount.GetClientSecret(SharePointAccount."Client Secret Key"), Scopes);
+
+        case SharePointAccount."Authentication Type" of
+            Enum::"Ext. SharePoint Auth Type"::"Client Secret":
+                SharePointAuthorization := SharePointAuth.CreateAuthorizationCode(
+                    Format(SharePointAccount."Tenant Id", 0, 4),
+                    Format(SharePointAccount."Client Id", 0, 4),
+                    SharePointAccount.GetClientSecret(SharePointAccount."Client Secret Key"),
+                    Scopes);
+            Enum::"Ext. SharePoint Auth Type"::Certificate:
+                SharePointAuthorization := SharePointAuth.CreateClientCredentials(
+                    Format(SharePointAccount."Tenant Id", 0, 4),
+                    Format(SharePointAccount."Client Id", 0, 4),
+                    SharePointAccount.GetCertificate(SharePointAccount."Certificate Key"),
+                    SharePointAccount.GetCertificatePassword(SharePointAccount."Certificate Password Key"),
+                    Scopes);
+        end;
+
         SharePointClient.Initialize(SharePointAccount."SharePoint Url", SharePointAuthorization);
     end;
 

--- a/Apps/W1/External File Storage - SharePoint Connector/app/src/ExtSharePointConnectorImpl.Codeunit.al
+++ b/Apps/W1/External File Storage - SharePoint Connector/app/src/ExtSharePointConnectorImpl.Codeunit.al
@@ -359,7 +359,12 @@ codeunit 4580 "Ext. SharePoint Connector Impl" implements "External File Storage
         exit(true);
     end;
 
-    internal procedure CreateAccount(var AccountToCopy: Record "Ext. SharePoint Account"; ClientSecretOrCertificate: SecretText; CertificatePassword: SecretText; var TempFileAccount: Record "File Account" temporary)
+    internal procedure CreateAccount(
+        var AccountToCopy: Record "Ext. SharePoint Account";
+        ClientSecretOrCertificate: SecretText;
+        CertificatePassword: SecretText;
+        var TempFileAccount: Record "File Account" temporary
+    )
     var
         NewExtSharePointAccount: Record "Ext. SharePoint Account";
     begin


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to AlAppExtensions please read our pull request guideline below
* https://github.com/microsoft/ALAppExtensions/blob/main/CONTRIBUTING.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Extended the SharePoint connector in the Ext. File Storage framework to support certificate-based authentication using the Client Credentials flow. This allows background integration scenarios without user interaction and offers a more secure alternative to client secrets for production use. The implementation supports both auth types but ensures only one is active at a time.

![image](https://github.com/user-attachments/assets/2eb6a7a2-e68a-4a29-890a-e778e4dd0855)

![image](https://github.com/user-attachments/assets/79d3a13a-3937-490d-a1c9-43a897749bc5)


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #28541
