### PR TITLE
GP - Enhancements to the GP Historical Data page menus

### DIFF
--- a/Apps/W1/DynamicsGPHistoricalData/app/src/PageExt/CustomerListExt.PageExt.al
+++ b/Apps/W1/DynamicsGPHistoricalData/app/src/PageExt/CustomerListExt.PageExt.al
@@ -13,7 +13,7 @@ pageextension 41018 "Customer List Ext." extends "Customer List"
                 action("GP Rec. Docs")
                 {
                     ApplicationArea = All;
-                    Caption = 'Customer AR Transactions';
+                    Caption = 'Customer Receivables Transactions';
                     Image = Documents;
                     ToolTip = 'View the GP receivables transactions for the customer.';
                     Visible = GPRecvDataAvailable;
@@ -25,6 +25,15 @@ pageextension 41018 "Customer List Ext." extends "Customer List"
                         HistReceivablesDocuments.SetFilterCustomerNo(Rec."No.");
                         HistReceivablesDocuments.Run();
                     end;
+                }
+                action("GP All Rec. Docs")
+                {
+                    ApplicationArea = All;
+                    Caption = 'All Receivables Transactions';
+                    Image = ViewWorksheet;
+                    RunObject = Page "Hist. Receivables Documents";
+                    ToolTip = 'View all GP receivables transactions.';
+                    Visible = GPRecvDataAvailable;
                 }
                 action("GP Sales Trx.")
                 {
@@ -41,15 +50,6 @@ pageextension 41018 "Customer List Ext." extends "Customer List"
                         HistSalesTrxHeaders.SetFilterCustomerNo(Rec."No.");
                         HistSalesTrxHeaders.Run();
                     end;
-                }
-                action("GP All Rec. Docs")
-                {
-                    ApplicationArea = All;
-                    Caption = 'All Receivables Transactions';
-                    Image = ViewWorksheet;
-                    RunObject = Page "Hist. Receivables Documents";
-                    ToolTip = 'View all GP receivables transactions.';
-                    Visible = GPRecvDataAvailable;
                 }
                 action("GP All Sales Trx.")
                 {
@@ -75,10 +75,10 @@ pageextension 41018 "Customer List Ext." extends "Customer List"
                 actionref("GP Rec. Docs_Promoted"; "GP Rec. Docs")
                 {
                 }
-                actionref("GP Sales Trx._Promoted"; "GP Sales Trx.")
+                actionref("GP All Rec. Docs_Promoted"; "GP All Rec. Docs")
                 {
                 }
-                actionref("GP All Rec. Docs_Promoted"; "GP All Rec. Docs")
+                actionref("GP Sales Trx._Promoted"; "GP Sales Trx.")
                 {
                 }
                 actionref("GP All Sales Trx._Promoted"; "GP All Sales Trx.")

--- a/Apps/W1/DynamicsGPHistoricalData/app/src/PageExt/CustomerListExt.PageExt.al
+++ b/Apps/W1/DynamicsGPHistoricalData/app/src/PageExt/CustomerListExt.PageExt.al
@@ -13,9 +13,9 @@ pageextension 41018 "Customer List Ext." extends "Customer List"
                 action("GP Rec. Docs")
                 {
                     ApplicationArea = All;
-                    Caption = 'Receivables Transactions';
+                    Caption = 'Customer AR Transactions';
                     Image = Documents;
-                    ToolTip = 'View the GP receivables transactions.';
+                    ToolTip = 'View the GP receivables transactions for the customer.';
                     Visible = GPRecvDataAvailable;
 
                     trigger OnAction()
@@ -29,9 +29,9 @@ pageextension 41018 "Customer List Ext." extends "Customer List"
                 action("GP Sales Trx.")
                 {
                     ApplicationArea = All;
-                    Caption = 'Sales Transactions';
+                    Caption = 'Customer Sales Transactions';
                     Image = Sales;
-                    ToolTip = 'View the GP sales transactions.';
+                    ToolTip = 'View the GP sales transactions for the customer.';
                     Visible = GPSalesTrxDataAvailable;
 
                     trigger OnAction()
@@ -41,6 +41,24 @@ pageextension 41018 "Customer List Ext." extends "Customer List"
                         HistSalesTrxHeaders.SetFilterCustomerNo(Rec."No.");
                         HistSalesTrxHeaders.Run();
                     end;
+                }
+                action("GP All Rec. Docs")
+                {
+                    ApplicationArea = All;
+                    Caption = 'All Receivables Transactions';
+                    Image = ViewWorksheet;
+                    RunObject = Page "Hist. Receivables Documents";
+                    ToolTip = 'View all GP receivables transactions.';
+                    Visible = GPRecvDataAvailable;
+                }
+                action("GP All Sales Trx.")
+                {
+                    ApplicationArea = All;
+                    Caption = 'All Sales Transactions';
+                    Image = ViewWorksheet;
+                    RunObject = Page "Hist. Sales Trx. Headers";
+                    ToolTip = 'View all GP sales transactions.';
+                    Visible = GPSalesTrxDataAvailable;
                 }
             }
         }
@@ -58,6 +76,12 @@ pageextension 41018 "Customer List Ext." extends "Customer List"
                 {
                 }
                 actionref("GP Sales Trx._Promoted"; "GP Sales Trx.")
+                {
+                }
+                actionref("GP All Rec. Docs_Promoted"; "GP All Rec. Docs")
+                {
+                }
+                actionref("GP All Sales Trx._Promoted"; "GP All Sales Trx.")
                 {
                 }
             }

--- a/Apps/W1/DynamicsGPHistoricalData/app/src/PageExt/CustomerListExt.PageExt.al
+++ b/Apps/W1/DynamicsGPHistoricalData/app/src/PageExt/CustomerListExt.PageExt.al
@@ -72,17 +72,26 @@ pageextension 41018 "Customer List Ext." extends "Customer List"
                 Image = Archive;
                 Visible = GPHistDataAvailable;
 
-                actionref("GP Rec. Docs_Promoted"; "GP Rec. Docs")
-                {
-                }
                 actionref("GP All Rec. Docs_Promoted"; "GP All Rec. Docs")
-                {
-                }
-                actionref("GP Sales Trx._Promoted"; "GP Sales Trx.")
                 {
                 }
                 actionref("GP All Sales Trx._Promoted"; "GP All Sales Trx.")
                 {
+                }
+
+                group(Category_GPGLDetail_Selected)
+                {
+                    Caption = 'Selected Customer';
+                    ShowAs = Standard;
+                    Image = Customer;
+                    Visible = GPHistDataAvailable;
+
+                    actionref("GP Rec. Docs_Promoted"; "GP Rec. Docs")
+                    {
+                    }
+                    actionref("GP Sales Trx._Promoted"; "GP Sales Trx.")
+                    {
+                    }
                 }
             }
         }

--- a/Apps/W1/DynamicsGPHistoricalData/app/src/PageExt/ItemListExt.PageExt.al
+++ b/Apps/W1/DynamicsGPHistoricalData/app/src/PageExt/ItemListExt.PageExt.al
@@ -13,10 +13,10 @@ pageextension 41020 "Item List Ext." extends "Item List"
                 action("GP Inventory Trx.")
                 {
                     ApplicationArea = All;
-                    Caption = 'Inventory Transactions';
-                    Image = InventoryJournal;
+                    Caption = 'All Inventory Transactions';
+                    Image = ViewWorksheet;
                     RunObject = Page "Hist. Inventory Trx. Headers";
-                    ToolTip = 'View the GP inventory transactions.';
+                    ToolTip = 'View all GP inventory transactions.';
                     Visible = GPHistDataAvailable;
                 }
             }

--- a/Apps/W1/DynamicsGPHistoricalData/app/src/PageExt/VendorListExt.PageExt.al
+++ b/Apps/W1/DynamicsGPHistoricalData/app/src/PageExt/VendorListExt.PageExt.al
@@ -72,17 +72,26 @@ pageextension 41019 "Vendor List Ext." extends "Vendor List"
                 Image = Archive;
                 Visible = GPHistDataAvailable;
 
-                actionref("GP Payables Docs_Promoted"; "GP Payables Docs")
-                {
-                }
                 actionref("GP All Payables Docs_Promoted"; "GP All Payables Docs")
-                {
-                }
-                actionref("GP Purchase Recv._Promoted"; "GP Purchase Recv.")
                 {
                 }
                 actionref("GP All Purchase Recv._Promoted"; "GP All Purchase Recv.")
                 {
+                }
+
+                group(Category_GPGLDetail_Selected)
+                {
+                    Caption = 'Selected Vendor';
+                    ShowAs = Standard;
+                    Image = Vendor;
+                    Visible = GPHistDataAvailable;
+
+                    actionref("GP Payables Docs_Promoted"; "GP Payables Docs")
+                    {
+                    }
+                    actionref("GP Purchase Recv._Promoted"; "GP Purchase Recv.")
+                    {
+                    }
                 }
             }
         }

--- a/Apps/W1/DynamicsGPHistoricalData/app/src/PageExt/VendorListExt.PageExt.al
+++ b/Apps/W1/DynamicsGPHistoricalData/app/src/PageExt/VendorListExt.PageExt.al
@@ -13,7 +13,7 @@ pageextension 41019 "Vendor List Ext." extends "Vendor List"
                 action("GP Payables Docs")
                 {
                     ApplicationArea = All;
-                    Caption = 'Vendor AP Transactions';
+                    Caption = 'Vendor Payables Transactions';
                     Image = Documents;
                     ToolTip = 'View the GP payables transactions for the vendor.';
                     Visible = GPPayablesDataAvailable;
@@ -25,6 +25,15 @@ pageextension 41019 "Vendor List Ext." extends "Vendor List"
                         HistPayablesDocuments.SetFilterVendorNo(Rec."No.");
                         HistPayablesDocuments.Run();
                     end;
+                }
+                action("GP All Payables Docs")
+                {
+                    ApplicationArea = All;
+                    Caption = 'All Payables Transactions';
+                    Image = ViewWorksheet;
+                    RunObject = Page "Hist. Payables Documents";
+                    ToolTip = 'View all GP payables transactions.';
+                    Visible = GPPayablesDataAvailable;
                 }
                 action("GP Purchase Recv.")
                 {
@@ -41,15 +50,6 @@ pageextension 41019 "Vendor List Ext." extends "Vendor List"
                         HistPurchaseRecvHeaders.SetFilterVendorNo(Rec."No.");
                         HistPurchaseRecvHeaders.Run();
                     end;
-                }
-                action("GP All Payables Docs")
-                {
-                    ApplicationArea = All;
-                    Caption = 'All AP Transactions';
-                    Image = ViewWorksheet;
-                    RunObject = Page "Hist. Payables Documents";
-                    ToolTip = 'View all GP payables transactions.';
-                    Visible = GPPayablesDataAvailable;
                 }
                 action("GP All Purchase Recv.")
                 {
@@ -75,10 +75,10 @@ pageextension 41019 "Vendor List Ext." extends "Vendor List"
                 actionref("GP Payables Docs_Promoted"; "GP Payables Docs")
                 {
                 }
-                actionref("GP Purchase Recv._Promoted"; "GP Purchase Recv.")
+                actionref("GP All Payables Docs_Promoted"; "GP All Payables Docs")
                 {
                 }
-                actionref("GP All Payables Docs_Promoted"; "GP All Payables Docs")
+                actionref("GP Purchase Recv._Promoted"; "GP Purchase Recv.")
                 {
                 }
                 actionref("GP All Purchase Recv._Promoted"; "GP All Purchase Recv.")

--- a/Apps/W1/DynamicsGPHistoricalData/app/src/PageExt/VendorListExt.PageExt.al
+++ b/Apps/W1/DynamicsGPHistoricalData/app/src/PageExt/VendorListExt.PageExt.al
@@ -13,9 +13,9 @@ pageextension 41019 "Vendor List Ext." extends "Vendor List"
                 action("GP Payables Docs")
                 {
                     ApplicationArea = All;
-                    Caption = 'GP Payables Transactions';
+                    Caption = 'Vendor AP Transactions';
                     Image = Documents;
-                    ToolTip = 'View the GP payables transactions.';
+                    ToolTip = 'View the GP payables transactions for the vendor.';
                     Visible = GPPayablesDataAvailable;
 
                     trigger OnAction()
@@ -29,9 +29,9 @@ pageextension 41019 "Vendor List Ext." extends "Vendor List"
                 action("GP Purchase Recv.")
                 {
                     ApplicationArea = All;
-                    Caption = 'Receivings Transactions';
+                    Caption = 'Vendor Receivings Transactions';
                     Image = ReceivablesPayables;
-                    ToolTip = 'View the GP purchase receivings transactions.';
+                    ToolTip = 'View the GP purchase receivings transactions for the vendor.';
                     Visible = GPPurchaseRecvDataAvailable;
 
                     trigger OnAction()
@@ -41,6 +41,24 @@ pageextension 41019 "Vendor List Ext." extends "Vendor List"
                         HistPurchaseRecvHeaders.SetFilterVendorNo(Rec."No.");
                         HistPurchaseRecvHeaders.Run();
                     end;
+                }
+                action("GP All Payables Docs")
+                {
+                    ApplicationArea = All;
+                    Caption = 'All AP Transactions';
+                    Image = ViewWorksheet;
+                    RunObject = Page "Hist. Payables Documents";
+                    ToolTip = 'View all GP payables transactions.';
+                    Visible = GPPayablesDataAvailable;
+                }
+                action("GP All Purchase Recv.")
+                {
+                    ApplicationArea = All;
+                    Caption = 'All Receivings Transactions';
+                    Image = ViewWorksheet;
+                    RunObject = Page "Hist. Purchase Recv. Headers";
+                    ToolTip = 'View all GP purchase receivings transactions.';
+                    Visible = GPPurchaseRecvDataAvailable;
                 }
             }
         }
@@ -58,6 +76,12 @@ pageextension 41019 "Vendor List Ext." extends "Vendor List"
                 {
                 }
                 actionref("GP Purchase Recv._Promoted"; "GP Purchase Recv.")
+                {
+                }
+                actionref("GP All Payables Docs_Promoted"; "GP All Payables Docs")
+                {
+                }
+                actionref("GP All Purchase Recv._Promoted"; "GP All Purchase Recv.")
                 {
                 }
             }


### PR DESCRIPTION
This update enhances the GP Historical Data page extensions to make the action labels clear and adding an 'All' version of the list pages to align with the others in this app.
Fixes [AB#575588](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/575588)