### PR TITLE
#28567 Update SubContractsGeneralMgt.Codeunit.al

### DIFF
--- a/Apps/W1/SubscriptionBilling/App/Base/Codeunits/SubContractsGeneralMgt.Codeunit.al
+++ b/Apps/W1/SubscriptionBilling/App/Base/Codeunits/SubContractsGeneralMgt.Codeunit.al
@@ -499,6 +499,8 @@ codeunit 8059 "Sub. Contracts General Mgt."
         CustomerContractExistErr: Label 'You cannot delete %1 %2 because there is at least one outstanding Contract for this customer.', Comment = '%1 = Table Caption, %2 = Customer No.';
         ServiceObjectExistErr: Label 'You cannot delete %1 %2 because there is at least one outstanding Subscription for this customer.', Comment = '%1 = Table Caption, %2 = Customer No.';
     begin
+        if Rec.IsTemporary() then
+            exit;
         CustomerContract.SetRange("Sell-to Customer No.", Rec."No.");
         if not CustomerContract.IsEmpty() then
             Error(CustomerContractExistErr, Rec.TableCaption, Rec."No.");
@@ -514,6 +516,8 @@ codeunit 8059 "Sub. Contracts General Mgt."
         VendorContract: Record "Vendor Subscription Contract";
         VendorContractExistErr: Label 'You cannot delete %1 %2 because there is at least one outstanding Contract for this vendor.', Comment = '%1 = Table Caption, %2 = Vendor No.';
     begin
+        if Rec.IsTemporary() then
+            exit;
         VendorContract.SetRange("Buy-from Vendor No.", Rec."No.");
         if not VendorContract.IsEmpty() then
             Error(VendorContractExistErr, Rec.TableCaption, Rec."No.");


### PR DESCRIPTION
CheckIfVendorContractExistWhenDeleteVendor and CheckIfCustomerContractOrServiceObjectExistWhenDeleteCustomer should only be used if the master data record (vendor or customer) is not temporary which is going to be deleted

#### Summary
Add a check to OnBeforeDeleteEvent event subscribers for both Customer and Vendor tables to bypass contract validation when records are temporary. This avoids unnecessary validation for temporary records, which do not represent persisted data and should not trigger deletion errors.

#### Work Item(s)

Fixes #28567 



Fixes [AB#575819](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/575819)


