### PR TITLE
Add indirect permission for Insert Sustainability Entries

### DIFF
--- a/Apps/W1/Sustainability/app/src/Posting/SustainabilityPostMgt.Codeunit.al
+++ b/Apps/W1/Sustainability/app/src/Posting/SustainabilityPostMgt.Codeunit.al
@@ -12,7 +12,7 @@ codeunit 6212 "Sustainability Post Mgt"
     Access = Internal;
     Permissions =
         tabledata "Sustainability Ledger Entry" = i,
-        tabledata "Sustainability Value Entry = i;
+        tabledata "Sustainability Value Entry" = i;
 
     procedure InsertLedgerEntry(SustainabilityJnlLine: Record "Sustainability Jnl. Line")
     var


### PR DESCRIPTION
#### Summary
Added Indirect insert permissions to posting codeunit.
This allows to create permission sets with only indirect permissions.

#### Work Item(s)
Fixes #28506

Fixes [AB#573964](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/573964)


