### PR TITLE
Set Additional Reporting Currency demo data for financial reporting

### DIFF
--- a/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Finance/1.Setup data/CreateGLAccount.Codeunit.al
+++ b/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Finance/1.Setup data/CreateGLAccount.Codeunit.al
@@ -396,6 +396,12 @@ codeunit 5208 "Create G/L Account"
         SubCategory := Format(GLAccountCategory."Account Category"::Expense, 80);
         ContosoGLAccount.InsertGLAccount(RealizedFXLosses(), RealizedFXLossesName(), Enum::"G/L Account Income/Balance"::"Income Statement", Enum::"G/L Account Category"::Expense, SubCategory, Enum::"G/L Account Type"::Posting, '', '', 0, '', Enum::"General Posting Type"::" ", '', '', false, false, false);
 
+        SubCategory := Format(GLAccountCategory."Account Category"::Income, 80);
+        ContosoGLAccount.InsertGLAccount(ResidualFXGains(), ResidualFXGainsName(), Enum::"G/L Account Income/Balance"::"Income Statement", Enum::"G/L Account Category"::Income, SubCategory, Enum::"G/L Account Type"::Posting, '', '', 0, '', Enum::"General Posting Type"::" ", '', '', false, false, false);
+
+        SubCategory := Format(GLAccountCategory."Account Category"::Expense, 80);
+        ContosoGLAccount.InsertGLAccount(ResidualFXLosses(), ResidualFXLossesName(), Enum::"G/L Account Income/Balance"::"Income Statement", Enum::"G/L Account Category"::Expense, SubCategory, Enum::"G/L Account Type"::Posting, '', '', 0, '', Enum::"General Posting Type"::" ", '', '', false, false, false);
+
         ContosoGLAccount.InsertGLAccount(NIBEFOREEXTRITEMSTAXES(), NIBEFOREEXTRITEMSTAXESName(), Enum::"G/L Account Income/Balance"::"Income Statement", Enum::"G/L Account Category"::" ", Enum::"G/L Account Type"::Total, '', '', 1, IncomeStatement() + '..' + NIBEFOREEXTRITEMSTAXES(), Enum::"General Posting Type"::" ", '', '', false, false, false);
 
         SubCategory := Format(GLAccountCategory."Account Category"::Income, 80);
@@ -677,6 +683,8 @@ codeunit 5208 "Create G/L Account"
         ContosoGLAccount.AddAccountForLocalization(UnrealizedFXLossesName(), '9320');
         ContosoGLAccount.AddAccountForLocalization(RealizedFXGainsName(), '9330');
         ContosoGLAccount.AddAccountForLocalization(RealizedFXLossesName(), '9340');
+        ContosoGLAccount.AddAccountForLocalization(ResidualFXGainsName(), '9350');
+        ContosoGLAccount.AddAccountForLocalization(ResidualFXLossesName(), '9360');
         ContosoGLAccount.AddAccountForLocalization(NIBEFOREEXTRITEMSTAXESName(), '9395');
         ContosoGLAccount.AddAccountForLocalization(ExtraordinaryIncomeName(), '9410');
         ContosoGLAccount.AddAccountForLocalization(ExtraordinaryExpensesName(), '9420');
@@ -3298,6 +3306,26 @@ codeunit 5208 "Create G/L Account"
         exit(RealizedFXLossesLbl);
     end;
 
+    procedure ResidualFXGains(): Code[20]
+    begin
+        exit(ContosoGLAccount.GetAccountNo(ResidualFXGainsName()));
+    end;
+
+    procedure ResidualFXGainsName(): Text[100]
+    begin
+        exit(ResidualFXGainsLbl);
+    end;
+
+    procedure ResidualFXLosses(): Code[20]
+    begin
+        exit(ContosoGLAccount.GetAccountNo(ResidualFXLossesName()));
+    end;
+
+    procedure ResidualFXLossesName(): Text[100]
+    begin
+        exit(ResidualFXLossesLbl);
+    end;
+
     procedure NIBEFOREEXTRITEMSTAXES(): Code[20]
     begin
         exit(ContosoGLAccount.GetAccountNo(NIBEFOREEXTRITEMSTAXESName()));
@@ -3628,6 +3656,8 @@ codeunit 5208 "Create G/L Account"
         UnrealizedFXLossesLbl: Label 'Unrealized FX Losses', MaxLength = 100;
         RealizedFXGainsLbl: Label 'Realized FX Gains', MaxLength = 100;
         RealizedFXLossesLbl: Label 'Realized FX Losses', MaxLength = 100;
+        ResidualFXGainsLbl: Label 'Residual FX Gains', MaxLength = 100;
+        ResidualFXLossesLbl: Label 'Residual FX Losses', MaxLength = 100;
         NIBEFOREEXTRITEMSTAXESLbl: Label 'NI BEFORE EXTR. ITEMS & TAXES', MaxLength = 100;
         ExtraordinaryIncomeLbl: Label 'Extraordinary Income', MaxLength = 100;
         ExtraordinaryExpensesLbl: Label 'Extraordinary Expenses', MaxLength = 100;

--- a/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Finance/1.Setup data/CreateGeneralLedgerSetup.Codeunit.al
+++ b/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Finance/1.Setup data/CreateGeneralLedgerSetup.Codeunit.al
@@ -25,6 +25,8 @@ codeunit 5230 "Create General Ledger Setup"
     procedure InsertData(JobQueueCategoryCode: Code[10]; InvoiceRoundingPrecisionLCY: Decimal; LocalContAddrFormat: Integer; BankAccountNo: Code[20]; LCYCode: Code[10]; DataCheck: Boolean; AccReceivablesCategory: Integer)
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
+        CreateCurrency: Codeunit "Create Currency";
+        ACYCode: Code[10];
     begin
         if not GeneralLedgerSetup.Get() then
             GeneralLedgerSetup.Insert();
@@ -36,6 +38,8 @@ codeunit 5230 "Create General Ledger Setup"
         GeneralLedgerSetup.Validate("LCY Code", LCYCode);
         GeneralLedgerSetup.Validate("Enable Data Check", DataCheck);
         GeneralLedgerSetup.Validate("Acc. Receivables Category", AccReceivablesCategory);
+        ACYCode := LCYCode = CreateCurrency.EUR() ? CreateCurrency.USD() : CreateCurrency.EUR();
+        GeneralLedgerSetup."Additional Reporting Currency" := ACYCode;
         GeneralLedgerSetup.Modify(true);
     end;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to AlAppExtensions please read our pull request guideline below
* https://github.com/microsoft/ALAppExtensions/blob/main/CONTRIBUTING.md
--> 
#### Summary <!-- Provide a general summary of your changes -->
- Applies to the W1 Contoso Coffee Demo Data app.
- Set Additional Reporting Currency on General Ledger Setup.
- Added residual FX gains and losses G/L accounts to allow posting with additional reporting currency.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #28759 

**ADO**: 575835
