### PR TITLE
Skip updating prices if "Subscription Option" has not changed

### DIFF
--- a/Apps/W1/SubscriptionBilling/App/Service Objects/Table Extensions/Item.TableExt.al
+++ b/Apps/W1/SubscriptionBilling/App/Service Objects/Table Extensions/Item.TableExt.al
@@ -127,6 +127,9 @@ tableextension 8052 Item extends Item
         PriceCalculationMgt: Codeunit "Price Calculation Mgt.";
 #endif
     begin
+        if Rec."Subscription Option" = xRec."Subscription Option" then
+            exit;
+
         if IsServiceCommitmentItem() then begin
             Rec.Validate("Allow Invoice Disc.", false);
 #if not CLEAN25

--- a/Apps/W1/SubscriptionBilling/App/Service Objects/Table Extensions/ItemTempl.TableExt.al
+++ b/Apps/W1/SubscriptionBilling/App/Service Objects/Table Extensions/ItemTempl.TableExt.al
@@ -18,6 +18,13 @@ tableextension 8095 "Item Templ." extends "Item Templ."
                     DeleteItemTemplateServiceCommitmentPackages();
             end;
         }
+        modify("Allow Invoice Disc.")
+        {
+            trigger OnAfterValidate()
+            begin
+                Rec.ValidateItemField(FieldNo("Allow Invoice Disc."));
+            end;
+        }
     }
 
     local procedure DeleteItemTemplateServiceCommitmentPackages()


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request. If you're new to contributing to AlAppExtensions please read our pull request guideline below
* https://github.com/microsoft/ALAppExtensions/blob/main/CONTRIBUTING.md
-->
#### Summary <!-- Provide a general summary of your changes -->
When validating the **"Subscription Option"** field, the code performs several checks. One of them is within the `UpdateItemPriceList` function, which enforces specific logic for **"Subscription Items"**:

- If the **"Subscription Option"** is set to **"Subscription Item",** the function ensures that the **"Allow Invoice Disc."** flag is **disabled** both on the Item and its related sales prices. This is because Subscription Items are excluded from document totals in Sales Quotes and Orders.
- Conversely, if the **"Subscription Option"** is _changed_ from **"Subscription Item"** to another value, the function resets **"Allow Invoice Disc."** to its default value (**true**).

This logic should execute **only when the "Subscription Option" value changes**.

However, when an Item is created from an **Item Template** where:
- **"Allow Invoice Disc."** is already set to **false**, and
- **"Subscription Option"** is **"No Subscription"**,

then this validation should **not run** and should **not modify sales prices** ΓÇö because no change to the **"Subscription Option"** has occurred.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #28764



Fixes [AB#581599](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/581599)

