### PR TITLE
Subscription Item and Default Item Quantity

### DIFF
--- a/Apps/W1/SubscriptionBilling/App/Sales Service Commitments/Codeunits/SalesSubscriptionLineMgmt.Codeunit.al
+++ b/Apps/W1/SubscriptionBilling/App/Sales Service Commitments/Codeunits/SalesSubscriptionLineMgmt.Codeunit.al
@@ -34,6 +34,8 @@ codeunit 8069 "Sales Subscription Line Mgmt."
 
         if not IsSalesLineWithSalesServiceCommitments(SalesLine, false) then
             exit;
+        if SalesLine."Line No." = 0 then
+            exit;
 
         SalesHeader.Get(SalesLine."Document Type", SalesLine."Document No.");
         ItemServCommitmentPackage.SetRange("Item No.", SalesLine."No.");
@@ -101,19 +103,14 @@ codeunit 8069 "Sales Subscription Line Mgmt."
     end;
 
     local procedure IsSalesLineWithSalesServiceCommitments(var SalesLine: Record "Sales Line"; SkipTemporaryCheck: Boolean; ServiceCommitmentItemOnly: Boolean): Boolean
-    var
-        SalesLine2: Record "Sales Line";
     begin
         if not SkipTemporaryCheck then
             if SalesLine.IsTemporary() then
                 exit(false);
         if (SalesLine.Type <> SalesLine.Type::Item) or
            (SalesLine."No." = '') or
-           (SalesLine."Line No." = 0) or
            not SalesLine.IsSalesDocumentTypeWithServiceCommitments()
         then
-            exit(false);
-        if not SalesLine2.Get(SalesLine."Document Type", SalesLine."Document No.", SalesLine."Line No.") then
             exit(false);
         if ServiceCommitmentItemOnly then begin
             if not ItemManagement.IsServiceCommitmentItem(SalesLine."No.") then
@@ -172,7 +169,6 @@ codeunit 8069 "Sales Subscription Line Mgmt."
         if ServiceCommitmentPackage.Get(ServCommPackageCode) then begin
             ServiceCommitmentPackageLine.SetRange("Subscription Package Code", ServiceCommitmentPackage.Code);
             if ServiceCommitmentPackageLine.FindSet() then begin
-                SalesLine.Modify(false);
                 repeat
                     CreateSalesServCommLineFromServCommPackageLine(SalesLine, ServiceCommitmentPackageLine);
                 until ServiceCommitmentPackageLine.Next() = 0;

--- a/Apps/W1/SubscriptionBilling/App/Sales Service Commitments/Table Extensions/SalesLine.TableExt.al
+++ b/Apps/W1/SubscriptionBilling/App/Sales Service Commitments/Table Extensions/SalesLine.TableExt.al
@@ -217,8 +217,8 @@ tableextension 8054 "Sales Line" extends "Sales Line"
             exit;
 
         if SalesServiceCommitment.FindSet() then begin
-            SalesLine.Modify(false);
             repeat
+                SalesServiceCommitment.SetSalesLine(Rec);
                 SalesServiceCommitment.CalculateCalculationBaseAmount();
             until SalesServiceCommitment.Next() = 0;
         end;

--- a/Apps/W1/SubscriptionBilling/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
+++ b/Apps/W1/SubscriptionBilling/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
@@ -422,6 +422,7 @@ table 8068 "Sales Subscription Line"
     begin
         Rec.Init();
         SetDocumentFields(SourceSalesLine."Document Type", SourceSalesLine."Document No.", SourceSalesLine."Line No.");
+        SalesLine := SourceSalesLine;
         Rec."Line No." := 0;
     end;
 
@@ -776,7 +777,7 @@ table 8068 "Sales Subscription Line"
         SalesHeader: Record "Sales Header";
         CurrencyDate: Date;
     begin
-        SalesLine.Get(Rec."Document Type", Rec."Document No.", Rec."Document Line No.");
+        GetSalesLine(SalesLine);
         case Rec.Partner of
             Partner::Customer:
                 Rec.Validate("Unit Cost (LCY)", SalesLine."Unit Cost (LCY)" * Rec."Calculation Base %" / 100);
@@ -808,8 +809,19 @@ table 8068 "Sales Subscription Line"
 
     local procedure GetSalesLine(SalesSubscriptionLine: Record "Sales Subscription Line"; var SalesLine2: Record "Sales Line")
     begin
-        SalesLine2.Get(SalesSubscriptionLine."Document Type", SalesSubscriptionLine."Document No.", SalesSubscriptionLine."Document Line No.");
+        if (SalesLine."Document Type" <> SalesSubscriptionLine."Document Type")
+            or (SalesLine."Document No." <> SalesSubscriptionLine."Document No.")
+            or (SalesLine."Line No." <> SalesSubscriptionLine."Document Line No.")
+        then
+            SalesLine2.Get(SalesSubscriptionLine."Document Type", SalesSubscriptionLine."Document No.", SalesSubscriptionLine."Document Line No.")
+        else
+            SalesLine2 := SalesLine;
         OnAfterGetSalesLine(Rec, SalesLine2);
+    end;
+
+    procedure SetSalesLine(var NewSalesLine: Record "Sales Line")
+    begin
+        SalesLine := NewSalesLine;
     end;
 
     [IntegrationEvent(false, false)]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to AlAppExtensions please read our pull request guideline below
* https://github.com/microsoft/ALAppExtensions/blob/main/CONTRIBUTING.md
-->
#### Summary <!-- Provide a general summary of your changes -->
In order to enable entering Subscription Items on Sales Orders and posting of the Sales Order without an error few improvements or fixes were done:
1. The function IsSalesLineWithSalesServiceCommitments has been improved in the sense that it always returns a deterministic value for a sales line regardless of the fact if the line has already been inserted and thus "Line No." generated or not. 
2. The function CalculateCalculationBaseAmount relies on up-to-date sales line record. This was so far done by (a bit hacky) call of a SalesLine.Modify on two places. Instead of modifying sales lines in the middle of processing a new function has been introduced in "Sales Subscription Line" table: SetSalesLine.
3. After fixing the code, the test TestTransferSalesServiceCommitmentsOnExplodeBOM started failing altough the manuall test was sucesfull. Therefore, the function CreateComponentItemWithSalesServiceCommitments has been adjusted in order to reflect the real use case..

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #28751


Fixes [AB#581593](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/581593)

