### PR TITLE
Two step processing for E-Documents on sales side

### DIFF
--- a/Apps/W1/EDocument/app/src/Document/EDocument.Page.al
+++ b/Apps/W1/EDocument/app/src/Document/EDocument.Page.al
@@ -544,6 +544,8 @@ page 6121 "E-Document"
                 StyleStatusTxt := 'Unfavorable';
             Rec.Status::Processed:
                 StyleStatusTxt := 'Favorable';
+            Rec.Status::Exported:
+                StyleStatusTxt := 'Ambiguous';
             else
                 StyleStatusTxt := 'None';
         end;

--- a/Apps/W1/EDocument/app/src/Document/Status/EDocExportedStatus.Codeunit.al
+++ b/Apps/W1/EDocument/app/src/Document/Status/EDocExportedStatus.Codeunit.al
@@ -1,0 +1,16 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument;
+
+/// <summary>
+/// E-Document Exported Status
+/// </summary>
+codeunit 6105 "E-Doc Exported Status" implements IEDocumentStatus
+{
+    procedure GetEDocumentStatus(): Enum "E-Document Status"
+    begin
+        exit(Enum::"E-Document Status"::Exported);
+    end;
+}

--- a/Apps/W1/EDocument/app/src/Document/Status/EDocumentServiceStatus.Enum.al
+++ b/Apps/W1/EDocument/app/src/Document/Status/EDocumentServiceStatus.Enum.al
@@ -14,7 +14,7 @@ enum 6106 "E-Document Service Status" implements IEDocumentStatus
     value(1; "Exported")
     {
         Caption = 'Exported';
-        Implementation = IEDocumentStatus = "E-Doc Processed Status";
+        Implementation = IEDocumentStatus = "E-Doc Exported Status";
     }
     value(2; "Sending Error")
     {

--- a/Apps/W1/EDocument/app/src/Document/Status/EDocumentStatus.Enum.al
+++ b/Apps/W1/EDocument/app/src/Document/Status/EDocumentStatus.Enum.al
@@ -11,4 +11,5 @@ enum 6108 "E-Document Status"
     value(0; "In Progress") { Caption = 'In progress'; }
     value(1; "Processed") { Caption = 'Processed'; }
     value(2; "Error") { Caption = 'Error'; }
+    value(3; "Exported") { Caption = 'Exported'; }
 }

--- a/Apps/W1/EDocument/app/src/Processing/EDocumentProcessing.Codeunit.al
+++ b/Apps/W1/EDocument/app/src/Processing/EDocumentProcessing.Codeunit.al
@@ -75,6 +75,7 @@ codeunit 6108 "E-Document Processing"
 #endif
         IEDocumentStatus: Interface IEDocumentStatus;
         InProgress: Boolean;
+        Exported: Boolean;
 #if not CLEAN26
         IsHandled: Boolean;
 #endif
@@ -99,15 +100,22 @@ codeunit 6108 "E-Document Processing"
                         end;
                     EDocument.Status::"In Progress":
                         InProgress := true;
+                    EDocument.Status::Exported:
+                        Exported := true;
                 end;
 
             until EDocumentServiceStatus.Next() = 0;
 
         // If one service is in progress, then the whole E-Document is in progress
-        if InProgress then
-            EDocument.Validate(Status, EDocument.Status::"In Progress")
-        else
-            EDocument.Validate(Status, EDocument.Status::Processed);
+        // If no service is in progress and at least one status is exported, then the whole E-Document is exported
+        case true of
+            InProgress:
+                EDocument.Validate(Status, EDocument.Status::"In Progress");
+            Exported:
+                EDocument.Validate(Status, EDocument.Status::Exported);
+            else
+                EDocument.Validate(Status, EDocument.Status::Processed);
+        end;
         EDocument.Modify(true);
 
         OnAfterModifyEDocumentStatus(EDocument, EDocumentServiceStatus);

--- a/Apps/W1/EDocument/app/src/Processing/Import/Purchase/EDocumentPurchaseDraft.Page.al
+++ b/Apps/W1/EDocument/app/src/Processing/Import/Purchase/EDocumentPurchaseDraft.Page.al
@@ -447,6 +447,8 @@ page 6181 "E-Document Purchase Draft"
                 StyleStatusTxt := 'Unfavorable';
             Rec.Status::Processed:
                 StyleStatusTxt := 'Favorable';
+            Rec.Status::Exported:
+                StyleStatusTxt := 'Ambiguous';
             else
                 StyleStatusTxt := 'None';
         end;

--- a/Apps/W1/EDocument/app/src/Workflow/EDocumentWorkFlowSetup.Codeunit.al
+++ b/Apps/W1/EDocument/app/src/Workflow/EDocumentWorkFlowSetup.Codeunit.al
@@ -35,6 +35,19 @@ codeunit 6139 "E-Document Workflow Setup"
         Workflow.Modify();
     end;
 
+    internal procedure InsertInitForSingleServiceTemplate()
+    var
+        Workflow: Record Workflow;
+        WorkflowSetup: Codeunit "Workflow Setup";
+    begin
+        WorkflowSetup.InsertWorkflowTemplate(Workflow, EDocInitForSingleServiceTemplateWfCodeTxt, EDocInitForSingleServiceTemplateWfDescriptionTxt, EDocCategoryTxt);
+        Workflow.Validate(Template, false);
+        Workflow.Modify();
+        InsertEDocExportWorkflowDetails(Workflow);
+        Workflow.Validate(Template, true);
+        Workflow.Modify();
+    end;
+
     #region Workflow Events
     procedure EDocCreated(): code[128];
     begin
@@ -182,6 +195,7 @@ codeunit 6139 "E-Document Workflow Setup"
     begin
         InsertSendToSingleServiceTemplate();
         InsertSendToMultiServiceTemplate();
+        InsertInitForSingleServiceTemplate();
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Workflow Setup", OnAddWorkflowCategoriesToLibrary, '', false, false)]
@@ -211,11 +225,22 @@ codeunit 6139 "E-Document Workflow Setup"
         WorkflowSetup.InsertResponseStep(Workflow, EDocSendEDocResponseCode(), ResponseStepIdA);
     end;
 
+    local procedure InsertEDocExportWorkflowDetails(var Workflow: Record Workflow)
+    var
+        WorkflowSetup: Codeunit "Workflow Setup";
+        EntryPointStepId: Integer;
+    begin
+        EntryPointStepId := WorkflowSetup.InsertEntryPointEventStep(Workflow, EDocCreated());
+        WorkflowSetup.InsertResponseStep(Workflow, ResponseEDocExport(), EntryPointStepId);
+    end;
+
     var
         EDocCategoryDescriptionTxt: Label 'E-Document';
         EDocCategoryTxt: Label 'EDOC', Locked = true;
         EDocSendToSingleServiceTemplateWfCodeTxt: Label 'EDOCTOS', Locked = true;
         EDocSendToMultiServicesTemplateWfCodeTxt: Label 'EDOCTOM', Locked = true;
+        EDocInitForSingleServiceTemplateWfCodeTxt: Label 'EDOCINIT', Locked = true;
         EDocSendToSingleServiceTemplateWfDescriptionTxt: Label 'Send to one service';
         EDocSendToMultiServicesTemplateWfDescriptionTxt: Label 'Send to multiple services';
+        EDocInitForSingleServiceTemplateWfDescriptionTxt: Label 'Init for one service';
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to AlAppExtensions please read our pull request guideline below
* https://github.com/microsoft/ALAppExtensions/blob/main/CONTRIBUTING.md
-->

### Description

Sending an e-document using E-Documents module in sales means that as soon as a sales document is posted it will be sent to the service provider. This is fine in most of the cases. However, the cancelling process in some countries might be cumbersome. Therefore, it is desired that an E-document is sent out to the service provider only after it is assured that the invoice being sent is correct. With a new Workflow response, it is possible to create an E-Document during posting of a sales document without sending the document to the customer. If the posted invoice is ok - the action **"Send Document"** on E-Document card can be called manually.

#### Summary <!-- Provide a general summary of your changes -->

- New Status for E-Document: Exported.
- New Workflow response added: **'Init E-Document using setup'** which should be manually selected instead of the current one named **'Send E-Document using setup'**
- No new tests added as there was no test on sending side checking statuses - glad to add new ones if needed.
- Waiting for the iniital feedback.

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes microsoft/BCApps#5004

Fixes [AB#580686](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/580686)


