### PR TITLE
Use GetPurchHeader in Sustainability App to support Recurring Purchase Lines (Standard Purchase Code)

### DIFF
--- a/Apps/W1/Sustainability/app/src/Purchase/SustPurchaseSubscriber.Codeunit.al
+++ b/Apps/W1/Sustainability/app/src/Purchase/SustPurchaseSubscriber.Codeunit.al
@@ -181,7 +181,7 @@ codeunit 6225 "Sust. Purchase Subscriber"
         N2OToPost: Decimal;
         CarbonFee: Decimal;
     begin
-        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+        PurchaseHeader := PurchaseLine.GetPurchHeader();
         GHGCredit := IsGHGCreditLine(PurchaseLine);
 
         if GHGCredit then begin

--- a/Apps/W1/Sustainability/app/src/Purchase/SustainabilityPurchLine.TableExt.al
+++ b/Apps/W1/Sustainability/app/src/Purchase/SustainabilityPurchLine.TableExt.al
@@ -562,7 +562,7 @@ tableextension 6211 "Sustainability Purch. Line" extends "Purchase Line"
         PurchaseSubscriber: Codeunit "Sust. Purchase Subscriber";
         TotalCO2e: Decimal;
     begin
-        PurchaseHeader.Get(PurchLine."Document Type", PurchLine."Document No.");
+        PurchaseHeader := PurchLine.GetPurchHeader();
 
         FilterCarbonPricing(SustainabilityCarbonPricing, PurchaseHeader, PurchLine);
         if not SustainabilityCarbonPricing.FindLast() then


### PR DESCRIPTION
#### Summary 
Refactor PurchaseHeader.Get(...) to `PurchaseLine.GetPurchHeader()`.
This enalbes scenarios when the Purchase Line is created before the Purchase Header is inserted.

#### Work Item(s)
Fixes #29107

Fixes [AB#598708](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/598708)
