### PR TITLE
Disable Unstable Headlines Test

### DIFF
--- a/Build/DisabledTests/EssentialBusHeadlines.DisabledTest.json
+++ b/Build/DisabledTests/EssentialBusHeadlines.DisabledTest.json
@@ -1,0 +1,12 @@
+[
+  {
+    "codeunitId": 139600,
+    "codeunitName": "Test Essential Bus. Headlines",
+    "method": "TestBothUpcomingAndOverdueVATReturnHeadlinesAreVisible"
+  },
+  {
+    "codeunitId": 139600,
+    "codeunitName": "Test Essential Bus. Headlines",
+    "method": "TestUpcomingOpenVATReturnHeadlineIsVisible"
+  }
+]


### PR DESCRIPTION
Disabling test which is unstable. The Headlines app will soon move to BCApps, where the tests will be enabled again. They will get fixed before the move.
