### PR TITLE
Issue 29317

### DIFF
--- a/Apps/W1/ReviewGLEntries/app/src/pages/ReviewGLEntries.Page.al
+++ b/Apps/W1/ReviewGLEntries/app/src/pages/ReviewGLEntries.Page.al
@@ -342,7 +342,8 @@ page 22207 "Review G/L Entries"
     begin
         Rec.CalcFields("Reviewed Amount");
         RemainingAmount := Rec.Amount - Rec."Reviewed Amount";
-        Rec."Amount to Review" := RemainingAmount;
+        if Rec."Amount to Review" = 0 then
+            Rec."Amount to Review" := RemainingAmount;
     end;
 
     trigger OnAfterGetCurrRecord()


### PR DESCRIPTION
#### Summary
The field 'Amount to Review' will now be filled when the page is opened with the calculated field remaining amount.

#### Work Item(s)
Fixes #29317


Fixes [AB#615546](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/615546)


