### PR TITLE
Correct Cleanup of IsolatedStorage on Deletion of SMTP Account

### DIFF
--- a/Apps/W1/Email - SMTP Connector/app/src/SMTPAccount.table.al
+++ b/Apps/W1/Email - SMTP Connector/app/src/SMTPAccount.table.al
@@ -147,8 +147,9 @@ table 4511 "SMTP Account"
 
     trigger OnDelete()
     begin
-        if not IsNullGuid(Rec."Password Key") then
-            if IsolatedStorage.Delete(Rec."Password Key") then;
+        DeleteIsolatedStorageIfExists(Rec."Password Key");
+        DeleteIsolatedStorageIfExists(Rec."Client Id Storage Id");
+        DeleteIsolatedStorageIfExists(Rec."Client Secret Storage Id");
     end;
 
     [NonDebuggable]
@@ -212,5 +213,13 @@ table 4511 "SMTP Account"
     begin
         if not IsolatedStorage.Get(Format(ClientSecretKey), DataScope::Company, ClientSecret) then
             Error(UnableToGetClientSecretMsg);
+    end;
+
+    local procedure DeleteIsolatedStorageIfExists(KeyToCheck: Guid)
+    begin
+        if IsNullGuid(KeyToCheck) then
+            exit;
+        if IsolatedStorage.Contains(Format(KeyToCheck), DataScope::Company) then
+            IsolatedStorage.Delete(Format(KeyToCheck), DataScope::Company);
     end;
 }


### PR DESCRIPTION
#### Summary
Correct cleanup of the IsolatedStorage when an SMTP account is deleted
#### Work Item(s)
Fixes #29565

Fixes [AB#617696](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617696)

