### PR TITLE
Add Remaining Amount field and calculation to General Ledger Entries Review page

### DIFF
--- a/Apps/W1/ReviewGLEntries/app/src/pages/GeneralLedgerEntriesReview.PageExt.al
+++ b/Apps/W1/ReviewGLEntries/app/src/pages/GeneralLedgerEntriesReview.PageExt.al
@@ -4,6 +4,20 @@ using Microsoft.Finance.GeneralLedger.Ledger;
 
 pageextension 22204 "General Ledger Entries Review" extends "General Ledger Entries"
 {
+    layout
+    {
+        addafter(Amount)
+        {
+            field(RemainingAmount; RemainingAmount)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Remaining Amount';
+                Editable = false;
+                ToolTip = 'Specifies the remaining amount that can be reviewed.';
+            }
+        }
+    }
+
     actions
     {
         addfirst("Ent&ry")
@@ -29,4 +43,13 @@ pageextension 22204 "General Ledger Entries Review" extends "General Ledger Entr
             }
         }
     }
+
+    trigger OnAfterGetRecord()
+    begin
+        Rec.CalcFields("Reviewed Amount");
+        RemainingAmount := Rec.Amount - Rec."Reviewed Amount";
+    end;
+
+    var
+        RemainingAmount: Decimal;
 }


### PR DESCRIPTION
#### Summary 
Added remaining amount to the page "General Ledger Entries" as an extension. Calculate the amount minus the reviewed amount.

Fixes #29469 
Fixes [AB#618355](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/618355)

