### PR TITLE
Uptake/permission apis

### DIFF
--- a/Apps/W1/APIV2/app/src/pages/APIV2AccessControl.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2AccessControl.Page.al
@@ -1,0 +1,96 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace System.Security.AccessControl;
+
+page 2149 "APIV2 - Access Control"
+{
+    APIGroup = 'automation';
+    APIPublisher = 'microsoft';
+    APIVersion = 'v2.0';
+    EntityCaption = 'Access Control';
+    EntitySetCaption = 'Access Controls';
+    EntityName = 'accessControl';
+    EntitySetName = 'accessControls';
+    Editable = false;
+    DeleteAllowed = false;
+    InsertAllowed = false;
+    ModifyAllowed = false;
+    PageType = API;
+    SourceTable = "Access Control";
+    ODataKeyFields = SystemId;
+    DataAccessIntent = ReadOnly;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Control1)
+            {
+                field(id; Rec.SystemId)
+                {
+                    Caption = 'Id';
+                }
+                field(userSecurityID; Rec."User Security ID")
+                {
+                    Caption = 'User Security ID';
+                }
+                field(roleID; Rec."Role ID")
+                {
+                    Caption = 'Role ID';
+                }
+                field(roleName; Rec."Role Name")
+                {
+                    Caption = 'Role Name';
+                }
+                field(company; Rec."Company Name")
+                {
+                    Caption = 'Company';
+                }
+                field(userName; Rec."User Name")
+                {
+                    Caption = 'User Name';
+                }
+                field(fullName; UserFullName)
+                {
+                    Caption = 'Full Name';
+                }
+                field(userLicenseType; UserLicenseType)
+                {
+                    Caption = 'User License Type';
+                }
+                field(scope; Rec.Scope)
+                {
+                    Caption = 'Scope';
+                }
+                field(appID; Rec."App ID")
+                {
+                    Caption = 'App ID';
+                }
+                field(appName; Rec."App Name")
+                {
+                    Caption = 'App Name';
+                }
+            }
+        }
+    }
+
+    var
+        User: Record User;
+        UserFullName: Text;
+        UserLicenseType: Text;
+
+    trigger OnAfterGetRecord()
+    begin
+        User.SetLoadFields("Full Name", "License Type");
+        if User."User Security ID" <> Rec."User Security ID" then
+            if User.Get(Rec."User Security ID") then begin
+                UserFullName := User."Full Name";
+                UserLicenseType := Format(User."License Type");
+            end else begin
+                UserFullName := '';
+                UserLicenseType := '';
+            end;
+    end;
+}

--- a/Apps/W1/APIV2/app/src/pages/APIV2AccessControl.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2AccessControl.Page.al
@@ -26,7 +26,7 @@ page 2149 "APIV2 - Access Control"
     {
         area(Content)
         {
-            repeater(Control1)
+            repeater(Group)
             {
                 field(id; Rec.SystemId)
                 {

--- a/Apps/W1/APIV2/app/src/pages/APIV2AutSecGrMembers.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2AutSecGrMembers.Page.al
@@ -43,6 +43,14 @@ page 30081 "APIV2 - Aut. Sec. Gr. Members"
                     Editable = false;
                     Caption = 'Security Group Name';
                 }
+                field(userName; Rec."User Name")
+                {
+                    Caption = 'User Name';
+                }
+                field(userFullName; Rec."User Full Name")
+                {
+                    Caption = 'User Full Name';
+                }
             }
         }
     }

--- a/Apps/W1/APIV2/app/src/pages/APIV2AutSecurityGroups.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2AutSecurityGroups.Page.al
@@ -42,6 +42,18 @@ page 30082 "APIV2 - Aut. Security Groups"
                     Caption = 'Group Name';
                     Editable = false;
                 }
+                field(groupUserSecurityID; Rec."Group User SID")
+                {
+                    Caption = 'Group User Security Id';
+                }
+                field(groupId; Rec."Group ID")
+                {
+                    Caption = 'Group Id';
+                }
+                field(retrievedSuccessfully; Rec."Retrieved Successfully")
+                {
+                    Caption = 'Retrieved Successfully';
+                }
                 part(securityGroupMembers; "APIV2 - Aut. Sec. Gr. Members")
                 {
                     Caption = 'User Group Member';
@@ -54,6 +66,14 @@ page 30082 "APIV2 - Aut. Security Groups"
                     Caption = 'Security Group Permissions';
                     EntityName = 'userPermission';
                     EntitySetName = 'userPermissions';
+                    SubPageLink = "User Security ID" = field("Group User SID");
+                }
+                part(permissionSets; "APIV2 - Access Control")
+                {
+                    Caption = 'Permission Sets';
+                    EntityName = 'accessControl';
+                    EntitySetName = 'accessControls';
+                    Multiplicity = Many;
                     SubPageLink = "User Security ID" = field("Group User SID");
                 }
             }

--- a/Apps/W1/APIV2/app/src/pages/APIV2ExpandedPermissionSets.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2ExpandedPermissionSets.Page.al
@@ -22,13 +22,14 @@ page 20766 "APIV2 Expanded Permission Sets"
     DataAccessIntent = ReadOnly;
     PageType = API;
     SourceTable = "Expanded Permission";
+    SourceTableView = where(Ap = filter('<> Exclude'));
     ODataKeyFields = SystemId;
 
     layout
     {
         area(Content)
         {
-            repeater(Control1)
+            repeater(Group)
             {
                 field(id; Rec.SystemId)
                 {

--- a/Apps/W1/APIV2/app/src/pages/APIV2ExpandedPermissionSets.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2ExpandedPermissionSets.Page.al
@@ -1,0 +1,107 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace System.Security.AccessControl;
+
+using System.Apps;
+
+page 20766 "APIV2 Expanded Permission Sets"
+{
+    APIGroup = 'auditing';
+    APIPublisher = 'microsoft';
+    APIVersion = 'v2.0';
+    EntityCaption = 'Expanded Permission Set';
+    EntitySetCaption = 'Expanded Permission Sets';
+    EntityName = 'expandedPermissionSet';
+    EntitySetName = 'expandedPermissionSets';
+    Editable = false;
+    DeleteAllowed = false;
+    InsertAllowed = false;
+    ModifyAllowed = false;
+    DataAccessIntent = ReadOnly;
+    PageType = API;
+    SourceTable = "Expanded Permission";
+    ODataKeyFields = SystemId;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Control1)
+            {
+                field(id; Rec.SystemId)
+                {
+                    Caption = 'Id';
+                }
+                field(appID; Rec."App ID")
+                {
+                    Caption = 'App ID';
+                }
+                field(appName; AppName)
+                {
+                    Caption = 'App Name';
+                }
+                field(roleID; Rec."Role ID")
+                {
+                    Caption = 'Role ID';
+                }
+                field(roleName; Rec."Role Name")
+                {
+                    Caption = 'Role Name';
+                }
+                field(objectType; Rec."Object Type")
+                {
+                    Caption = 'Object Type';
+                }
+                field(objectID; Rec."Object ID")
+                {
+                    Caption = 'Object ID';
+                }
+                field(objectName; Rec."Object Name")
+                {
+                    Caption = 'Object Name';
+                }
+                field(readPermission; Rec."Read Permission")
+                {
+                    Caption = 'Read Permission';
+                }
+                field(insertPermission; Rec."Insert Permission")
+                {
+                    Caption = 'Insert Permission';
+                }
+                field(modifyPermission; Rec."Modify Permission")
+                {
+                    Caption = 'Modify Permission';
+                }
+                field(deletePermission; Rec."Delete Permission")
+                {
+                    Caption = 'Delete Permission';
+                }
+                field(executePermission; Rec."Execute Permission")
+                {
+                    Caption = 'Execute Permission';
+                }
+                field(alObjectName; Rec."AL Object Name")
+                {
+                    Caption = 'AL Object Name';
+                }
+                field(scope; Rec.Scope)
+                {
+                    Caption = 'Scope';
+                }
+            }
+        }
+    }
+
+    var
+        ExtensionManagement: Codeunit "Extension Management";
+        AppName: Text;
+
+    trigger OnAfterGetRecord()
+    begin
+        Clear(AppName);
+        if not IsNullGuid(Rec."App ID") then
+            AppName := ExtensionManagement.GetAppName(Rec."App ID");
+    end;
+}

--- a/Apps/W1/APIV2/app/src/pages/APIV2PermissionSets.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2PermissionSets.Page.al
@@ -27,7 +27,7 @@ page 30003 "APIV2 - Permission Sets"
     {
         area(Content)
         {
-            repeater(Control1)
+            repeater(Group)
             {
                 field(id; Rec.SystemId)
                 {

--- a/Apps/W1/APIV2/app/src/pages/APIV2PermissionSets.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2PermissionSets.Page.al
@@ -1,0 +1,67 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace System.Security.AccessControl;
+
+page 30003 "APIV2 - Permission Sets"
+{
+    APIGroup = 'automation';
+    APIPublisher = 'microsoft';
+    APIVersion = 'v2.0';
+    EntityCaption = 'Permission Set';
+    EntitySetCaption = 'Permission Sets';
+    EntityName = 'aggregatePermissionSet';
+    EntitySetName = 'aggregatePermissionSets';
+    Editable = false;
+    DeleteAllowed = false;
+    InsertAllowed = false;
+    ModifyAllowed = false;
+    DataAccessIntent = ReadOnly;
+    PageType = API;
+    SourceTable = "Aggregate Permission Set";
+    SourceTableView = where("App Name" = filter('<> *_Exclude_*'));
+    ODataKeyFields = SystemId;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Control1)
+            {
+                field(id; Rec.SystemId)
+                {
+                    Caption = 'Id';
+                }
+                field(appID; Rec."App ID")
+                {
+                    Caption = 'App Id';
+                }
+                field(appName; Rec."App Name")
+                {
+                    Caption = 'App Name';
+                }
+                field(name; Rec.Name)
+                {
+                    Caption = 'Name';
+                }
+                field(roleID; Rec."Role ID")
+                {
+                    Caption = 'Role Id';
+                }
+                field(scope; Rec.Scope)
+                {
+                    Caption = 'Scope';
+                }
+                part(accessControl; "APIV2 - Access Control")
+                {
+                    Caption = 'Access Control';
+                    EntityName = 'accessControl';
+                    EntitySetName = 'accessControls';
+                    Multiplicity = Many;
+                    SubPageLink = "Role ID" = field("Role ID");
+                }
+            }
+        }
+    }
+}

--- a/Apps/W1/APIV2/app/src/pages/APIV2UserPermissionSets.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2UserPermissionSets.Page.al
@@ -27,7 +27,7 @@ page 30058 "APIV2 - User Permission Sets"
     {
         area(Content)
         {
-            repeater(Control1)
+            repeater(Group)
             {
                 field(id; Rec.SystemId)
                 {

--- a/Apps/W1/APIV2/app/src/pages/APIV2UserPermissionSets.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2UserPermissionSets.Page.al
@@ -1,0 +1,80 @@
+
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace System.Security.AccessControl;
+
+page 30058 "APIV2 - User Permission Sets"
+{
+    APIGroup = 'automation';
+    APIPublisher = 'microsoft';
+    APIVersion = 'v2.0';
+    EntityCaption = 'User Permission Set';
+    EntitySetCaption = 'User Permission Sets';
+    EntityName = 'userPermissionSet';
+    EntitySetName = 'userPermissionSets';
+    Editable = false;
+    DeleteAllowed = false;
+    InsertAllowed = false;
+    ModifyAllowed = false;
+    DataAccessIntent = ReadOnly;
+    PageType = API;
+    SourceTable = "User Permissions Buffer";
+    ODataKeyFields = SystemId;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Control1)
+            {
+                field(id; Rec.SystemId)
+                {
+                    Caption = 'Id';
+                }
+                field(userSecurityID; Rec."User Security ID")
+                {
+                    Caption = 'User Security ID';
+                }
+                field(type; Rec.Type)
+                {
+                    Caption = 'Type';
+                }
+                field(roleID; Rec."Role ID")
+                {
+                    Caption = 'Role ID';
+                }
+                field(roleName; Rec."Role Name")
+                {
+                    Caption = 'Role Name';
+                }
+                field(securityGroupCode; Rec.SecurityGroupCode)
+                {
+                    Caption = 'Security Group Code';
+                }
+                field(company; Rec."Company Name")
+                {
+                    Caption = 'Company';
+                }
+                field(scope; Rec.Scope)
+                {
+                    Caption = 'Scope';
+                }
+                field(appID; Rec."App ID")
+                {
+                    Caption = 'App ID';
+                }
+                field(appName; Rec."App Name")
+                {
+                    Caption = 'App Name';
+                }
+            }
+        }
+    }
+
+    trigger OnInit()
+    begin
+        Rec.FillBuffer();
+    end;
+}

--- a/Apps/W1/APIV2/app/src/pages/APIV2UsersPermissions.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2UsersPermissions.Page.al
@@ -26,7 +26,7 @@ page 30099 "APIV2 - Users Permissions"
     {
         area(Content)
         {
-            repeater(Control1)
+            repeater(Group)
             {
                 field(id; Rec.SystemId)
                 {

--- a/Apps/W1/APIV2/app/src/pages/APIV2UsersPermissions.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2UsersPermissions.Page.al
@@ -1,0 +1,94 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace System.Security.AccessControl;
+page 30099 "APIV2 - Users Permissions"
+{
+    APIGroup = 'automation';
+    APIPublisher = 'microsoft';
+    APIVersion = 'v2.0';
+    EntityCaption = 'User Permission';
+    EntitySetCaption = 'User Permissions';
+    EntityName = 'usersPermission';
+    EntitySetName = 'usersPermissions';
+    Editable = false;
+    DeleteAllowed = false;
+    InsertAllowed = false;
+    ModifyAllowed = false;
+    DataAccessIntent = ReadOnly;
+    PageType = API;
+    SourceTable = User;
+    SourceTableView = where("License Type" = filter('Full User|Limited User|Device Only User|External User|External Administrator|External Accountant'));
+    ODataKeyFields = SystemId;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Control1)
+            {
+                field(id; Rec.SystemId)
+                {
+                    Caption = 'Id';
+                }
+                field(userSecurityID; Rec."User Security ID")
+                {
+                    Caption = 'User Security Id';
+                }
+                field(userName; Rec."User Name")
+                {
+                    Caption = 'User Name';
+                }
+                field(fullName; Rec."Full Name")
+                {
+                    Caption = 'Full Name';
+                }
+                field(state; Rec.State)
+                {
+                    Caption = 'State';
+                }
+                field(expiryDate; Rec."Expiry Date")
+                {
+                    Caption = 'Expiry Date';
+                }
+                field(windowsSecurityID; Rec."Windows Security ID")
+                {
+                    Caption = 'Windows Security Id';
+                }
+                field(changePassword; Rec."Change Password")
+                {
+                    Caption = 'Change Password';
+                }
+                field(licenseType; Rec."License Type")
+                {
+                    Caption = 'License Type';
+                }
+                field(authenticationEmail; Rec."Authentication Email")
+                {
+                    Caption = 'Authentication Email';
+                }
+                field(contactEmail; Rec."Contact Email")
+                {
+                    Caption = 'Contact Email';
+                }
+                field(exchangeIdentifier; Rec."Exchange Identifier")
+                {
+                    Caption = 'Exchange Identifier';
+                }
+                field(applicationID; Rec."Application ID")
+                {
+                    Caption = 'Application Id';
+                }
+                part(userPermissionSets; "APIV2 - User Permission Sets")
+                {
+                    Caption = 'User Permission Sets';
+                    EntityName = 'userPermissionSet';
+                    EntitySetName = 'userPermissionSets';
+                    Multiplicity = Many;
+                    SubPageLink = "User Security ID" = field("User Security ID");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to AlAppExtensions please read our pull request guideline below
* https://github.com/microsoft/ALAppExtensions/blob/main/CONTRIBUTING.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Created a range of read-only API pages and supplemented existing APIs for querying permission related data.

- permissionSets shows all Permission Sets and includes accessControl subpage for linked Users/Security Groups
- expandedPermissionSets is Expanded Permissions Table with App name added
- securityGroups shows all Security Groups has been supplemented with accessControl subpage for linked Permission Sets
- usersPermissions list users and includes userPermissionSets subpage to list All assigned Sets Assigned directly and inherited from Security Groups

Depends on objects added in Base App PR https://github.com/microsoft/BusinessCentralApps/pull/1710

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #29779 
Fixes [AB#613825](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/613825)

