### PR TITLE
[Bug]: Two sessions can process the same Audit File Export Line simul…

### DIFF
--- a/Apps/W1/AuditFileExport/app/src/ExportEngine/AuditFileExportMgt.Codeunit.al
+++ b/Apps/W1/AuditFileExport/app/src/ExportEngine/AuditFileExportMgt.Codeunit.al
@@ -289,11 +289,16 @@ codeunit 5261 "Audit File Export Mgt."
             OnBeforeScheduleTask(DoNotScheduleTask, TaskID);
             if DoNotScheduleTask then
                 AuditFileExportLine."Task ID" := TaskID
-            else
+            else begin
+                if not IsNullGuid(AuditFileExportLine."Task ID") then
+                    if TaskScheduler.TaskExists(AuditFileExportLine."Task ID") then
+                        TaskScheduler.CancelTask(AuditFileExportLine."Task ID");
+
                 AuditFileExportLine."Task ID" :=
                     TaskScheduler.CreateTask(
                         Codeunit::"Audit Line Export Runner", Codeunit::"Audit File Export Error Handl.", true, CompanyName(),
                         NotBefore, AuditFileExportLine.RecordId());
+            end;
             AuditFileExportLine.Modify(true);
             Commit();
             NoOfJobs += 1;

--- a/Apps/W1/AuditFileExport/app/src/ExportEngine/AuditLineExportRunner.Codeunit.al
+++ b/Apps/W1/AuditFileExport/app/src/ExportEngine/AuditLineExportRunner.Codeunit.al
@@ -24,6 +24,11 @@ codeunit 5265 "Audit Line Export Runner"
         FileContentInStream: InStream;
     begin
         Rec.LockTable();
+        Rec.Find();
+        if (Rec."Session ID" <> 0) and (Rec."Session ID" <> SessionId()) then
+            if Rec."Server Instance ID" = ServiceInstanceId() then
+                if Session.IsSessionActive(Rec."Session ID") then
+                    exit;
         Rec.Validate("Server Instance ID", ServiceInstanceId());
         Rec.Validate("Session ID", SessionId());
         Rec.Validate("Created Date/Time", 0DT);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to AlAppExtensions please read our pull request guideline below
* https://github.com/microsoft/ALAppExtensions/blob/main/CONTRIBUTING.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Ensure that previously scheduled tasks are properly cancelled before scheduling new ones and that export runner codeunits avoid duplicate processing by checking for active sessions.

In `AuditLineExportRunner.Codeunit.al`, before proceeding, the code now checks if the record's session is active in the current server instance and exits early if so. This avoids duplicate processing by ensuring only one active session handles the export line.
#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #29798 


Fixes [AB#625902](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625902)
