### PR TITLE
[Bug]: xRechnung/ZUGFeRD export missing TaxExemptionReason and unsupported VATEX codes

### DIFF
--- a/Apps/DE/EDocumentDE/app/app.json
+++ b/Apps/DE/EDocumentDE/app/app.json
@@ -17,6 +17,12 @@
       "name": "E-Document Core",
       "publisher": "Microsoft",
       "version": "29.0.0.0"
+    },
+    {
+      "id": "e1966889-b5fb-4fda-a84c-ea71b590e1a9",
+      "name": "PEPPOL",
+      "publisher": "Microsoft",
+      "version": "29.0.0.0"
     }
   ],
   "screenshots": [],

--- a/Apps/DE/EDocumentDE/app/src/XRechnung/ExportXRechnungDocument.Codeunit.al
+++ b/Apps/DE/EDocumentDE/app/src/XRechnung/ExportXRechnungDocument.Codeunit.al
@@ -17,6 +17,7 @@ using Microsoft.Foundation.PaymentTerms;
 using Microsoft.Foundation.Reporting;
 using Microsoft.Foundation.UOM;
 using Microsoft.Inventory.Location;
+using Microsoft.Peppol;
 using Microsoft.Sales.Customer;
 using Microsoft.Sales.Document;
 using Microsoft.Sales.History;
@@ -39,6 +40,7 @@ codeunit 13916 "Export XRechnung Document"
         EDocumentService: Record "E-Document Service";
         FeatureTelemetry: Codeunit "Feature Telemetry";
         PEPPOLMgt: Codeunit "PEPPOL Management";
+        PeppolVATHelper: Codeunit "PEPPOL VAT Helper";
         TypeHelper: Codeunit "Type Helper";
         FeatureNameTok: Label 'E-document XRechnung Format', Locked = true;
         StartEventNameTok: Label 'E-document XRechnung export started', Locked = true;
@@ -46,6 +48,8 @@ codeunit 13916 "Export XRechnung Document"
         XmlNamespaceCBC: Text;
         XmlNamespaceCAC: Text;
         AlwaysIncludeTwoDecimalPlacesForAmountFields: Boolean;
+        AllLinesNotSubjectToVAT: Boolean;
+        DocumentLanguageCode: Code[10];
 
     trigger OnRun();
     begin
@@ -150,6 +154,7 @@ codeunit 13916 "Export XRechnung Document"
         if not DocumentLinesExist(SalesInvoiceHeader, SalesInvLine) then
             exit;
 
+        DocumentLanguageCode := SalesInvoiceHeader."Language Code";
         CurrencyCode := GetCurrencyCode(SalesInvoiceHeader."Currency Code", Currency);
 
         XmlDocument.ReadFrom(GetInvoiceXMLHeader(), XMLDoc);
@@ -162,6 +167,7 @@ codeunit 13916 "Export XRechnung Document"
         InsertEmbeddedDocument(RootXMLNode, SalesInvoiceHeader);
         InsertAttachment(RootXMLNode, Database::"Sales Invoice Header", SalesInvoiceHeader."No.");
         CalculateLineAmounts(SalesInvoiceHeader, SalesInvLine, Currency, LineAmounts);
+        DetectNotSubjectToVATLines(SalesInvLine);
         InsertAccountingSupplierParty(SalesInvoiceHeader."Responsibility Center", SalesInvoiceHeader."Salesperson Code", RootXMLNode);
         InsertAccountingCustomerParty(RootXMLNode, SalesInvoiceHeader);
         InsertDelivery(RootXMLNode, SalesInvoiceHeader);
@@ -195,6 +201,7 @@ codeunit 13916 "Export XRechnung Document"
         if not DocumentLinesExist(SalesCrMemoHeader, SalesCrMemoLine) then
             exit;
 
+        DocumentLanguageCode := SalesCrMemoHeader."Language Code";
         CurrencyCode := GetCurrencyCode(SalesCrMemoHeader."Currency Code", Currency);
 
         XmlDocument.ReadFrom(GetCrMemoXMLHeader(), XMLDoc);
@@ -207,6 +214,7 @@ codeunit 13916 "Export XRechnung Document"
         InsertEmbeddedDocument(RootXMLNode, SalesCrMemoHeader);
         InsertAttachment(RootXMLNode, Database::"Sales Cr.Memo Header", SalesCrMemoHeader."No.");
         CalculateLineAmounts(SalesCrMemoHeader, SalesCrMemoLine, Currency, LineAmounts);
+        DetectNotSubjectToVATLines(SalesCrMemoLine);
         InsertAccountingSupplierParty(SalesCrMemoHeader."Responsibility Center", SalesCrMemoHeader."Salesperson Code", RootXMLNode);
         InsertAccountingCustomerParty(RootXMLNode, SalesCrMemoHeader);
         InsertDelivery(RootXMLNode, SalesCrMemoHeader);
@@ -251,6 +259,7 @@ codeunit 13916 "Export XRechnung Document"
         if not DocumentLinesExist(SalesInvoiceHeader, TempSalesInvLine) then
             exit;
 
+        DocumentLanguageCode := SalesInvoiceHeader."Language Code";
         CurrencyCode := GetCurrencyCode(SalesInvoiceHeader."Currency Code", Currency);
 
         XmlDocument.ReadFrom(GetInvoiceXMLHeader(), XMLDoc);
@@ -263,6 +272,7 @@ codeunit 13916 "Export XRechnung Document"
         InsertEmbeddedDocument(RootXMLNode, SalesInvoiceHeader);
         InsertAttachment(RootXMLNode, Database::"Service Invoice Header", SalesInvoiceHeader."No.");
         CalculateLineAmounts(SalesInvoiceHeader, TempSalesInvLine, Currency, LineAmounts);
+        DetectNotSubjectToVATLines(TempSalesInvLine);
         InsertAccountingSupplierParty(SalesInvoiceHeader."Responsibility Center", SalesInvoiceHeader."Salesperson Code", RootXMLNode);
         InsertAccountingCustomerParty(RootXMLNode, SalesInvoiceHeader);
         InsertDelivery(RootXMLNode, SalesInvoiceHeader);
@@ -306,6 +316,7 @@ codeunit 13916 "Export XRechnung Document"
         if not DocumentLinesExist(SalesCrMemoHeader, TempSalesCrMemoLine) then
             exit;
 
+        DocumentLanguageCode := SalesCrMemoHeader."Language Code";
         CurrencyCode := GetCurrencyCode(SalesCrMemoHeader."Currency Code", Currency);
 
         XmlDocument.ReadFrom(GetCrMemoXMLHeader(), XMLDoc);
@@ -318,6 +329,7 @@ codeunit 13916 "Export XRechnung Document"
         InsertEmbeddedDocument(RootXMLNode, SalesCrMemoHeader);
         InsertAttachment(RootXMLNode, Database::"Service Cr.Memo Header", SalesCrMemoHeader."No.");
         CalculateLineAmounts(SalesCrMemoHeader, TempSalesCrMemoLine, Currency, LineAmounts);
+        DetectNotSubjectToVATLines(TempSalesCrMemoLine);
         InsertAccountingSupplierParty(SalesCrMemoHeader."Responsibility Center", SalesCrMemoHeader."Salesperson Code", RootXMLNode);
         InsertAccountingCustomerParty(RootXMLNode, SalesCrMemoHeader);
         InsertDelivery(RootXMLNode, SalesCrMemoHeader);
@@ -406,6 +418,8 @@ codeunit 13916 "Export XRechnung Document"
     local procedure InsertInvDiscountAllowanceCharge(var LineAmounts: Dictionary of [Text, Decimal]; var SalesInvLine: Record "Sales Invoice Line"; CurrencyCode: Code[10]; var RootXMLNode: XmlElement; LineDiscAmount: Dictionary of [Decimal, Decimal]; LineAmount: Dictionary of [Decimal, Decimal]; RoundingPrecision: Decimal)
     var
         InvDiscountAmount: Decimal;
+        VATEXCode: Text;
+        VATClauseDescription: Text;
     begin
         InvDiscountAmount := LineAmounts.Get(SalesInvLine.FieldName("Inv. Discount Amount"));
         if InvDiscountAmount = 0 then
@@ -413,11 +427,12 @@ codeunit 13916 "Export XRechnung Document"
         if SalesInvLine.FindSet() then
             repeat
                 if LineDiscAmount.ContainsKey(SalesInvLine."VAT %") and LineAmount.ContainsKey(SalesInvLine."VAT %") then begin
+                    PeppolVATHelper.GetVATClauseInfo(SalesInvLine."VAT Bus. Posting Group", SalesInvLine."VAT Prod. Posting Group", DocumentLanguageCode, VATEXCode, VATClauseDescription);
                     InsertAllowanceCharge(
                                RootXMLNode, 'Document discount',
                                GetTaxCategoryID(SalesInvLine."Tax Category", SalesInvLine."VAT Bus. Posting Group", SalesInvLine."VAT Prod. Posting Group"),
                                LineDiscAmount.Get(SalesInvLine."VAT %"), Round(LineAmount.Get(SalesInvLine."VAT %"), RoundingPrecision) + Round(LineDiscAmount.Get(SalesInvLine."VAT %"), RoundingPrecision),
-                               CurrencyCode, SalesInvLine."VAT %", 100 * LineDiscAmount.Get(SalesInvLine."VAT %") / (Round(LineAmount.Get(SalesInvLine."VAT %"), RoundingPrecision) + Round(LineDiscAmount.Get(SalesInvLine."VAT %"), RoundingPrecision)), true);
+                               CurrencyCode, SalesInvLine."VAT %", 100 * LineDiscAmount.Get(SalesInvLine."VAT %") / (Round(LineAmount.Get(SalesInvLine."VAT %"), RoundingPrecision) + Round(LineDiscAmount.Get(SalesInvLine."VAT %"), RoundingPrecision)), true, VATEXCode, VATClauseDescription);
                     LineDiscAmount.Remove(SalesInvLine."VAT %");
                 end;
             until SalesInvLine.Next() = 0;
@@ -427,6 +442,8 @@ codeunit 13916 "Export XRechnung Document"
     local procedure InsertInvDiscountAllowanceCharge(var LineAmounts: Dictionary of [Text, Decimal]; var SalesCrMemoLine: Record "Sales Cr.Memo Line"; CurrencyCode: Code[10]; var RootXMLNode: XmlElement; LineDiscAmount: Dictionary of [Decimal, Decimal]; LineAmount: Dictionary of [Decimal, Decimal]; RoundingPrecision: Decimal)
     var
         InvDiscountAmount: Decimal;
+        VATEXCode: Text;
+        VATClauseDescription: Text;
     begin
         InvDiscountAmount := LineAmounts.Get(SalesCrMemoLine.FieldName("Inv. Discount Amount"));
         if InvDiscountAmount = 0 then
@@ -434,11 +451,12 @@ codeunit 13916 "Export XRechnung Document"
         if SalesCrMemoLine.FindSet() then
             repeat
                 if LineDiscAmount.ContainsKey(SalesCrMemoLine."VAT %") and LineAmount.ContainsKey(SalesCrMemoLine."VAT %") then begin
+                    PeppolVATHelper.GetVATClauseInfo(SalesCrMemoLine."VAT Bus. Posting Group", SalesCrMemoLine."VAT Prod. Posting Group", DocumentLanguageCode, VATEXCode, VATClauseDescription);
                     InsertAllowanceCharge(
                                RootXMLNode, 'Document discount',
                                GetTaxCategoryID(SalesCrMemoLine."Tax Category", SalesCrMemoLine."VAT Bus. Posting Group", SalesCrMemoLine."VAT Prod. Posting Group"),
                                LineDiscAmount.Get(SalesCrMemoLine."VAT %"), Round(LineAmount.Get(SalesCrMemoLine."VAT %"), RoundingPrecision) + Round(LineDiscAmount.Get(SalesCrMemoLine."VAT %"), RoundingPrecision),
-                               CurrencyCode, SalesCrMemoLine."VAT %", 100 * LineDiscAmount.Get(SalesCrMemoLine."VAT %") / (Round(LineAmount.Get(SalesCrMemoLine."VAT %"), RoundingPrecision) + Round(LineDiscAmount.Get(SalesCrMemoLine."VAT %"), RoundingPrecision)), true);
+                               CurrencyCode, SalesCrMemoLine."VAT %", 100 * LineDiscAmount.Get(SalesCrMemoLine."VAT %") / (Round(LineAmount.Get(SalesCrMemoLine."VAT %"), RoundingPrecision) + Round(LineDiscAmount.Get(SalesCrMemoLine."VAT %"), RoundingPrecision)), true, VATEXCode, VATClauseDescription);
                     LineDiscAmount.Remove(SalesCrMemoLine."VAT %");
                 end;
             until SalesCrMemoLine.Next() = 0;
@@ -587,7 +605,7 @@ codeunit 13916 "Export XRechnung Document"
             ItemElement.Add(XmlElement.Create('Description', XmlNamespaceCBC, SalesInvLine."Description 2"));
         ItemElement.Add(XmlElement.Create('Name', XmlNamespaceCBC, CopyStr(SalesInvLine.Description, 1, 40)));
         InsertSellersItemIdentification(ItemElement, SalesInvLine."No.");
-        InsertTaxCategory(ItemElement, 'ClassifiedTaxCategory', GetTaxCategoryID(SalesInvLine."Tax Category", SalesInvLine."VAT Bus. Posting Group", SalesInvLine."VAT Prod. Posting Group"), SalesInvLine."VAT %");
+        InsertClassifiedTaxCategory(ItemElement, GetTaxCategoryID(SalesInvLine."Tax Category", SalesInvLine."VAT Bus. Posting Group", SalesInvLine."VAT Prod. Posting Group"), SalesInvLine."VAT %");
         RootElement.Add(ItemElement);
     end;
 
@@ -600,7 +618,7 @@ codeunit 13916 "Export XRechnung Document"
             ItemElement.Add(XmlElement.Create('Description', XmlNamespaceCBC, SalesCrMemoLine."Description 2"));
         ItemElement.Add(XmlElement.Create('Name', XmlNamespaceCBC, CopyStr(SalesCrMemoLine.Description, 1, 40)));
         InsertSellersItemIdentification(ItemElement, SalesCrMemoLine."No.");
-        InsertTaxCategory(ItemElement, 'ClassifiedTaxCategory', GetTaxCategoryID(SalesCrMemoLine."Tax Category", SalesCrMemoLine."VAT Bus. Posting Group", SalesCrMemoLine."VAT Prod. Posting Group"), SalesCrMemoLine."VAT %");
+        InsertClassifiedTaxCategory(ItemElement, GetTaxCategoryID(SalesCrMemoLine."Tax Category", SalesCrMemoLine."VAT Bus. Posting Group", SalesCrMemoLine."VAT Prod. Posting Group"), SalesCrMemoLine."VAT %");
         RootElement.Add(ItemElement);
     end;
 
@@ -757,7 +775,8 @@ codeunit 13916 "Export XRechnung Document"
         TempCompanyAddress.CopyFromCompanyInformation(CompanyInformation);
         UpdateSellerAddressFromResponsibilityCenter(RespCenterCode, TempCompanyAddress);
         InsertAddress(PartyElement, 'PostalAddress', TempCompanyAddress);
-        InsertPartyTaxScheme(PartyElement, CompanyInformation."VAT Registration No.", CompanyInformation."Country/Region Code");
+        if not AllLinesNotSubjectToVAT then
+            InsertPartyTaxScheme(PartyElement, CompanyInformation."VAT Registration No.", CompanyInformation."Country/Region Code");
         InsertPartyLegalEntity(PartyElement);
         InsertSupplierContact(SalespersonCode, PartyElement);
         AccountingSupplierPartyElement.Add(PartyElement);
@@ -835,26 +854,41 @@ codeunit 13916 "Export XRechnung Document"
 
         InsertPartyName(PartyElement, PartyName);
         InsertAddress(PartyElement, 'PostalAddress', PostalAddress);
-        InsertPartyTaxScheme(PartyElement, VATRegNo, PostalAddress."Country/Region Code");
+        if not AllLinesNotSubjectToVAT then
+            InsertPartyTaxScheme(PartyElement, VATRegNo, PostalAddress."Country/Region Code");
         InsertCustomerPartyLegalEntity(PartyElement, CustomerName);
         InsertContact(PartyElement, ContactName, ContactEMail);
         AccountingCustomerParty.Add(PartyElement);
     end;
 
-    local procedure InsertTaxCategory(var RootElement: XmlElement; TaxCategory: Text; TaxCategoryID: Text; Percent: Decimal);
+    local procedure InsertClassifiedTaxCategory(var RootElement: XmlElement; TaxCategoryID: Text; Percent: Decimal);
     var
         TaxCategoryElement: XmlElement;
     begin
-        TaxCategoryElement := XmlElement.Create(TaxCategory, XmlNamespaceCAC);
+        TaxCategoryElement := XmlElement.Create('ClassifiedTaxCategory', XmlNamespaceCAC);
         TaxCategoryElement.Add(XmlElement.Create('ID', XmlNamespaceCBC, TaxCategoryID));
-        TaxCategoryElement.Add(XmlElement.Create('Percent', XmlNamespaceCBC, FormatFiveDecimal(Percent)));
-        if Percent = 0 then
-            TaxCategoryElement.Add(XmlElement.Create('TaxExemptionReasonCode', XmlNamespaceCBC, 'VATEX-EU-O'));
+        if not IsTaxCategoryNotSubjectToVAT(TaxCategoryID) then
+            TaxCategoryElement.Add(XmlElement.Create('Percent', XmlNamespaceCBC, FormatFiveDecimal(Percent)));
         InsertTaxScheme(TaxCategoryElement);
         RootElement.Add(TaxCategoryElement);
     end;
 
-    local procedure InsertAllowanceCharge(var RootXMLNode: XmlElement; AllowanceChargeReason: Text; TaxCategory: Text; Amount: Decimal; BaseAmount: Decimal; CurrencyCode: Code[10]; Percent: Decimal; MultiplierFactorNumeric: Decimal; InsertTaxCat: Boolean)
+    local procedure InsertTaxCategory(var RootElement: XmlElement; TaxCategoryID: Text; Percent: Decimal; VATEXCode: Text; VATClauseDescription: Text);
+    var
+        TaxCategoryElement: XmlElement;
+    begin
+        TaxCategoryElement := XmlElement.Create('TaxCategory', XmlNamespaceCAC);
+        TaxCategoryElement.Add(XmlElement.Create('ID', XmlNamespaceCBC, TaxCategoryID));
+        TaxCategoryElement.Add(XmlElement.Create('Percent', XmlNamespaceCBC, FormatFiveDecimal(Percent)));
+        if VATEXCode <> '' then
+            TaxCategoryElement.Add(XmlElement.Create('TaxExemptionReasonCode', XmlNamespaceCBC, VATEXCode));
+        if VATClauseDescription <> '' then
+            TaxCategoryElement.Add(XmlElement.Create('TaxExemptionReason', XmlNamespaceCBC, VATClauseDescription));
+        InsertTaxScheme(TaxCategoryElement);
+        RootElement.Add(TaxCategoryElement);
+    end;
+
+    local procedure InsertAllowanceCharge(var RootXMLNode: XmlElement; AllowanceChargeReason: Text; TaxCategory: Text; Amount: Decimal; BaseAmount: Decimal; CurrencyCode: Code[10]; Percent: Decimal; MultiplierFactorNumeric: Decimal; InsertTaxCat: Boolean; VATEXCode: Text; VATClauseDescription: Text)
     var
         AllowanceChargeElement: XmlElement;
     begin
@@ -865,18 +899,31 @@ codeunit 13916 "Export XRechnung Document"
         AllowanceChargeElement.Add(XmlElement.Create('Amount', XmlNamespaceCBC, XmlAttribute.Create('currencyID', CurrencyCode), FormatDecimal(Amount, AlwaysIncludeTwoDecimalPlacesForAmountFields)));
         AllowanceChargeElement.Add(XmlElement.Create('BaseAmount', XmlNamespaceCBC, XmlAttribute.Create('currencyID', CurrencyCode), FormatDecimal(BaseAmount, AlwaysIncludeTwoDecimalPlacesForAmountFields)));
         if InsertTaxCat then
-            InsertTaxCategory(AllowanceChargeElement, 'TaxCategory', TaxCategory, Percent);
+            InsertTaxCategory(AllowanceChargeElement, TaxCategory, Percent, VATEXCode, VATClauseDescription);
         RootXMLNode.Add(AllowanceChargeElement);
     end;
 
-    local procedure InsertTaxSubtotal(var RootElement: XmlElement; TaxCategory: Code[10]; TaxableAmount: Decimal; TaxAmount: Decimal; VATPercentage: Decimal; CurrencyCode: Code[10]);
+    local procedure InsertAllowanceCharge(var RootXMLNode: XmlElement; AllowanceChargeReason: Text; Amount: Decimal; BaseAmount: Decimal; CurrencyCode: Code[10]; MultiplierFactorNumeric: Decimal)
+    var
+        AllowanceChargeElement: XmlElement;
+    begin
+        AllowanceChargeElement := XmlElement.Create('AllowanceCharge', XmlNamespaceCAC);
+        AllowanceChargeElement.Add(XmlElement.Create('ChargeIndicator', XmlNamespaceCBC, 'false'));
+        AllowanceChargeElement.Add(XmlElement.Create('AllowanceChargeReason', XmlNamespaceCBC, AllowanceChargeReason));
+        AllowanceChargeElement.Add(XmlElement.Create('MultiplierFactorNumeric', XmlNamespaceCBC, FormatFiveDecimal(MultiplierFactorNumeric)));
+        AllowanceChargeElement.Add(XmlElement.Create('Amount', XmlNamespaceCBC, XmlAttribute.Create('currencyID', CurrencyCode), FormatDecimal(Amount, AlwaysIncludeTwoDecimalPlacesForAmountFields)));
+        AllowanceChargeElement.Add(XmlElement.Create('BaseAmount', XmlNamespaceCBC, XmlAttribute.Create('currencyID', CurrencyCode), FormatDecimal(BaseAmount, AlwaysIncludeTwoDecimalPlacesForAmountFields)));
+        RootXMLNode.Add(AllowanceChargeElement);
+    end;
+
+    local procedure InsertTaxSubtotal(var RootElement: XmlElement; TaxCategory: Code[10]; TaxableAmount: Decimal; TaxAmount: Decimal; VATPercentage: Decimal; CurrencyCode: Code[10]; VATEXCode: Text; VATClauseDescription: Text);
     var
         TaxSubtotalElement: XmlElement;
     begin
         TaxSubtotalElement := XmlElement.Create('TaxSubtotal', XmlNamespaceCAC);
         TaxSubtotalElement.Add(XmlElement.Create('TaxableAmount', XmlNamespaceCBC, XmlAttribute.Create('currencyID', CurrencyCode), FormatDecimal(TaxableAmount, AlwaysIncludeTwoDecimalPlacesForAmountFields)));
         TaxSubtotalElement.Add(XmlElement.Create('TaxAmount', XmlNamespaceCBC, XmlAttribute.Create('currencyID', CurrencyCode), FormatDecimal(TaxAmount, AlwaysIncludeTwoDecimalPlacesForAmountFields)));
-        InsertTaxCategory(TaxSubtotalElement, 'TaxCategory', TaxCategory, VATPercentage);
+        InsertTaxCategory(TaxSubtotalElement, TaxCategory, VATPercentage, VATEXCode, VATClauseDescription);
         RootElement.Add(TaxSubtotalElement);
     end;
 
@@ -891,9 +938,44 @@ codeunit 13916 "Export XRechnung Document"
         exit(VATPostingSetup."Tax Category");
     end;
 
+    local procedure IsTaxCategoryNotSubjectToVAT(TaxCategoryID: Text): Boolean
+    begin
+        exit(TaxCategoryID = 'O');
+    end;
+
+    local procedure DetectNotSubjectToVATLines(var SalesInvLine: Record "Sales Invoice Line")
+    begin
+        AllLinesNotSubjectToVAT := false;
+        if SalesInvLine.FindSet() then begin
+            AllLinesNotSubjectToVAT := true;
+            repeat
+                if not IsTaxCategoryNotSubjectToVAT(GetTaxCategoryID(SalesInvLine."Tax Category", SalesInvLine."VAT Bus. Posting Group", SalesInvLine."VAT Prod. Posting Group")) then begin
+                    AllLinesNotSubjectToVAT := false;
+                    exit;
+                end;
+            until SalesInvLine.Next() = 0;
+        end;
+    end;
+
+    local procedure DetectNotSubjectToVATLines(var SalesCrMemoLine: Record "Sales Cr.Memo Line")
+    begin
+        AllLinesNotSubjectToVAT := false;
+        if SalesCrMemoLine.FindSet() then begin
+            AllLinesNotSubjectToVAT := true;
+            repeat
+                if not IsTaxCategoryNotSubjectToVAT(GetTaxCategoryID(SalesCrMemoLine."Tax Category", SalesCrMemoLine."VAT Bus. Posting Group", SalesCrMemoLine."VAT Prod. Posting Group")) then begin
+                    AllLinesNotSubjectToVAT := false;
+                    exit;
+                end;
+            until SalesCrMemoLine.Next() = 0;
+        end;
+    end;
+
     local procedure InsertTaxTotal(var RootXMLNode: XmlElement; var SalesInvLine: Record "Sales Invoice Line"; CurrencyCode: Code[10]; var LineAmount: Dictionary of [Decimal, Decimal]; var LineVATAmount: Dictionary of [Decimal, Decimal])
     var
         TaxTotalElement: XmlElement;
+        VATEXCode: Text;
+        VATClauseDescription: Text;
     begin
         TaxTotalElement := XmlElement.Create('TaxTotal', XmlNamespaceCAC);
         TaxTotalElement.Add(XmlElement.Create('TaxAmount', XmlNamespaceCBC, XmlAttribute.Create('currencyID', CurrencyCode), FormatDecimal(GetTotalTaxAmount(SalesInvLine), AlwaysIncludeTwoDecimalPlacesForAmountFields)));
@@ -901,9 +983,10 @@ codeunit 13916 "Export XRechnung Document"
         if SalesInvLine.FindSet() then
             repeat
                 if LineVATAmount.ContainsKey(SalesInvLine."VAT %") and LineAmount.ContainsKey(SalesInvLine."VAT %") then begin
+                    PeppolVATHelper.GetVATClauseInfo(SalesInvLine."VAT Bus. Posting Group", SalesInvLine."VAT Prod. Posting Group", DocumentLanguageCode, VATEXCode, VATClauseDescription);
                     InsertTaxSubtotal(
                         TaxTotalElement, GetTaxCategoryID(SalesInvLine."Tax Category", SalesInvLine."VAT Bus. Posting Group", SalesInvLine."VAT Prod. Posting Group"), LineAmount.Get(SalesInvLine."VAT %"),
-                        LineVATAmount.Get(SalesInvLine."VAT %"), SalesInvLine."VAT %", CurrencyCode);
+                        LineVATAmount.Get(SalesInvLine."VAT %"), SalesInvLine."VAT %", CurrencyCode, VATEXCode, VATClauseDescription);
                     LineAmount.Remove(SalesInvLine."VAT %");
                     LineVATAmount.Remove(SalesInvLine."VAT %");
                 end;
@@ -920,6 +1003,8 @@ codeunit 13916 "Export XRechnung Document"
     local procedure InsertTaxTotal(var RootXMLNode: XmlElement; var SalesCrMemoLine: Record "Sales Cr.Memo Line"; CurrencyCode: Code[10]; var LineAmount: Dictionary of [Decimal, Decimal]; var LineVATAmount: Dictionary of [Decimal, Decimal])
     var
         TaxTotalElement: XmlElement;
+        VATEXCode: Text;
+        VATClauseDescription: Text;
     begin
         TaxTotalElement := XmlElement.Create('TaxTotal', XmlNamespaceCAC);
         TaxTotalElement.Add(XmlElement.Create('TaxAmount', XmlNamespaceCBC, XmlAttribute.Create('currencyID', CurrencyCode), FormatDecimal(GetTotalTaxAmount(SalesCrMemoLine), AlwaysIncludeTwoDecimalPlacesForAmountFields)));
@@ -927,9 +1012,10 @@ codeunit 13916 "Export XRechnung Document"
         if SalesCrMemoLine.FindSet() then
             repeat
                 if LineVATAmount.ContainsKey(SalesCrMemoLine."VAT %") and LineAmount.ContainsKey(SalesCrMemoLine."VAT %") then begin
+                    PeppolVATHelper.GetVATClauseInfo(SalesCrMemoLine."VAT Bus. Posting Group", SalesCrMemoLine."VAT Prod. Posting Group", DocumentLanguageCode, VATEXCode, VATClauseDescription);
                     InsertTaxSubtotal(
                         TaxTotalElement, GetTaxCategoryID(SalesCrMemoLine."Tax Category", SalesCrMemoLine."VAT Bus. Posting Group", SalesCrMemoLine."VAT Prod. Posting Group"), LineAmount.Get(SalesCrMemoLine."VAT %"),
-                        LineVATAmount.Get(SalesCrMemoLine."VAT %"), SalesCrMemoLine."VAT %", CurrencyCode);
+                        LineVATAmount.Get(SalesCrMemoLine."VAT %"), SalesCrMemoLine."VAT %", CurrencyCode, VATEXCode, VATClauseDescription);
                     LineAmount.Remove(SalesCrMemoLine."VAT %");
                     LineVATAmount.Remove(SalesCrMemoLine."VAT %");
                 end;
@@ -1040,9 +1126,9 @@ codeunit 13916 "Export XRechnung Document"
             InsertOrderLineReference(InvoiceLineElement, SalesInvLine."Line No.");
             if SalesInvLine."Line Discount Amount" > 0 then
                 InsertAllowanceCharge(
-                    InvoiceLineElement, 'LineDiscount', GetTaxCategoryID(SalesInvLine."Tax Category", SalesInvLine."VAT Bus. Posting Group", SalesInvLine."VAT Prod. Posting Group"),
+                    InvoiceLineElement, 'LineDiscount',
                     SalesInvLine."Line Discount Amount", SalesInvLine."Unit Price" * SalesInvLine.Quantity,
-                    CurrencyCode, SalesInvLine."Line Discount %", SalesInvLine."Line Discount %", false);
+                    CurrencyCode, SalesInvLine."Line Discount %");
 
             InsertItem(InvoiceLineElement, SalesInvLine);
             InsertPrice(InvoiceLineElement, SalesInvLine."Unit Price", CurrencyCode);
@@ -1079,9 +1165,9 @@ codeunit 13916 "Export XRechnung Document"
                 InsertInvoicePeriod(CrMemoLineElement, SalesCrMemoLine."Shipment Date", SalesCrMemoLine."Shipment Date");
             if SalesCrMemoLine."Line Discount Amount" > 0 then
                 InsertAllowanceCharge(
-                    CrMemoLineElement, 'LineDiscount', GetTaxCategoryID(SalesCrMemoLine."Tax Category", SalesCrMemoLine."VAT Bus. Posting Group", SalesCrMemoLine."VAT Prod. Posting Group"),
+                    CrMemoLineElement, 'LineDiscount',
                     SalesCrMemoLine."Line Discount Amount", SalesCrMemoLine."Unit Price" * SalesCrMemoLine.Quantity,
-                    CurrencyCode, SalesCrMemoLine."Line Discount %", SalesCrMemoLine."Line Discount %", false);
+                    CurrencyCode, SalesCrMemoLine."Line Discount %");
 
             InsertItem(CrMemoLineElement, SalesCrMemoLine);
             InsertPrice(CrMemoLineElement, SalesCrMemoLine."Unit Price", CurrencyCode);

--- a/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
+++ b/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
@@ -16,6 +16,7 @@ using Microsoft.Foundation.PaymentTerms;
 using Microsoft.Foundation.Reporting;
 using Microsoft.Foundation.UOM;
 using Microsoft.Inventory.Location;
+using Microsoft.Peppol;
 using Microsoft.Sales.Customer;
 using Microsoft.Sales.History;
 using Microsoft.Sales.Peppol;
@@ -37,12 +38,14 @@ codeunit 13917 "Export ZUGFeRD Document"
         EDocumentService: Record "E-Document Service";
         FeatureTelemetry: Codeunit "Feature Telemetry";
         PEPPOLMgt: Codeunit "PEPPOL Management";
+        PeppolVATHelper: Codeunit "PEPPOL VAT Helper";
         FeatureNameTok: Label 'E-document ZUGFeRD Format', Locked = true;
         StartEventNameTok: Label 'E-document ZUGFeRD export started', Locked = true;
         EndEventNameTok: Label 'E-document ZUGFeRD export completed', Locked = true;
         XmlNamespaceRSM: Text;
         XmlNamespaceRAM: Text;
         XmlNamespaceUDT: Text;
+        DocumentLanguageCode: Code[10];
 
     trigger OnRun()
     var
@@ -284,6 +287,7 @@ codeunit 13917 "Export ZUGFeRD Document"
         if not DocumentLinesExist(SalesInvoiceHeader, SalesInvLine) then
             exit;
 
+        DocumentLanguageCode := SalesInvoiceHeader."Language Code";
         XmlDocument.ReadFrom(GetInvoiceXMLHeader(), XMLDoc);
         XmlDoc.GetRoot(RootXMLNode);
 
@@ -317,6 +321,7 @@ codeunit 13917 "Export ZUGFeRD Document"
         if not DocumentLinesExist(SalesCrMemoHeader, SalesCrMemoLine) then
             exit;
 
+        DocumentLanguageCode := SalesCrMemoHeader."Language Code";
         XmlDocument.ReadFrom(GetInvoiceXMLHeader(), XMLDoc);
         XmlDoc.GetRoot(RootXMLNode);
 
@@ -360,6 +365,7 @@ codeunit 13917 "Export ZUGFeRD Document"
         if not DocumentLinesExist(SalesInvoiceHeader, TempSalesInvLine) then
             exit;
 
+        DocumentLanguageCode := SalesInvoiceHeader."Language Code";
         XmlDocument.ReadFrom(GetInvoiceXMLHeader(), XMLDoc);
         XmlDoc.GetRoot(RootXMLNode);
 
@@ -403,6 +409,7 @@ codeunit 13917 "Export ZUGFeRD Document"
         if not DocumentLinesExist(SalesCrMemoHeader, TempSalesCrMemoLine) then
             exit;
 
+        DocumentLanguageCode := SalesCrMemoHeader."Language Code";
         XmlDocument.ReadFrom(GetInvoiceXMLHeader(), XMLDoc);
         XmlDoc.GetRoot(RootXMLNode);
 
@@ -793,13 +800,17 @@ codeunit 13917 "Export ZUGFeRD Document"
     end;
 
     local procedure InsertTradeTax(var SettlementElement: XmlElement; var SalesInvLine: Record "Sales Invoice Line"; var LineAmount: Dictionary of [Decimal, Decimal]; var LineVATAmount: Dictionary of [Decimal, Decimal])
+    var
+        VATEXCode: Text;
+        VATClauseDescription: Text;
     begin
         if SalesInvLine.FindSet() then
             repeat
                 if LineVATAmount.ContainsKey(SalesInvLine."VAT %") and LineAmount.ContainsKey(SalesInvLine."VAT %") then begin
+                    PeppolVATHelper.GetVATClauseInfo(SalesInvLine."VAT Bus. Posting Group", SalesInvLine."VAT Prod. Posting Group", DocumentLanguageCode, VATEXCode, VATClauseDescription);
                     InsertTaxElement(SettlementElement, FormatDecimal(LineVATAmount.Get(SalesInvLine."VAT %")), FormatDecimal(LineAmount.Get(SalesInvLine."VAT %")),
                         GetTaxCategoryID(SalesInvLine."Tax Category", SalesInvLine."VAT Bus. Posting Group", SalesInvLine."VAT Prod. Posting Group"), FormatFiveDecimal(SalesInvLine."VAT %"),
-                        SalesInvLine."VAT %" = 0);
+                        VATEXCode, VATClauseDescription);
                     LineAmount.Remove(SalesInvLine."VAT %");
                     LineVATAmount.Remove(SalesInvLine."VAT %");
                 end;
@@ -810,13 +821,17 @@ codeunit 13917 "Export ZUGFeRD Document"
     end;
 
     local procedure InsertTradeTax(var SettlementElement: XmlElement; var SalesCrMemoLine: Record "Sales Cr.Memo Line"; var LineAmount: Dictionary of [Decimal, Decimal]; var LineVATAmount: Dictionary of [Decimal, Decimal])
+    var
+        VATEXCode: Text;
+        VATClauseDescription: Text;
     begin
         if SalesCrMemoLine.FindSet() then
             repeat
                 if LineVATAmount.ContainsKey(SalesCrMemoLine."VAT %") and LineAmount.ContainsKey(SalesCrMemoLine."VAT %") then begin
+                    PeppolVATHelper.GetVATClauseInfo(SalesCrMemoLine."VAT Bus. Posting Group", SalesCrMemoLine."VAT Prod. Posting Group", DocumentLanguageCode, VATEXCode, VATClauseDescription);
                     InsertTaxElement(SettlementElement, FormatDecimal(LineVATAmount.Get(SalesCrMemoLine."VAT %")), FormatDecimal(LineAmount.Get(SalesCrMemoLine."VAT %")),
                         GetTaxCategoryID(SalesCrMemoLine."Tax Category", SalesCrMemoLine."VAT Bus. Posting Group", SalesCrMemoLine."VAT Prod. Posting Group"), FormatFiveDecimal(SalesCrMemoLine."VAT %"),
-                        SalesCrMemoLine."VAT %" = 0);
+                        VATEXCode, VATClauseDescription);
 
                     LineAmount.Remove(SalesCrMemoLine."VAT %");
                     LineVATAmount.Remove(SalesCrMemoLine."VAT %");
@@ -827,17 +842,19 @@ codeunit 13917 "Export ZUGFeRD Document"
         SalesCrMemoLine.SetRange("VAT Calculation Type");
     end;
 
-    local procedure InsertTaxElement(var SettlementElement: XmlElement; CalculatedAmount: Text; BasisAmount: Text; CategoryCode: Text; RateApplicablePercent: Text; ZeroVAT: Boolean)
+    local procedure InsertTaxElement(var SettlementElement: XmlElement; CalculatedAmount: Text; BasisAmount: Text; CategoryCode: Text; RateApplicablePercent: Text; VATEXCode: Text; VATClauseDescription: Text)
     var
         TaxElement: XmlElement;
     begin
         TaxElement := XmlElement.Create('ApplicableTradeTax', XmlNamespaceRAM);
         TaxElement.Add(XmlElement.Create('CalculatedAmount', XmlNamespaceRAM, CalculatedAmount));
         TaxElement.Add(XmlElement.Create('TypeCode', XmlNamespaceRAM, 'VAT'));
-        if ZeroVAT then
-            TaxElement.Add(XmlElement.Create('ExemptionReason', XmlNamespaceRAM, 'VATEX-EU-O'));
+        if VATClauseDescription <> '' then
+            TaxElement.Add(XmlElement.Create('ExemptionReason', XmlNamespaceRAM, VATClauseDescription));
         TaxElement.Add(XmlElement.Create('BasisAmount', XmlNamespaceRAM, BasisAmount));
         TaxElement.Add(XmlElement.Create('CategoryCode', XmlNamespaceRAM, CategoryCode));
+        if VATEXCode <> '' then
+            TaxElement.Add(XmlElement.Create('ExemptionReasonCode', XmlNamespaceRAM, VATEXCode));
         TaxElement.Add(XmlElement.Create('RateApplicablePercent', XmlNamespaceRAM, RateApplicablePercent));
         SettlementElement.Add(TaxElement);
     end;

--- a/Apps/DE/EDocumentDE/test/app.json
+++ b/Apps/DE/EDocumentDE/test/app.json
@@ -19,6 +19,12 @@
       "version": "29.0.0.0"
     },
     {
+      "id": "e1966889-b5fb-4fda-a84c-ea71b590e1a9",
+      "name": "PEPPOL",
+      "publisher": "Microsoft",
+      "version": "29.0.0.0"
+    },
+    {
       "id": "e1d97edc-c239-46b4-8d84-6368bdf67c8b",
       "name": "E-Document Core",
       "publisher": "Microsoft",

--- a/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
+++ b/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
@@ -9,12 +9,15 @@ using Microsoft.eServices.EDocument;
 using Microsoft.eServices.EDocument.Integration;
 using Microsoft.Finance.Currency;
 using Microsoft.Finance.GeneralLedger.Setup;
+using Microsoft.Finance.VAT.Clause;
+using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Attachment;
 using Microsoft.Foundation.Company;
 using Microsoft.Foundation.PaymentTerms;
 using Microsoft.Foundation.UOM;
 using Microsoft.Inventory.Location;
+using Microsoft.Peppol;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 using Microsoft.Sales.Customer;
@@ -387,6 +390,36 @@ codeunit 13918 "XRechnung XML Document Tests"
 
         // [THEN] XRechnung Electronic Document is created with company data as accounting supplier party
         VerifyAccountingSupplierParty(TempXMLBuffer, '/ubl:Invoice/cac:AccountingSupplierParty/cac:Party', ResponsibilityCenter);
+    end;
+
+    [Test]
+    procedure ExportPostedSalesInvoiceInXRechnungFormatVerifyVATEXCodeAndExemptionReason();
+    var
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        SalesInvoiceLine: Record "Sales Invoice Line";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        InvoiceTaxCategoryTok: Label '/ubl:Invoice/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory', Locked = true;
+        Path: Text;
+    begin
+        // [SCENARIO] Export posted sales invoice creates electronic document in XRechnung format with VATEX code and exemption reason from VAT Clause
+        Initialize();
+
+        // [GIVEN] Create and Post Sales Invoice.
+        SalesInvoiceHeader.Get(CreateAndPostSalesDocument("Sales Document Type"::Invoice, Enum::"Sales Line Type"::Item, false));
+
+        // [GIVEN] VAT Clause with VATEX Code 'VATEX-EU-O' and Description 'Not subject to VAT' linked to the VAT Posting Setup
+        SalesInvoiceLine.SetRange("Document No.", SalesInvoiceHeader."No.");
+        SalesInvoiceLine.FindFirst();
+        CreateVATClauseWithVATEXCode(SalesInvoiceLine."VAT Bus. Posting Group", SalesInvoiceLine."VAT Prod. Posting Group");
+
+        // [WHEN] Export XRechnung Electronic Document.
+        ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
+
+        // [THEN] TaxExemptionReasonCode and TaxExemptionReason are exported with correct values
+        Path := InvoiceTaxCategoryTok + '/cbc:TaxExemptionReasonCode';
+        Assert.AreEqual('VATEX-EU-O', GetNodeByPathWithError(TempXMLBuffer, Path), StrSubstNo(IncorrectValueErr, Path));
+        Path := InvoiceTaxCategoryTok + '/cbc:TaxExemptionReason';
+        Assert.AreEqual('Not subject to VAT', GetNodeByPathWithError(TempXMLBuffer, Path), StrSubstNo(IncorrectValueErr, Path));
     end;
     #endregion
 
@@ -991,6 +1024,36 @@ codeunit 13918 "XRechnung XML Document Tests"
 
         // [THEN] XRechnung Electronic Document is created with company data as accounting supplier party
         VerifyAccountingSupplierParty(TempXMLBuffer, '/ns0:CreditNote/cac:AccountingSupplierParty/cac:Party', ResponsibilityCenter);
+    end;
+
+    [Test]
+    procedure ExportPostedSalesCrMemoInXRechnungFormatVerifyVATEXCodeAndExemptionReason();
+    var
+        SalesCrMemoHeader: Record "Sales Cr.Memo Header";
+        SalesCrMemoLine: Record "Sales Cr.Memo Line";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        CrMemoTaxCategoryTok: Label '/ns0:CreditNote/cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory', Locked = true;
+        Path: Text;
+    begin
+        // [SCENARIO] Export posted sales cr. memo creates electronic document in XRechnung format with VATEX code and exemption reason from VAT Clause
+        Initialize();
+
+        // [GIVEN] Create and Post Sales Credit Memo.
+        SalesCrMemoHeader.Get(CreateAndPostSalesDocument("Sales Document Type"::"Credit Memo", Enum::"Sales Line Type"::Item, false));
+
+        // [GIVEN] VAT Clause with VATEX Code 'VATEX-EU-O' and Description 'Not subject to VAT' linked to the VAT Posting Setup
+        SalesCrMemoLine.SetRange("Document No.", SalesCrMemoHeader."No.");
+        SalesCrMemoLine.FindFirst();
+        CreateVATClauseWithVATEXCode(SalesCrMemoLine."VAT Bus. Posting Group", SalesCrMemoLine."VAT Prod. Posting Group");
+
+        // [WHEN] Export XRechnung Electronic Document.
+        ExportCreditMemo(SalesCrMemoHeader, TempXMLBuffer);
+
+        // [THEN] TaxExemptionReasonCode and TaxExemptionReason are exported with correct values
+        Path := CrMemoTaxCategoryTok + '/cbc:TaxExemptionReasonCode';
+        Assert.AreEqual('VATEX-EU-O', GetNodeByPathWithError(TempXMLBuffer, Path), StrSubstNo(IncorrectValueErr, Path));
+        Path := CrMemoTaxCategoryTok + '/cbc:TaxExemptionReason';
+        Assert.AreEqual('Not subject to VAT', GetNodeByPathWithError(TempXMLBuffer, Path), StrSubstNo(IncorrectValueErr, Path));
     end;
     #endregion
 
@@ -2891,6 +2954,23 @@ codeunit 13918 "XRechnung XML Document Tests"
         if VarDate = 0D then
             exit('1753-01-01');
         exit(Format(VarDate, 0, '<Year4>-<Month,2>-<Day,2>'));
+    end;
+
+    local procedure CreateVATClauseWithVATEXCode(VATBusPostingGroup: Code[20]; VATProductPostingGroup: Code[20])
+    var
+        VATClause: Record "VAT Clause";
+        VATPostingSetup: Record "VAT Posting Setup";
+        VATClauseCode: Code[10];
+    begin
+        VATClauseCode := LibraryUtility.GenerateRandomCode(VATClause.FieldNo(Code), Database::"VAT Clause");
+        VATClause.Init();
+        VATClause.Validate(Code, VATClauseCode);
+        VATClause.Validate(Description, 'Not subject to VAT');
+        VATClause.Validate("VATEX Code", 'VATEX-EU-O');
+        VATClause.Insert(true);
+        VATPostingSetup.Get(VATBusPostingGroup, VATProductPostingGroup);
+        VATPostingSetup.Validate("VAT Clause Code", VATClauseCode);
+        VATPostingSetup.Modify(true);
     end;
 
     local procedure Initialize();

--- a/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
+++ b/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
@@ -9,12 +9,15 @@ using Microsoft.eServices.EDocument;
 using Microsoft.eServices.EDocument.Integration;
 using Microsoft.Finance.Currency;
 using Microsoft.Finance.GeneralLedger.Setup;
+using Microsoft.Finance.VAT.Clause;
+using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
 using Microsoft.Foundation.PaymentTerms;
 using Microsoft.Foundation.Reporting;
 using Microsoft.Foundation.UOM;
 using Microsoft.Inventory.Location;
+using Microsoft.Peppol;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 using Microsoft.Sales.Customer;
@@ -469,6 +472,36 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
     end;
 
     [Test]
+    procedure ExportPostedSalesInvoiceInZUGFeRDFormatVerifyVATEXCodeAndExemptionReason();
+    var
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        SalesInvoiceLine: Record "Sales Invoice Line";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        TradeTaxTok: Label '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax', Locked = true;
+        Path: Text;
+    begin
+        // [SCENARIO] Export posted sales invoice creates electronic document in ZUGFeRD format with VATEX code and exemption reason from VAT Clause
+        Initialize();
+
+        // [GIVEN] Create and Post Sales Invoice.
+        SalesInvoiceHeader.Get(CreateAndPostSalesDocument("Sales Document Type"::Invoice, Enum::"Sales Line Type"::Item, false));
+
+        // [GIVEN] VAT Clause with VATEX Code 'VATEX-EU-O' and Description 'Not subject to VAT' linked to the VAT Posting Setup
+        SalesInvoiceLine.SetRange("Document No.", SalesInvoiceHeader."No.");
+        SalesInvoiceLine.FindFirst();
+        CreateVATClauseWithVATEXCode(SalesInvoiceLine."VAT Bus. Posting Group", SalesInvoiceLine."VAT Prod. Posting Group");
+
+        // [WHEN] Export ZUGFeRD Electronic Document.
+        ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
+
+        // [THEN] ExemptionReasonCode and ExemptionReason are exported with correct values
+        Path := TradeTaxTok + '/ram:ExemptionReasonCode';
+        Assert.AreEqual('VATEX-EU-O', GetNodeByPathWithError(TempXMLBuffer, Path), StrSubstNo(IncorrectValueErr, Path));
+        Path := TradeTaxTok + '/ram:ExemptionReason';
+        Assert.AreEqual('Not subject to VAT', GetNodeByPathWithError(TempXMLBuffer, Path), StrSubstNo(IncorrectValueErr, Path));
+    end;
+
+    [Test]
     procedure PrintPostedSalesInvoiceWithCustomReportLayout();
     var
         SalesInvoiceHeader: Record "Sales Invoice Header";
@@ -791,6 +824,36 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
 
         // [THEN] ZUGFeRD Electronic Document is created with 2 cr.memo lines
         VerifyCrMemoLine(SalesCrMemoHeader, TempXMLBuffer);
+    end;
+
+    [Test]
+    procedure ExportPostedSalesCrMemoInZUGFeRDFormatVerifyVATEXCodeAndExemptionReason();
+    var
+        SalesCrMemoHeader: Record "Sales Cr.Memo Header";
+        SalesCrMemoLine: Record "Sales Cr.Memo Line";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        TradeTaxTok: Label '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax', Locked = true;
+        Path: Text;
+    begin
+        // [SCENARIO] Export posted sales cr. memo creates electronic document in ZUGFeRD format with VATEX code and exemption reason from VAT Clause
+        Initialize();
+
+        // [GIVEN] Create and Post Sales Credit Memo.
+        SalesCrMemoHeader.Get(CreateAndPostSalesDocument("Sales Document Type"::"Credit Memo", Enum::"Sales Line Type"::Item, false));
+
+        // [GIVEN] VAT Clause with VATEX Code 'VATEX-EU-O' and Description 'Not subject to VAT' linked to the VAT Posting Setup
+        SalesCrMemoLine.SetRange("Document No.", SalesCrMemoHeader."No.");
+        SalesCrMemoLine.FindFirst();
+        CreateVATClauseWithVATEXCode(SalesCrMemoLine."VAT Bus. Posting Group", SalesCrMemoLine."VAT Prod. Posting Group");
+
+        // [WHEN] Export ZUGFeRD Electronic Document.
+        ExportCreditMemo(SalesCrMemoHeader, TempXMLBuffer);
+
+        // [THEN] ExemptionReasonCode and ExemptionReason are exported with correct values
+        Path := TradeTaxTok + '/ram:ExemptionReasonCode';
+        Assert.AreEqual('VATEX-EU-O', GetNodeByPathWithError(TempXMLBuffer, Path), StrSubstNo(IncorrectValueErr, Path));
+        Path := TradeTaxTok + '/ram:ExemptionReason';
+        Assert.AreEqual('Not subject to VAT', GetNodeByPathWithError(TempXMLBuffer, Path), StrSubstNo(IncorrectValueErr, Path));
     end;
     #endregion
 
@@ -2760,6 +2823,23 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         if VarDate = 0D then
             exit('17530101');
         exit(Format(VarDate, 0, '<Year4><Month,2><Day,2>'));
+    end;
+
+    local procedure CreateVATClauseWithVATEXCode(VATBusPostingGroup: Code[20]; VATProductPostingGroup: Code[20])
+    var
+        VATClause: Record "VAT Clause";
+        VATPostingSetup: Record "VAT Posting Setup";
+        VATClauseCode: Code[10];
+    begin
+        VATClauseCode := LibraryUtility.GenerateRandomCode(VATClause.FieldNo(Code), Database::"VAT Clause");
+        VATClause.Init();
+        VATClause.Validate(Code, VATClauseCode);
+        VATClause.Validate(Description, 'Not subject to VAT');
+        VATClause.Validate("VATEX Code", 'VATEX-EU-O');
+        VATClause.Insert(true);
+        VATPostingSetup.Get(VATBusPostingGroup, VATProductPostingGroup);
+        VATPostingSetup.Validate("VAT Clause Code", VATClauseCode);
+        VATPostingSetup.Modify(true);
     end;
 
     local procedure Initialize();


### PR DESCRIPTION
**Important**: Depending on : https://github.com/microsoft/BCApps/pull/7640

<!-- Thank you for submitting a Pull Request. If you're new to contributing to AlAppExtensions please read our pull request guideline below
* https://github.com/microsoft/ALAppExtensions/blob/main/CONTRIBUTING.md
-->
#### Summary <!-- Provide a general summary of your changes -->
**VATEX Implementation:**
- Export dynamic VATEX code and tax exemption reason from VAT Posting Setup
- Support 'Not Subject to VAT' (Category O) via VAT Clause integration
- Added comprehensive test coverage for XRechnung and ZUGFeRD with all VATEX codes

**EN16931 & BR-DE Compliance Fixes:**
- BR-O-02: Skip Seller/Buyer VAT ID only when ALL invoice lines are category 'O' (fixed critical bug: previously skipped if ANY line was 'O', breaking mixed invoices)
- BR-O-05: Remove tax percent from line-level 'O' category elements
- BR-DE-14: Always include tax percent at document level

**Code Architecture:**
- Split tax category insertion into line-level and document-level procedures
- Separated AllowanceCharge handling by context (6-param line-level, 11-param document-level)
- Thread document language code to GetVATClauseInfo for localized exemption descriptions
- Add IsTaxCategoryNotSubjectToVAT() helper to centralise the 'O' value

**Files Changed:**
- XRechnung: Export logic refactored for UBL compliance
- ZUGFeRD: CII format aligned with EN16931 requirements
- Tests: Added VATEX scenarios for all supported exemption categories

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #29863
Fixes [AB#630660](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630660)


