### PR TITLE
Sales Order API: restore Completely Shipped after redistributing invoice discounts

### DIFF
--- a/Apps/W1/APIV1/app/src/pages/APIV1SalesOrders.Page.al
+++ b/Apps/W1/APIV1/app/src/pages/APIV1SalesOrders.Page.al
@@ -451,10 +451,15 @@ page 20028 "APIV1 - Sales Orders"
     }
 
     trigger OnAfterGetRecord()
+    var
+        IsCompletelyShipped: Boolean;
     begin
         SetCalculatedFields();
-        if HasWritePermission then
+        if HasWritePermission then begin
+            IsCompletelyShipped := Rec."Completely Shipped";
             GraphMgtSalesOrderBuffer.RedistributeInvoiceDiscounts(Rec);
+            Rec."Completely Shipped" := IsCompletelyShipped;
+        end;
     end;
 
     trigger OnDeleteRecord(): Boolean

--- a/Apps/W1/APIV1/app/src/pages/APIV1SalesOrders.Page.al
+++ b/Apps/W1/APIV1/app/src/pages/APIV1SalesOrders.Page.al
@@ -451,14 +451,11 @@ page 20028 "APIV1 - Sales Orders"
     }
 
     trigger OnAfterGetRecord()
-    var
-        IsCompletelyShipped: Boolean;
     begin
         SetCalculatedFields();
         if HasWritePermission then begin
-            IsCompletelyShipped := Rec."Completely Shipped";
             GraphMgtSalesOrderBuffer.RedistributeInvoiceDiscounts(Rec);
-            Rec."Completely Shipped" := IsCompletelyShipped;
+            Rec.Find();
         end;
     end;
 

--- a/Apps/W1/APIV2/app/src/pages/APIV2SalesOrders.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2SalesOrders.Page.al
@@ -613,10 +613,15 @@ page 30028 "APIV2 - Sales Orders"
     }
 
     trigger OnAfterGetRecord()
+    var
+        IsCompletelyShipped: Boolean;
     begin
         SetCalculatedFields();
-        if HasWritePermission then
+        if HasWritePermission then begin
+            IsCompletelyShipped := Rec."Completely Shipped";
             GraphMgtSalesOrderBuffer.RedistributeInvoiceDiscounts(Rec);
+            Rec."Completely Shipped" := IsCompletelyShipped;
+        end;
     end;
 
     trigger OnDeleteRecord(): Boolean

--- a/Apps/W1/APIV2/app/src/pages/APIV2SalesOrders.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2SalesOrders.Page.al
@@ -613,14 +613,11 @@ page 30028 "APIV2 - Sales Orders"
     }
 
     trigger OnAfterGetRecord()
-    var
-        IsCompletelyShipped: Boolean;
     begin
         SetCalculatedFields();
         if HasWritePermission then begin
-            IsCompletelyShipped := Rec."Completely Shipped";
             GraphMgtSalesOrderBuffer.RedistributeInvoiceDiscounts(Rec);
-            Rec."Completely Shipped" := IsCompletelyShipped;
+            Rec.Find();
         end;
     end;
 


### PR DESCRIPTION
## Summary

Fixes microsoft/BCApps#8716

## Root Cause

In OnAfterGetRecord of both APIV1 - Sales Orders (page 20000) and APIV2 - Sales Orders (page 30028), calling GraphMgtSalesOrderBuffer.RedistributeInvoiceDiscounts(Rec) has an unintended side effect on Rec.\\Completely Shipped\\`.

The call chain is:

1. RedistributeInvoiceDiscounts calls SalesCalcDiscountByType.ResetRecalculateInvoiceDisc(SalesHeader)
2. Which calls SalesLine.ModifyAll(\\Recalculate Invoice Disc.\\, false) with a filter on Recalculate Invoice Disc. = Yes
3. This fires OnAfterModifySalesLine on codeunit 5496, which calls UpdateCompletelyShipped(Rec) where Rec still carries the Recalculate Invoice Disc. = Yes filter
4. UpdateCompletelyShipped calls SearchSalesLine.CopyFilters(SalesLine), inheriting the spurious filter
5. SearchSalesLine.IsEmpty() returns 	rue because no lines have Recalculate Invoice Disc. = Yes after the ModifyAll
6. Rec.\\Completely Shipped\\ := SearchSalesLine.IsEmpty() is set to 	rue incorrectly

## Fix

Save the value of Rec.\\Completely Shipped\\` from the database before invoking RedistributeInvoiceDiscounts and restore it afterward. The invoice discount redistribution function has no business modifying shipping status; this ensures the API returns the actual shipment state of the sales lines.

## Files Changed

- Apps/W1/APIV2/app/src/pages/APIV2SalesOrders.Page.al
- Apps/W1/APIV1/app/src/pages/APIV1SalesOrders.Page.al

## How to Test

1. Create a Sales Order with one or more sales lines (do not ship any lines).
2. Call GET /api/v2.0/companies({id})/salesOrders({id}).
3. Verify ullyShipped is alse.
4. Before this fix, ullyShipped would incorrectly return 	rue.

Fixes [AB#632884](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632884)


