### PR TITLE
APIV2: replace LoadFields with AddLoadFields

### DIFF
--- a/Apps/W1/APIV2/app/src/pages/APIV2BankAccounts.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2BankAccounts.Page.al
@@ -108,6 +108,11 @@ page 30051 "APIV2 - Bank Accounts"
         CurrencyCodeDoesNotMatchACurrencyErr: Label 'The "currencyCode" does not match to a Currency.', Comment = 'currencyCode is a field name and should not be translated.';
         CurrencyValuesDontMatchErr: Label 'The currency values do not match to a specific Currency.';
 
+    trigger OnOpenPage()
+    begin
+        Rec.AddLoadFields("Currency Code");
+    end;
+
     trigger OnAfterGetRecord()
     begin
         LoadCurrencyInformation();
@@ -127,7 +132,6 @@ page 30051 "APIV2 - Bank Accounts"
     var
         GraphMgtGeneralTools: Codeunit "Graph Mgt - General Tools";
     begin
-        Rec.LoadFields("Currency Code");
         CurrencyCodeTxt := GraphMgtGeneralTools.TranslateNAVCurrencyCodeToCurrencyCode(LCYCurrencyCode, Rec."Currency Code");
     end;
 }

--- a/Apps/W1/APIV2/app/src/pages/APIV2BankAccounts.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2BankAccounts.Page.al
@@ -108,7 +108,7 @@ page 30051 "APIV2 - Bank Accounts"
         CurrencyCodeDoesNotMatchACurrencyErr: Label 'The "currencyCode" does not match to a Currency.', Comment = 'currencyCode is a field name and should not be translated.';
         CurrencyValuesDontMatchErr: Label 'The currency values do not match to a specific Currency.';
 
-    trigger OnOpenPage()
+    trigger OnInit()
     begin
         Rec.AddLoadFields("Currency Code");
     end;

--- a/Apps/W1/APIV2/app/src/pages/APIV2PurchaseCreditMemos.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2PurchaseCreditMemos.Page.al
@@ -616,6 +616,7 @@ page 30083 "APIV2 - Purchase Credit Memos"
     begin
         CheckDataUpgrade();
         SetPermissionsFilters();
+        Rec.AddLoadFields("Applies-to Doc. Type", "Currency Code");
     end;
 
     var
@@ -670,7 +671,6 @@ page 30083 "APIV2 - Purchase Credit Memos"
 
     local procedure SetCalculatedFields()
     begin
-        Rec.LoadFields("Applies-to Doc. Type", "Currency Code");
         SetInvoiceId();
         CurrencyCodeTxt := GraphMgtGeneralTools.TranslateNAVCurrencyCodeToCurrencyCode(LCYCurrencyCode, Rec."Currency Code");
     end;

--- a/Apps/W1/APIV2/app/src/pages/APIV2PurchaseInvoices.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2PurchaseInvoices.Page.al
@@ -595,6 +595,7 @@ page 30042 "APIV2 - Purchase Invoices"
     trigger OnOpenPage()
     begin
         CheckPermissions();
+        Rec.AddLoadFields("Currency Code");
     end;
 
     var
@@ -622,7 +623,6 @@ page 30042 "APIV2 - Purchase Invoices"
 
     local procedure SetCalculatedFields()
     begin
-        Rec.LoadFields("Currency Code");
         CurrencyCodeTxt := GraphMgtGeneralTools.TranslateNAVCurrencyCodeToCurrencyCode(LCYCurrencyCode, Rec."Currency Code");
     end;
 

--- a/Apps/W1/APIV2/app/src/pages/APIV2SalesCreditMemos.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2SalesCreditMemos.Page.al
@@ -638,6 +638,7 @@ page 30038 "APIV2 - Sales Credit Memos"
     trigger OnOpenPage()
     begin
         SetPemissionsFilters();
+        Rec.AddLoadFields("Applies-to Doc. Type", "Currency Code");
     end;
 
     var
@@ -691,7 +692,6 @@ page 30038 "APIV2 - Sales Credit Memos"
 
     local procedure SetCalculatedFields()
     begin
-        Rec.LoadFields("Applies-to Doc. Type", "Currency Code");
         SetInvoiceId();
         CurrencyCodeTxt := GraphMgtGeneralTools.TranslateNAVCurrencyCodeToCurrencyCode(LCYCurrencyCode, Rec."Currency Code");
     end;

--- a/Apps/W1/APIV2/app/src/pages/APIV2SalesInvoices.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2SalesInvoices.Page.al
@@ -718,6 +718,7 @@ page 30012 "APIV2 - Sales Invoices"
     trigger OnOpenPage()
     begin
         SetPermissionFilters();
+        Rec.AddLoadFields("No.", "Currency Code", "Amount Including VAT", Posted, Status);
     end;
 
     var
@@ -772,7 +773,6 @@ page 30012 "APIV2 - Sales Invoices"
 
     local procedure SetCalculatedFields()
     begin
-        Rec.LoadFields("No.", "Currency Code", "Amount Including VAT", Posted, Status);
         GetRemainingAmount();
         CurrencyCodeTxt := GraphMgtGeneralTools.TranslateNAVCurrencyCodeToCurrencyCode(LCYCurrencyCode, Rec."Currency Code");
     end;

--- a/Apps/W1/APIV2/app/src/pages/APIV2SalesQuotes.Page.al
+++ b/Apps/W1/APIV2/app/src/pages/APIV2SalesQuotes.Page.al
@@ -679,6 +679,7 @@ page 30037 "APIV2 - Sales Quotes"
     trigger OnOpenPage()
     begin
         CheckPermissions();
+        Rec.AddLoadFields("Currency Code");
     end;
 
     var
@@ -717,7 +718,6 @@ page 30037 "APIV2 - Sales Quotes"
 
     local procedure SetCalculatedFields()
     begin
-        Rec.LoadFields("Currency Code");
         CurrencyCodeTxt := GraphMgtGeneralTools.TranslateNAVCurrencyCodeToCurrencyCode(LCYCurrencyCode, Rec."Currency Code");
     end;
 


### PR DESCRIPTION
## Summary

APIV2 pages call Rec.LoadFields(...) inside SetCalculatedFields and LoadCurrencyInformation procedures, which are themselves called from OnAfterGetRecord. This causes a JIT (Just-In-Time) read from the database for every record fetched, resulting in telemetry errors under concurrent API load as reported in issue microsoft/BCApps#8709.

## Root Cause

Rec.LoadFields in OnAfterGetRecord forces a supplemental DB read per record. When many records are fetched concurrently the platform logs JIT load warnings and the performance degrades unnecessarily.

## Fix

Replace Rec.LoadFields with Rec.AddLoadFields placed in OnOpenPage. AddLoadFields declares which fields must be included in the initial record-set query for the entire page session. The fields are fetched once alongside the primary key columns, removing the per-record JIT reads entirely.

Changes per page:
- APIV2SalesInvoices - fields No., Currency Code, Amount Including VAT, Posted, Status
- APIV2SalesCreditMemos - fields Applies-to Doc. Type, Currency Code
- APIV2SalesQuotes - field Currency Code
- APIV2PurchaseInvoices - field Currency Code
- APIV2PurchaseCreditMemos - fields Applies-to Doc. Type, Currency Code
- APIV2BankAccounts - field Currency Code (new OnOpenPage trigger added)

There is no behavioral change. The same fields are loaded; only the loading strategy changes from JIT per-record to eager per-session.

Fixes microsoft/BCApps#8709

Fixes [AB#632881](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632881)



