### PR TITLE
NO SAF-T: skip currency export when currency matches LCY code

### DIFF
--- a/Apps/NO/NorwegianSAFT/app/src/Export Engine/GenerateSAFT13File.Codeunit.al
+++ b/Apps/NO/NorwegianSAFT/app/src/Export Engine/GenerateSAFT13File.Codeunit.al
@@ -1076,6 +1076,7 @@ codeunit 10692 "Generate SAF-T 1.3 File"
         CustLedgEntry: Record "Cust. Ledger Entry";
         VendLedgEntry: Record "Vendor Ledger Entry";
         BankAccLedgEntry: Record "Bank Account Ledger Entry";
+        GeneralLedgerSetup: Record "General Ledger Setup";
     begin
         CurrencyCode := '';
         ExchangeRate := 0;
@@ -1083,6 +1084,7 @@ codeunit 10692 "Generate SAF-T 1.3 File"
         EntryAmountLCY := 0;
         if not SAFTExportHeader."Export Currency Information" then
             exit;
+        GeneralLedgerSetup.Get();
 
         if GLEntry."Source Type" in [GLEntry."Source Type"::Customer, GLEntry."Source Type"::" "] then begin
             CustLedgEntry.SetRange("Transaction No.", GLEntry."Transaction No.");
@@ -1090,6 +1092,8 @@ codeunit 10692 "Generate SAF-T 1.3 File"
             if not CustLedgEntry.FindFirst() then
                 exit;
             if CustLedgEntry."Currency Code" = '' then
+                exit;
+            if CustLedgEntry."Currency Code" = GeneralLedgerSetup."LCY Code" then
                 exit;
             CustLedgEntry.CalcFields(Amount, "Amount (LCY)");
             if CustLedgEntry.Amount = 0 then
@@ -1109,6 +1113,8 @@ codeunit 10692 "Generate SAF-T 1.3 File"
                 exit;
             if VendLedgEntry."Currency Code" = '' then
                 exit;
+            if VendLedgEntry."Currency Code" = GeneralLedgerSetup."LCY Code" then
+                exit;
             VendLedgEntry.CalcFields(Amount, "Amount (LCY)");
             if VendLedgEntry.Amount = 0 then
                 exit;
@@ -1126,6 +1132,8 @@ codeunit 10692 "Generate SAF-T 1.3 File"
             if not BankAccLedgEntry.FindFirst() then
                 exit;
             if BankAccLedgEntry."Currency Code" = '' then
+                exit;
+            if BankAccLedgEntry."Currency Code" = GeneralLedgerSetup."LCY Code" then
                 exit;
             if BankAccLedgEntry.Amount = 0 then
                 exit;

--- a/Apps/NO/NorwegianSAFT/app/src/Export Engine/GenerateSAFTFile.Codeunit.al
+++ b/Apps/NO/NorwegianSAFT/app/src/Export Engine/GenerateSAFTFile.Codeunit.al
@@ -1070,6 +1070,7 @@ codeunit 10673 "Generate SAF-T File"
         CustLedgEntry: Record "Cust. Ledger Entry";
         VendLedgEntry: Record "Vendor Ledger Entry";
         BankAccLedgEntry: Record "Bank Account Ledger Entry";
+        GeneralLedgerSetup: Record "General Ledger Setup";
     begin
         CurrencyCode := '';
         ExchangeRate := 0;
@@ -1077,6 +1078,7 @@ codeunit 10673 "Generate SAF-T File"
         EntryAmountLCY := 0;
         if not SAFTExportHeader."Export Currency Information" then
             exit;
+        GeneralLedgerSetup.Get();
 
         if GLEntry."Source Type" in [GLEntry."Source Type"::Customer, GLEntry."Source Type"::" "] then begin
             CustLedgEntry.SetRange("Transaction No.", GLEntry."Transaction No.");
@@ -1084,6 +1086,8 @@ codeunit 10673 "Generate SAF-T File"
             if not CustLedgEntry.FindFirst() then
                 exit;
             if CustLedgEntry."Currency Code" = '' then
+                exit;
+            if CustLedgEntry."Currency Code" = GeneralLedgerSetup."LCY Code" then
                 exit;
             CustLedgEntry.CalcFields(Amount, "Amount (LCY)");
             if CustLedgEntry.Amount = 0 then
@@ -1103,6 +1107,8 @@ codeunit 10673 "Generate SAF-T File"
                 exit;
             if VendLedgEntry."Currency Code" = '' then
                 exit;
+            if VendLedgEntry."Currency Code" = GeneralLedgerSetup."LCY Code" then
+                exit;
             VendLedgEntry.CalcFields(Amount, "Amount (LCY)");
             if VendLedgEntry.Amount = 0 then
                 exit;
@@ -1120,6 +1126,8 @@ codeunit 10673 "Generate SAF-T File"
             if not BankAccLedgEntry.FindFirst() then
                 exit;
             if BankAccLedgEntry."Currency Code" = '' then
+                exit;
+            if BankAccLedgEntry."Currency Code" = GeneralLedgerSetup."LCY Code" then
                 exit;
             if BankAccLedgEntry.Amount = 0 then
                 exit;

--- a/Apps/NO/NorwegianSAFT/test/src/SAFTXMLTests.Codeunit.al
+++ b/Apps/NO/NorwegianSAFT/test/src/SAFTXMLTests.Codeunit.al
@@ -1835,6 +1835,201 @@ codeunit 148103 "SAF-T XML Tests"
             Abs(GenJournalLine."Amount (LCY)"), GenJournalLine."Currency Factor");
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmYesHandler')]
+    procedure VendLCYCurrencyCodeNotExportedInCurrencyBlock()
+    var
+        SAFTMappingRange: Record "SAF-T Mapping Range";
+        SAFTExportHeader: Record "SAF-T Export Header";
+        SAFTExportLine: Record "SAF-T Export Line";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        TempChildXMLBuffer: Record "XML Buffer" temporary;
+        GLAccount: Record "G/L Account";
+        Vendor: Record Vendor;
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GLEntry: Record "G/L Entry";
+        DocNo: Code[20];
+        GLEntryNo: Integer;
+        TransactionNo: Integer;
+        AmountLCY: Decimal;
+    begin
+        // [FEATURE] [Currency] [Purchase]
+        // [SCENARIO 26554] No currency information is exported for a vendor ledger entry when currency code equals the company LCY code
+        // and "Export Currency Information" option is enabled in the SAF-T export card
+
+        Initialize();
+
+        SAFTTestHelper.SetupSAFT(SAFTMappingRange, SAFTMappingType::"Four Digit Standard Account", 10);
+        SAFTTestHelper.MatchGLAccountsFourDigit(SAFTMappingRange.Code);
+        SAFTTestHelper.CreateSAFTExportHeader(SAFTExportHeader, SAFTMappingRange.Code);
+        GeneralLedgerSetup.Get();
+
+        DocNo := LibraryUtility.GenerateGUID();
+        GLAccount.SetRange("Income/Balance", GLAccount."Income/Balance"::"Balance Sheet");
+        GLAccount.FindFirst();
+        Vendor.FindFirst();
+        SAFTTestHelper.IncludesNoSourceCodeToTheFirstSAFTSourceCode();
+
+        // [GIVEN] G/L entry for a vendor with "Transaction No." = "Y" and Amount = 100 (Amount LCY)
+        AmountLCY := LibraryRandom.RandDec(100, 2);
+        TransactionNo := GetLastUsedTransactionNo() + 1;
+        GLEntryNo :=
+            SAFTTestHelper.MockGLEntry(
+                SAFTExportHeader."Ending Date", DocNo, GLAccount."No.",
+                TransactionNo, 0, GLEntry."Gen. Posting Type"::Purchase, '',
+                '', GLEntry."Source Type"::Vendor, Vendor."No.", '', AmountLCY, 0);
+
+        // [GIVEN] Vendor ledger entry with "Currency Code" equal to the company LCY code
+        SAFTTestHelper.MockVendLedgEntry(
+            GLEntryNo, SAFTExportHeader."Starting Date", Vendor."No.", TransactionNo,
+            GeneralLedgerSetup."LCY Code", AmountLCY, AmountLCY, AmountLCY, 1, "Gen. Journal Document Type"::Invoice);
+
+        // [WHEN] Export G/L entries to the XML file
+        LibraryVariableStorage.Enqueue(GenerateSAFTFileImmediatelyQst);
+        SAFTTestHelper.RunSAFTExport(SAFTExportHeader);
+        SAFTExportLine.SetRange("Master Data", false);
+        SAFTTestHelper.FindSAFTExportLine(SAFTExportLine, SAFTExportHeader.ID);
+        SAFTTestHelper.LoadXMLBufferFromSAFTExportLine(TempXMLBuffer, SAFTExportLine);
+
+        // [THEN] The DebitAmount node has only "n1:Amount" and no currency information
+        Assert.IsTrue(
+            TempXMLBuffer.FindNodesByXPath(
+                TempXMLBuffer, '/n1:AuditFile/n1:GeneralLedgerEntries/n1:Journal/n1:Transaction/n1:Line/n1:DebitAmount'),
+            'No G/L entries exported.');
+        VerifyChildElementsCount(TempChildXMLBuffer, TempXMLBuffer, 1);
+        SAFTTestHelper.AssertCurrentElementValue(TempChildXMLBuffer, 'n1:Amount', SAFTTestHelper.FormatAmount(AmountLCY));
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmYesHandler')]
+    procedure CustLCYCurrencyCodeNotExportedInCurrencyBlock()
+    var
+        SAFTMappingRange: Record "SAF-T Mapping Range";
+        SAFTExportHeader: Record "SAF-T Export Header";
+        SAFTExportLine: Record "SAF-T Export Line";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        TempChildXMLBuffer: Record "XML Buffer" temporary;
+        GLAccount: Record "G/L Account";
+        Customer: Record Customer;
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GLEntry: Record "G/L Entry";
+        DocNo: Code[20];
+        GLEntryNo: Integer;
+        TransactionNo: Integer;
+        AmountLCY: Decimal;
+    begin
+        // [FEATURE] [Currency] [Sales]
+        // [SCENARIO 26554] No currency information is exported for a customer ledger entry when currency code equals the company LCY code
+        // and "Export Currency Information" option is enabled in the SAF-T export card
+
+        Initialize();
+
+        SAFTTestHelper.SetupSAFT(SAFTMappingRange, SAFTMappingType::"Four Digit Standard Account", 10);
+        SAFTTestHelper.MatchGLAccountsFourDigit(SAFTMappingRange.Code);
+        SAFTTestHelper.CreateSAFTExportHeader(SAFTExportHeader, SAFTMappingRange.Code);
+        GeneralLedgerSetup.Get();
+
+        DocNo := LibraryUtility.GenerateGUID();
+        GLAccount.SetRange("Income/Balance", GLAccount."Income/Balance"::"Balance Sheet");
+        GLAccount.FindFirst();
+        Customer.FindFirst();
+        SAFTTestHelper.IncludesNoSourceCodeToTheFirstSAFTSourceCode();
+
+        // [GIVEN] G/L entry for a customer with "Transaction No." = "Y" and Amount = 100 (Amount LCY)
+        AmountLCY := LibraryRandom.RandDec(100, 2);
+        TransactionNo := GetLastUsedTransactionNo() + 1;
+        GLEntryNo :=
+            SAFTTestHelper.MockGLEntry(
+                SAFTExportHeader."Ending Date", DocNo, GLAccount."No.",
+                TransactionNo, 0, GLEntry."Gen. Posting Type"::Sale, '',
+                '', GLEntry."Source Type"::Customer, Customer."No.", '', AmountLCY, 0);
+
+        // [GIVEN] Customer ledger entry with "Currency Code" equal to the company LCY code
+        SAFTTestHelper.MockCustLedgEntry(
+            GLEntryNo, SAFTExportHeader."Starting Date", Customer."No.", TransactionNo,
+            GeneralLedgerSetup."LCY Code", AmountLCY, AmountLCY, AmountLCY, 1, "Gen. Journal Document Type"::Invoice);
+
+        // [WHEN] Export G/L entries to the XML file
+        LibraryVariableStorage.Enqueue(GenerateSAFTFileImmediatelyQst);
+        SAFTTestHelper.RunSAFTExport(SAFTExportHeader);
+        SAFTExportLine.SetRange("Master Data", false);
+        SAFTTestHelper.FindSAFTExportLine(SAFTExportLine, SAFTExportHeader.ID);
+        SAFTTestHelper.LoadXMLBufferFromSAFTExportLine(TempXMLBuffer, SAFTExportLine);
+
+        // [THEN] The DebitAmount node has only "n1:Amount" and no currency information
+        Assert.IsTrue(
+            TempXMLBuffer.FindNodesByXPath(
+                TempXMLBuffer, '/n1:AuditFile/n1:GeneralLedgerEntries/n1:Journal/n1:Transaction/n1:Line/n1:DebitAmount'),
+            'No G/L entries exported.');
+        VerifyChildElementsCount(TempChildXMLBuffer, TempXMLBuffer, 1);
+        SAFTTestHelper.AssertCurrentElementValue(TempChildXMLBuffer, 'n1:Amount', SAFTTestHelper.FormatAmount(AmountLCY));
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmYesHandler')]
+    procedure BankLCYCurrencyCodeNotExportedInCurrencyBlock()
+    var
+        SAFTMappingRange: Record "SAF-T Mapping Range";
+        SAFTExportHeader: Record "SAF-T Export Header";
+        SAFTExportLine: Record "SAF-T Export Line";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        TempChildXMLBuffer: Record "XML Buffer" temporary;
+        BankAccount: Record "Bank Account";
+        GLAccount: Record "G/L Account";
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GLEntry: Record "G/L Entry";
+        DocNo: Code[20];
+        GLEntryNo: Integer;
+        TransactionNo: Integer;
+        AmountLCY: Decimal;
+    begin
+        // [FEATURE] [Currency] [Bank]
+        // [SCENARIO 26554] No currency information is exported for a bank account ledger entry when currency code equals the company LCY code
+        // and "Export Currency Information" option is enabled in the SAF-T export card
+
+        Initialize();
+
+        SAFTTestHelper.SetupSAFT(SAFTMappingRange, SAFTMappingType::"Four Digit Standard Account", 10);
+        SAFTTestHelper.MatchGLAccountsFourDigit(SAFTMappingRange.Code);
+        SAFTTestHelper.CreateSAFTExportHeader(SAFTExportHeader, SAFTMappingRange.Code);
+        GeneralLedgerSetup.Get();
+
+        DocNo := LibraryUtility.GenerateGUID();
+        GLAccount.SetRange("Income/Balance", GLAccount."Income/Balance"::"Balance Sheet");
+        GLAccount.FindFirst();
+        BankAccount.FindFirst();
+        SAFTTestHelper.IncludesNoSourceCodeToTheFirstSAFTSourceCode();
+
+        // [GIVEN] G/L entry for a bank account with "Transaction No." = "Y" and Amount = 100 (Amount LCY)
+        AmountLCY := LibraryRandom.RandDec(100, 2);
+        TransactionNo := GetLastUsedTransactionNo() + 1;
+        GLEntryNo :=
+            SAFTTestHelper.MockGLEntry(
+                SAFTExportHeader."Ending Date", DocNo, GLAccount."No.",
+                TransactionNo, 0, GLEntry."Gen. Posting Type"::Sale, '',
+                '', GLEntry."Source Type"::"Bank Account", BankAccount."No.", '', AmountLCY, 0);
+
+        // [GIVEN] Bank account ledger entry with "Currency Code" equal to the company LCY code
+        SAFTTestHelper.MockBankLedgEntry(
+            GLEntryNo, SAFTExportHeader."Starting Date", BankAccount."No.", TransactionNo,
+            GeneralLedgerSetup."LCY Code", AmountLCY, AmountLCY, "Gen. Journal Document Type"::Invoice);
+
+        // [WHEN] Export G/L entries to the XML file
+        LibraryVariableStorage.Enqueue(GenerateSAFTFileImmediatelyQst);
+        SAFTTestHelper.RunSAFTExport(SAFTExportHeader);
+        SAFTExportLine.SetRange("Master Data", false);
+        SAFTTestHelper.FindSAFTExportLine(SAFTExportLine, SAFTExportHeader.ID);
+        SAFTTestHelper.LoadXMLBufferFromSAFTExportLine(TempXMLBuffer, SAFTExportLine);
+
+        // [THEN] The DebitAmount node has only "n1:Amount" and no currency information
+        Assert.IsTrue(
+            TempXMLBuffer.FindNodesByXPath(
+                TempXMLBuffer, '/n1:AuditFile/n1:GeneralLedgerEntries/n1:Journal/n1:Transaction/n1:Line/n1:DebitAmount'),
+            'No G/L entries exported.');
+        VerifyChildElementsCount(TempChildXMLBuffer, TempXMLBuffer, 1);
+        SAFTTestHelper.AssertCurrentElementValue(TempChildXMLBuffer, 'n1:Amount', SAFTTestHelper.FormatAmount(AmountLCY));
+    end;
+
     local procedure Initialize()
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"SAF-T XML Tests");

--- a/Apps/NO/NorwegianSAFT/test/src/SAFTXMLTests13.Codeunit.al
+++ b/Apps/NO/NorwegianSAFT/test/src/SAFTXMLTests13.Codeunit.al
@@ -1922,6 +1922,201 @@ codeunit 148110 "SAF-T XML Tests 1.3"
         SAFTTestHelper.AssertCurrentElementValue(TempChildXMLBuffer, 'n1:Amount', SAFTTestHelper.FormatAmount(PaymentAmount));
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmYesHandler')]
+    procedure VendLCYCurrencyCodeNotExportedInCurrencyBlock()
+    var
+        SAFTMappingRange: Record "SAF-T Mapping Range";
+        SAFTExportHeader: Record "SAF-T Export Header";
+        SAFTExportLine: Record "SAF-T Export Line";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        TempChildXMLBuffer: Record "XML Buffer" temporary;
+        GLAccount: Record "G/L Account";
+        Vendor: Record Vendor;
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GLEntry: Record "G/L Entry";
+        DocNo: Code[20];
+        GLEntryNo: Integer;
+        TransactionNo: Integer;
+        AmountLCY: Decimal;
+    begin
+        // [FEATURE] [Currency] [Purchase]
+        // [SCENARIO 26554] No currency information is exported for a vendor ledger entry when currency code equals the company LCY code
+        // and "Export Currency Information" option is enabled in the SAF-T 1.3 export card
+
+        Initialize();
+
+        SAFTTestHelper.SetupSAFT(SAFTMappingRange, SAFTMappingType::"Income Statement", 10);
+        SAFTTestHelper.MatchGLAccountsFourDigit(SAFTMappingRange.Code);
+        SAFTTestHelper.CreateSAFTExportHeader(SAFTExportHeader, SAFTMappingRange.Code, Enum::"SAF-T Version"::"1.30");
+        GeneralLedgerSetup.Get();
+
+        DocNo := LibraryUtility.GenerateGUID();
+        GLAccount.SetRange("Income/Balance", GLAccount."Income/Balance"::"Balance Sheet");
+        GLAccount.FindFirst();
+        Vendor.FindFirst();
+        SAFTTestHelper.IncludesNoSourceCodeToTheFirstSAFTSourceCode();
+
+        // [GIVEN] G/L entry for a vendor with "Transaction No." = "Y" and Amount = 100 (Amount LCY)
+        AmountLCY := LibraryRandom.RandDec(100, 2);
+        TransactionNo := GetLastUsedTransactionNo() + 1;
+        GLEntryNo :=
+            SAFTTestHelper.MockGLEntry(
+                SAFTExportHeader."Ending Date", DocNo, GLAccount."No.",
+                TransactionNo, 0, GLEntry."Gen. Posting Type"::Purchase, '',
+                '', GLEntry."Source Type"::Vendor, Vendor."No.", '', AmountLCY, 0);
+
+        // [GIVEN] Vendor ledger entry with "Currency Code" equal to the company LCY code
+        SAFTTestHelper.MockVendLedgEntry(
+            GLEntryNo, SAFTExportHeader."Starting Date", Vendor."No.", TransactionNo,
+            GeneralLedgerSetup."LCY Code", AmountLCY, AmountLCY, AmountLCY, 1, "Gen. Journal Document Type"::Invoice);
+
+        // [WHEN] Export G/L entries to the XML file
+        LibraryVariableStorage.Enqueue(GenerateSAFTFileImmediatelyQst);
+        SAFTTestHelper.RunSAFTExport(SAFTExportHeader);
+        SAFTExportLine.SetRange("Master Data", false);
+        SAFTTestHelper.FindSAFTExportLine(SAFTExportLine, SAFTExportHeader.ID);
+        SAFTTestHelper.LoadXMLBufferFromSAFTExportLine(TempXMLBuffer, SAFTExportLine);
+
+        // [THEN] The DebitAmount node has only "n1:Amount" and no currency information
+        Assert.IsTrue(
+            TempXMLBuffer.FindNodesByXPath(
+                TempXMLBuffer, '/n1:AuditFile/n1:GeneralLedgerEntries/n1:Journal/n1:Transaction/n1:Line/n1:DebitAmount'),
+            'No G/L entries exported.');
+        VerifyChildElementsCount(TempChildXMLBuffer, TempXMLBuffer, 1);
+        SAFTTestHelper.AssertCurrentElementValue(TempChildXMLBuffer, 'n1:Amount', SAFTTestHelper.FormatAmount(AmountLCY));
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmYesHandler')]
+    procedure CustLCYCurrencyCodeNotExportedInCurrencyBlock()
+    var
+        SAFTMappingRange: Record "SAF-T Mapping Range";
+        SAFTExportHeader: Record "SAF-T Export Header";
+        SAFTExportLine: Record "SAF-T Export Line";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        TempChildXMLBuffer: Record "XML Buffer" temporary;
+        Customer: Record Customer;
+        GLAccount: Record "G/L Account";
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GLEntry: Record "G/L Entry";
+        DocNo: Code[20];
+        GLEntryNo: Integer;
+        TransactionNo: Integer;
+        AmountLCY: Decimal;
+    begin
+        // [FEATURE] [Currency] [Sales]
+        // [SCENARIO 26554] No currency information is exported for a customer ledger entry when currency code equals the company LCY code
+        // and "Export Currency Information" option is enabled in the SAF-T 1.3 export card
+
+        Initialize();
+
+        SAFTTestHelper.SetupSAFT(SAFTMappingRange, SAFTMappingType::"Income Statement", 10);
+        SAFTTestHelper.MatchGLAccountsFourDigit(SAFTMappingRange.Code);
+        SAFTTestHelper.CreateSAFTExportHeader(SAFTExportHeader, SAFTMappingRange.Code, Enum::"SAF-T Version"::"1.30");
+        GeneralLedgerSetup.Get();
+
+        DocNo := LibraryUtility.GenerateGUID();
+        GLAccount.SetRange("Income/Balance", GLAccount."Income/Balance"::"Balance Sheet");
+        GLAccount.FindFirst();
+        Customer.FindFirst();
+        SAFTTestHelper.IncludesNoSourceCodeToTheFirstSAFTSourceCode();
+
+        // [GIVEN] G/L entry for a customer with "Transaction No." = "Y" and Amount = 100 (Amount LCY)
+        AmountLCY := LibraryRandom.RandDec(100, 2);
+        TransactionNo := GetLastUsedTransactionNo() + 1;
+        GLEntryNo :=
+            SAFTTestHelper.MockGLEntry(
+                SAFTExportHeader."Ending Date", DocNo, GLAccount."No.",
+                TransactionNo, 0, GLEntry."Gen. Posting Type"::Sale, '',
+                '', GLEntry."Source Type"::Customer, Customer."No.", '', AmountLCY, 0);
+
+        // [GIVEN] Customer ledger entry with "Currency Code" equal to the company LCY code
+        SAFTTestHelper.MockCustLedgEntry(
+            GLEntryNo, SAFTExportHeader."Starting Date", Customer."No.", TransactionNo,
+            GeneralLedgerSetup."LCY Code", AmountLCY, AmountLCY, AmountLCY, 1, "Gen. Journal Document Type"::Invoice);
+
+        // [WHEN] Export G/L entries to the XML file
+        LibraryVariableStorage.Enqueue(GenerateSAFTFileImmediatelyQst);
+        SAFTTestHelper.RunSAFTExport(SAFTExportHeader);
+        SAFTExportLine.SetRange("Master Data", false);
+        SAFTTestHelper.FindSAFTExportLine(SAFTExportLine, SAFTExportHeader.ID);
+        SAFTTestHelper.LoadXMLBufferFromSAFTExportLine(TempXMLBuffer, SAFTExportLine);
+
+        // [THEN] The DebitAmount node has only "n1:Amount" and no currency information
+        Assert.IsTrue(
+            TempXMLBuffer.FindNodesByXPath(
+                TempXMLBuffer, '/n1:AuditFile/n1:GeneralLedgerEntries/n1:Journal/n1:Transaction/n1:Line/n1:DebitAmount'),
+            'No G/L entries exported.');
+        VerifyChildElementsCount(TempChildXMLBuffer, TempXMLBuffer, 1);
+        SAFTTestHelper.AssertCurrentElementValue(TempChildXMLBuffer, 'n1:Amount', SAFTTestHelper.FormatAmount(AmountLCY));
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmYesHandler')]
+    procedure BankLCYCurrencyCodeNotExportedInCurrencyBlock()
+    var
+        SAFTMappingRange: Record "SAF-T Mapping Range";
+        SAFTExportHeader: Record "SAF-T Export Header";
+        SAFTExportLine: Record "SAF-T Export Line";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        TempChildXMLBuffer: Record "XML Buffer" temporary;
+        BankAccount: Record "Bank Account";
+        GLAccount: Record "G/L Account";
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GLEntry: Record "G/L Entry";
+        DocNo: Code[20];
+        GLEntryNo: Integer;
+        TransactionNo: Integer;
+        AmountLCY: Decimal;
+    begin
+        // [FEATURE] [Currency] [Bank]
+        // [SCENARIO 26554] No currency information is exported for a bank account ledger entry when currency code equals the company LCY code
+        // and "Export Currency Information" option is enabled in the SAF-T 1.3 export card
+
+        Initialize();
+
+        SAFTTestHelper.SetupSAFT(SAFTMappingRange, SAFTMappingType::"Income Statement", 10);
+        SAFTTestHelper.MatchGLAccountsFourDigit(SAFTMappingRange.Code);
+        SAFTTestHelper.CreateSAFTExportHeader(SAFTExportHeader, SAFTMappingRange.Code, Enum::"SAF-T Version"::"1.30");
+        GeneralLedgerSetup.Get();
+
+        DocNo := LibraryUtility.GenerateGUID();
+        GLAccount.SetRange("Income/Balance", GLAccount."Income/Balance"::"Balance Sheet");
+        GLAccount.FindFirst();
+        BankAccount.FindFirst();
+        SAFTTestHelper.IncludesNoSourceCodeToTheFirstSAFTSourceCode();
+
+        // [GIVEN] G/L entry for a bank account with "Transaction No." = "Y" and Amount = 100 (Amount LCY)
+        AmountLCY := LibraryRandom.RandDec(100, 2);
+        TransactionNo := GetLastUsedTransactionNo() + 1;
+        GLEntryNo :=
+            SAFTTestHelper.MockGLEntry(
+                SAFTExportHeader."Ending Date", DocNo, GLAccount."No.",
+                TransactionNo, 0, GLEntry."Gen. Posting Type"::Sale, '',
+                '', GLEntry."Source Type"::"Bank Account", BankAccount."No.", '', AmountLCY, 0);
+
+        // [GIVEN] Bank account ledger entry with "Currency Code" equal to the company LCY code
+        SAFTTestHelper.MockBankLedgEntry(
+            GLEntryNo, SAFTExportHeader."Starting Date", BankAccount."No.", TransactionNo,
+            GeneralLedgerSetup."LCY Code", AmountLCY, AmountLCY, "Gen. Journal Document Type"::Invoice);
+
+        // [WHEN] Export G/L entries to the XML file
+        LibraryVariableStorage.Enqueue(GenerateSAFTFileImmediatelyQst);
+        SAFTTestHelper.RunSAFTExport(SAFTExportHeader);
+        SAFTExportLine.SetRange("Master Data", false);
+        SAFTTestHelper.FindSAFTExportLine(SAFTExportLine, SAFTExportHeader.ID);
+        SAFTTestHelper.LoadXMLBufferFromSAFTExportLine(TempXMLBuffer, SAFTExportLine);
+
+        // [THEN] The DebitAmount node has only "n1:Amount" and no currency information
+        Assert.IsTrue(
+            TempXMLBuffer.FindNodesByXPath(
+                TempXMLBuffer, '/n1:AuditFile/n1:GeneralLedgerEntries/n1:Journal/n1:Transaction/n1:Line/n1:DebitAmount'),
+            'No G/L entries exported.');
+        VerifyChildElementsCount(TempChildXMLBuffer, TempXMLBuffer, 1);
+        SAFTTestHelper.AssertCurrentElementValue(TempChildXMLBuffer, 'n1:Amount', SAFTTestHelper.FormatAmount(AmountLCY));
+    end;
+
     local procedure Initialize()
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"SAF-T XML Tests 1.3");


### PR DESCRIPTION
## Summary

When exporting SAF-T (both v1.0 and v1.3), if a Bank Account Ledger Entry (or Customer/Vendor Ledger Entry) has a Currency Code that equals the company LCY code, the export was incorrectly writing CurrencyCode, CurrencyAmount, and ExchangeRate XML nodes for what is effectively a domestic currency entry.

The root cause is in GetFCYData: after checking for a blank Currency Code, the function did not check whether the currency equals the LCY code. A bank account explicitly configured with LCY code (e.g. NOK on a Norwegian company) would pass the blank-check and inject spurious currency XML on all G/L entries in the same transaction.

## Changes

- Added GeneralLedgerSetup.Get() in GetFCYData, called once after the Export Currency Information guard.
- Added an LCY code guard in each ledger-entry branch (Customer, Vendor, Bank Account): if the retrieved Currency Code equals GeneralLedgerSetup.LCY Code, exit immediately.
- The LCY guard is placed before CalcFields to avoid an unnecessary database round-trip when it triggers.
- Applied identically to both GenerateSAFTFile.Codeunit.al (codeunit 10673, SAF-T v1.0) and GenerateSAFT13File.Codeunit.al (codeunit 10692, SAF-T v1.3).

## Related Issue

Fixes #26554

Fixes [AB#632882](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632882)



