### PR TITLE
[DE E-Document] ZUGFeRD: Include Seller Item Number (BT-155) in XML Export

### DIFF
--- a/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
+++ b/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
@@ -924,6 +924,8 @@ codeunit 13917 "Export ZUGFeRD Document"
             InvoiceLineElement.Add(AssociatedDocumentLineElement);
 
             SpecifiedTradeProductElement := XmlElement.Create('SpecifiedTradeProduct', XmlNamespaceRAM);
+            if SalesInvoiceLine."No." <> '' then
+                SpecifiedTradeProductElement.Add(XmlElement.Create('SellerAssignedID', XmlNamespaceRAM, SalesInvoiceLine."No."));
             SpecifiedTradeProductElement.Add(XmlElement.Create('Name', XmlNamespaceRAM, SalesInvoiceLine.Description));
             InvoiceLineElement.Add(SpecifiedTradeProductElement);
 
@@ -1008,6 +1010,8 @@ codeunit 13917 "Export ZUGFeRD Document"
             CrMemoLineElement.Add(AssociatedDocumentLineElement);
 
             SpecifiedTradeProductElement := XmlElement.Create('SpecifiedTradeProduct', XmlNamespaceRAM);
+            if SalesCrMemoLine."No." <> '' then
+                SpecifiedTradeProductElement.Add(XmlElement.Create('SellerAssignedID', XmlNamespaceRAM, SalesCrMemoLine."No."));
             SpecifiedTradeProductElement.Add(XmlElement.Create('Name', XmlNamespaceRAM, SalesCrMemoLine.Description));
             CrMemoLineElement.Add(SpecifiedTradeProductElement);
 

--- a/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
+++ b/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
@@ -466,6 +466,29 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
     end;
 
     [Test]
+    procedure ExportPostedSalesInvoiceInZUGFeRDFormatVerifySellerAssignedID();
+    var
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        SalesInvoiceLine: Record "Sales Invoice Line";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        SellerAssignedIDPathTok: Label '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedTradeProduct/ram:SellerAssignedID', Locked = true;
+    begin
+        // [SCENARIO] Export posted sales invoice creates electronic document in ZUGFeRD format with seller item number (BT-155) in invoice line
+        Initialize();
+
+        // [GIVEN] Create and Post Sales Invoice with an item line.
+        SalesInvoiceHeader.Get(CreateAndPostSalesDocument("Sales Document Type"::Invoice, Enum::"Sales Line Type"::Item, false));
+
+        // [WHEN] Export ZUGFeRD Electronic Document.
+        ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
+
+        // [THEN] ZUGFeRD Electronic Document contains the seller item number (BT-155) in ram:SpecifiedTradeProduct/ram:SellerAssignedID.
+        SalesInvoiceLine.SetRange("Document No.", SalesInvoiceHeader."No.");
+        SalesInvoiceLine.FindFirst();
+        Assert.AreEqual(SalesInvoiceLine."No.", GetNodeByPathWithError(TempXMLBuffer, SellerAssignedIDPathTok), StrSubstNo(IncorrectValueErr, SellerAssignedIDPathTok));
+    end;
+
+    [Test]
     procedure ExportPostedSalesInvoiceInZUGFeRDFormatVerifyInvoiceLineWithLineDiscount();
     var
         SalesInvoiceHeader: Record "Sales Invoice Header";
@@ -868,6 +891,30 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         // [THEN] ZUGFeRD Electronic Document is created with 2 cr.memo lines
         VerifyCrMemoLine(SalesCrMemoHeader, TempXMLBuffer);
     end;
+
+    [Test]
+    procedure ExportPostedSalesCrMemoInZUGFeRDFormatVerifySellerAssignedID();
+    var
+        SalesCrMemoHeader: Record "Sales Cr.Memo Header";
+        SalesCrMemoLine: Record "Sales Cr.Memo Line";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        SellerAssignedIDPathTok: Label '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedTradeProduct/ram:SellerAssignedID', Locked = true;
+    begin
+        // [SCENARIO] Export posted sales cr. memo creates electronic document in ZUGFeRD format with seller item number (BT-155) in cr. memo line
+        Initialize();
+
+        // [GIVEN] Create and Post sales cr. memo with an item line.
+        SalesCrMemoHeader.Get(CreateAndPostSalesDocument("Sales Document Type"::"Credit Memo", Enum::"Sales Line Type"::Item, false));
+
+        // [WHEN] Export ZUGFeRD Electronic Document.
+        ExportCreditMemo(SalesCrMemoHeader, TempXMLBuffer);
+
+        // [THEN] ZUGFeRD Electronic Document contains the seller item number (BT-155) in ram:SpecifiedTradeProduct/ram:SellerAssignedID.
+        SalesCrMemoLine.SetRange("Document No.", SalesCrMemoHeader."No.");
+        SalesCrMemoLine.FindFirst();
+        Assert.AreEqual(SalesCrMemoLine."No.", GetNodeByPathWithError(TempXMLBuffer, SellerAssignedIDPathTok), StrSubstNo(IncorrectValueErr, SellerAssignedIDPathTok));
+    end;
+
     #endregion
 
     #region ServiceInvoice


### PR DESCRIPTION
## Summary

ZUGFeRD electronic invoice export was missing the Seller Item Number (BT-155) from the XML output. Per EN 16931 and ZUGFeRD 2.x specification, BT-155 must be emitted as `ram:SellerAssignedID` inside `ram:SpecifiedTradeProduct` for each supply-chain trade line item.

Fixes #29871

## Root Cause

`InsertInvoiceLine` and `InsertCrMemoLine` in `ExportZUGFeRDDocument` (codeunit 13917) only emitted `ram:Name` inside `ram:SpecifiedTradeProduct`. The `ram:SellerAssignedID` element was never added.

The XRechnung UBL counterpart (codeunit 13916) correctly includes the seller item number via `InsertSellersItemIdentification`, but the ZUGFeRD CII counterpart was not updated accordingly.

## Changes

**`Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al`**
- In `InsertInvoiceLine`: add `ram:SellerAssignedID` with `SalesInvoiceLine."No."` before `ram:Name` in `ram:SpecifiedTradeProduct`, guarded by a non-empty check.
- In `InsertCrMemoLine`: same change for `SalesCrMemoLine."No."`.

The element order (SellerAssignedID before Name) matches the EN 16931 / ZUGFeRD CII schema.

**`Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al`**
- `ExportPostedSalesInvoiceInZUGFeRDFormatVerifySellerAssignedID`: verifies `ram:SellerAssignedID` is present and correct in an exported Sales Invoice.
- `ExportPostedSalesCrMemoInZUGFeRDFormatVerifySellerAssignedID`: same verification for an exported Sales Credit Memo.

## Before / After

**Before:**
`.xml
<ram:SpecifiedTradeProduct>
    <ram:Name>Bicycle</ram:Name>
</ram:SpecifiedTradeProduct>
`

**After:**
`.xml
<ram:SpecifiedTradeProduct>
    <ram:SellerAssignedID>1000</ram:SellerAssignedID>
    <ram:Name>Bicycle</ram:Name>
</ram:SpecifiedTradeProduct>
`

## Testing

The two new automated tests in `ZUGFeRDXMLDocumentTests` cover the fix. They follow the existing test patterns in that codeunit: create and post a document, export to ZUGFeRD, parse the resulting XML, assert the element value.
