### PR TITLE
Restore WorkDate after E-Document DE demo data generation on error

### DIFF
--- a/Apps/DE/EDocumentDE/demo data/3.Transactions/CreateDemoEDocsDE.Codeunit.al
+++ b/Apps/DE/EDocumentDE/demo data/3.Transactions/CreateDemoEDocsDE.Codeunit.al
@@ -39,6 +39,24 @@ codeunit 11370 "Create Demo EDocs DE"
 
     local procedure GenerateContosoInboundEDocuments()
     var
+        EDocSamplePurchaseInvoice: Codeunit "E-Doc Sample Purchase Invoice";
+        SavedWorkDate, SampleInvoiceDate: Date;
+        ErrorText: Text;
+    begin
+        SavedWorkDate := WorkDate();
+        SampleInvoiceDate := EDocSamplePurchaseInvoice.GetSampleInvoicePostingDate();
+        WorkDate(SampleInvoiceDate);
+        if not TryCreateInboundEDocuments(SampleInvoiceDate) then begin
+            ErrorText := GetLastErrorText();
+            WorkDate(SavedWorkDate);
+            Error(ErrorText);
+        end;
+        WorkDate(SavedWorkDate);
+    end;
+
+    [TryFunction]
+    local procedure TryCreateInboundEDocuments(SampleInvoiceDate: Date)
+    var
         CreateVendor: Codeunit "Create Vendor";
         CreateGLAccDE: Codeunit "Create DE GL Acc.";
         CreateCommonUnitOfMeasure: Codeunit "Create Common Unit Of Measure";
@@ -46,17 +64,12 @@ codeunit 11370 "Create Demo EDocs DE"
         CreateJobItem: Codeunit "Create Job Item";
         CreateAllocationAccount: Codeunit "Create Allocation Account";
         CreateDeferralTemplate: Codeunit "Create Deferral Template";
-        EDocSamplePurchaseInvoice: Codeunit "E-Doc Sample Purchase Invoice";
         AccountingServicesJanuaryLbl: Label 'Accounting support period: January', MaxLength = 100;
         AccountingServicesFebruaryLbl: Label 'Accounting support period: February', MaxLength = 100;
         AccountingServicesMarchLbl: Label 'Accounting support period: March', MaxLength = 100;
         AccountingServicesDecemberLbl: Label 'Accounting support period: December', MaxLength = 100;
         AccountingServicesMayLbl: Label 'Accounting support period: May', MaxLength = 100;
-        SavedWorkDate, SampleInvoiceDate : Date;
     begin
-        SavedWorkDate := WorkDate();
-        SampleInvoiceDate := EDocSamplePurchaseInvoice.GetSampleInvoicePostingDate();
-        WorkDate(SampleInvoiceDate);
         ContosoInboundEDocument.AddEDocPurchaseHeader(CreateVendor.EUGraphicDesign(), SampleInvoiceDate, '245', 0);
         ContosoInboundEDocument.AddEDocPurchaseLine(
             Enum::"Purchase Line Type"::"Allocation Account", CreateAllocationAccount.Licenses(),
@@ -113,7 +126,6 @@ codeunit 11370 "Create Demo EDocs DE"
             Enum::"Purchase Line Type"::Item, CreateEDocumentMasterData.PrecisionGrindHome(),
             '', 50, 199, '', CreateCommonUnitOfMeasure.Piece());
         ContosoInboundEDocument.Generate();
-        WorkDate(SavedWorkDate);
     end;
 
 }


### PR DESCRIPTION
Relates to microsoft/ALAppExtensions#29644

Fixes #29644 

**Root cause**

When the Contoso demo tool ran E-Document DE demo data, the previous code in `EDocDemodataDE` called `Create Demo EDocs DE` at the Transactional level. That codeunit called `ContosoInboundEDocument.Generate()`, which internally ran the "Finish draft" import step. Because the `CreateEDocSampleInvoices` event subscriber was not bound at that point, the purchase header update event did not fire, causing the "Finish draft" processing to fail and leave `Document Record ID` unset. The subsequent `TestField("Document Record ID")` call in `PostPurchaseInvoice` then surfaced the confusing validation error.

The invocation of `Create Demo EDocs DE` was removed from `EDocDemodataDE` as part of the v29 realignment, which resolves the crash. This PR addresses a secondary problem that was exposed by the same scenario: `WorkDate` was modified before the `Generate()` calls and only restored at the very end of the procedure. If any `Generate()` call threw an error, `WorkDate` was left permanently modified for the remainder of the session.

**Changes**

In `CreateDemoEDocsDE` (codeunit 11370, pending obsolete since 28.0):

- Extracted the eight `Generate()` calls into a `[TryFunction]` procedure named `TryCreateInboundEDocuments`.
- `GenerateContosoInboundEDocuments` now saves and restores `WorkDate` around a call to `TryCreateInboundEDocuments`, guaranteeing restoration even when an error occurs.
- If the try-function returns false, `WorkDate` is restored before the original error text is re-raised, preserving the original error message and behavior while preventing global state from being corrupted.

**How to test**

1. Create a new company using the DE localization with Contoso demo data enabled.
2. Confirm the setup completes without the "Document record ID must contain a value in E-Document" error.
3. Confirm that `WorkDate` returns to its original value after the demo data run completes, regardless of whether any individual E-Document invoice failed during generation.

**Expected behavior**

- New DE company creation with E-Document and Contoso demo data succeeds in v29+.
- If a `Generate()` call fails for any reason, `WorkDate` is restored to its value before demo data generation started, and the original error message is surfaced to the caller.
