### PR TITLE
GP Migration - Prevent date issues with new No Series for Sales/Purchase Codes

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
@@ -501,7 +501,7 @@ codeunit 4018 "GP Customer Migrator"
         DimSetID: Integer;
     begin
         if GPAccount."Standard Sales Code" = '' then begin
-            GPAccount."Standard Sales Code" := CopyStr(NoSeries.GetNextNo(NoSeriesStandardSalesCodeTok), 1, MaxStrLen(GPAccount."Standard Sales Code"));
+            GPAccount."Standard Sales Code" := CopyStr(NoSeries.GetNextNo(NoSeriesStandardSalesCodeTok, Today()), 1, MaxStrLen(GPAccount."Standard Sales Code"));
 
             StandardSalesCode.Validate("Code", GPAccount."Standard Sales Code");
             StandardSalesCode.Validate(Description, CopyStr(HelperFunctions.GenerateStandardCodeDescriptionFromAccount(GPAccount), 1, MaxStrLen(StandardSalesCode.Description)));

--- a/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
@@ -643,7 +643,7 @@ codeunit 4037 "Helper Functions"
 
         NoSeriesLine.Validate("Series Code", NoSeriesCode);
         NoSeriesLine.Validate("Starting No.", StartingNo);
-        NoSeriesLine.Validate("Starting Date", Today());
+        NoSeriesLine.Validate("Starting Date", 0D);
         NoSeriesLine.Validate("Increment-by No.", 1);
         NoSeriesLine.Validate(Implementation, "No. Series Implementation"::Normal);
         NoSeriesLine.Insert(true);

--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
@@ -637,7 +637,7 @@ codeunit 4022 "GP Vendor Migrator"
         DimSetID: Integer;
     begin
         if GPAccount."Standard Purchase Code" = '' then begin
-            GPAccount."Standard Purchase Code" := CopyStr(NoSeries.GetNextNo(NoSeriesStandardPurchaseCodeTok), 1, MaxStrLen(GPAccount."Standard Purchase Code"));
+            GPAccount."Standard Purchase Code" := CopyStr(NoSeries.GetNextNo(NoSeriesStandardPurchaseCodeTok, Today()), 1, MaxStrLen(GPAccount."Standard Purchase Code"));
 
             StandardPurchaseCode.Validate("Code", GPAccount."Standard Purchase Code");
             StandardPurchaseCode.Validate(Description, CopyStr(HelperFunctions.GenerateStandardCodeDescriptionFromAccount(GPAccount), 1, MaxStrLen(StandardPurchaseCode.Description)));


### PR DESCRIPTION
This change fixes an issue found with the new recurring lines feature.

When the migration is attempting to generate a new number from the Standard Sales/Purchase Codes No Series, an error can be thrown if the user's Work Date is set in the past.


Fixes [AB#634079](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/634079)