### PR TITLE
fix

### DIFF
--- a/.github/workflows/ExtReqImplementDispatch.yml
+++ b/.github/workflows/ExtReqImplementDispatch.yml
@@ -28,7 +28,7 @@ jobs:
   dispatch:
     if: >-
       github.event.issue.state == 'open' &&
-      github.event.label.name == env.FIX_LABEL
+      github.event.label.name == 'ext-ready-to-implement'
     runs-on: ubuntu-latest
     steps:
       - name: Validate PAT secret


### PR DESCRIPTION
# This repository no longer accepts new pull requests

ALAppExtensions no longer accepts new pull requests.

Extensibility requests, such as event requests and requests to make functions external, are still accepted as issues using the extensibility request template.

New pull requests opened in this repository will be closed automatically.


